### PR TITLE
add support for uploading windows installers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 #   being optional.
 
 Donald Stufft <donald@stufft.io> (https://caremad.io/)
+Ralf Schmitt <ralf@systemexit.de>

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -30,17 +30,20 @@ import pkg_resources
 import requests
 
 from twine.wheel import Wheel
+from twine.wininst import WinInst
 from twine.utils import get_config
 
 
 DIST_TYPES = {
     "bdist_wheel": Wheel,
+    "bdist_wininst": WinInst,
     "bdist_egg": pkginfo.BDist,
     "sdist": pkginfo.SDist,
 }
 
 DIST_EXTENSIONS = {
     ".whl": "bdist_wheel",
+    ".exe": "bdist_wininst",
     ".egg": "bdist_egg",
     ".tar.bz2": "sdist",
     ".tar.gz": "sdist",
@@ -103,6 +106,8 @@ def upload(dists, repository, sign, identity, username, password, comment):
             pkgd = pkg_resources.Distribution.from_filename(filename)
             py_version = pkgd.py_version
         elif dtype == "bdist_wheel":
+            py_version = meta.py_version
+        elif dtype == "bdist_wininst":
             py_version = meta.py_version
         else:
             py_version = None

--- a/twine/wininst.py
+++ b/twine/wininst.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, division, print_function
+from __future__ import unicode_literals
+
+import os
+import re
+import zipfile
+
+from pkginfo.distribution import Distribution
+
+wininst_file_re = re.compile(r".*py(?P<pyver>\d+\.\d+)\.exe$")
+
+
+class WinInst(Distribution):
+
+    def __init__(self, filename, metadata_version=None):
+        self.filename = filename
+        self.metadata_version = metadata_version
+        self.extractMetadata()
+
+    @property
+    def py_version(self):
+        m = wininst_file_re.match(self.filename)
+        if m is None:
+            return "any"
+        else:
+            return m.group("pyver")
+
+    def read(self):
+        fqn = os.path.abspath(os.path.normpath(self.filename))
+        if not os.path.exists(fqn):
+            raise ValueError('No such file: %s' % fqn)
+
+        if fqn.endswith('.exe'):
+            archive = zipfile.ZipFile(fqn)
+            names = archive.namelist()
+
+            def read_file(name):
+                return archive.read(name)
+        else:
+            raise ValueError('Not a known archive format: %s' % fqn)
+
+        try:
+            tuples = [x.split('/') for x in names
+                      if x.endswith(".egg-info") or x.endswith("PKG-INFO")]
+            schwarz = sorted([(len(x), x) for x in tuples])
+            for path in [x[1] for x in schwarz]:
+                candidate = '/'.join(path)
+                data = read_file(candidate)
+                if b'Metadata-Version' in data:
+                    return data
+        finally:
+            archive.close()
+
+        raise ValueError('No PKG-INFO/.egg-info in archive: %s' % fqn)


### PR DESCRIPTION
twine is currently not able to upload bdist_wininst generated windows installers. this pull requests adds support for it.
