### PR TITLE
Work without ~/.pypirc

### DIFF
--- a/twine/utils.py
+++ b/twine/utils.py
@@ -29,6 +29,13 @@ def get_config(path="~/.pypirc"):
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
+    if not os.path.isfile(path):
+        return {None: {"repository": DEFAULT_REPOSITORY,
+                       "username": None,
+                       "password": None
+                       }
+                }
+
     # Parse the rc file
     parser = configparser.ConfigParser()
     parser.read(path)


### PR DESCRIPTION
Perhaps I'm missing something, but without a ~/.pypirc file, I get an error like:

  File "...../twine/commands/upload.py", line 69, in **call**
    parsed = urlparse(config["repository"])
KeyError: 'repository'

This patch seems to work.
