### PR TITLE
Make upload repository parameter optional

### DIFF
--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -225,12 +225,7 @@ def main():
 
     # Call the upload function with the arguments from the command line
     try:
-        upload(
-            *args._get_args(),
-            **dict(
-                (k, v) for k, v in args._get_kwargs() if not k.startswith("_")
-            )
-        )
+        upload(**vars(args))
     except Exception as exc:
         sys.exit("{0}: {1}".format(exc.__class__.__name__, exc.message))
 


### PR DESCRIPTION
Add default to argument parsing, thus making it fully optional, should fix #33.

Also contains a simplification to calling `upload()` with the arguments from the command line.

I have tested the changes manually on python 2.7 by uploading a package to a private pypi.
