### PR TITLE
Upload refactor

### DIFF
--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -225,7 +225,15 @@ def main():
 
     # Call the upload function with the arguments from the command line
     try:
-        upload(**vars(args))
+        upload(
+            dists=args.dists,
+            repository=args.repository,
+            sign=args.sign,
+            identity=args.identity,
+            username=args.username,
+            password=args.password,
+            comment=args.comment,
+        )
     except Exception as exc:
         sys.exit("{0}: {1}".format(exc.__class__.__name__, exc.message))
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -33,10 +33,23 @@ from twine.wheel import Wheel
 from twine.utils import get_config
 
 
+class BDist(pkginfo.BDist):
+
+    @property
+    def py_version(self):
+        pkgd = pkg_resources.Distribution.from_filename(self.filename)
+        return pkgd.py_version
+
+
+class SDist(pkginfo.SDist):
+
+    py_version = None
+
+
 DIST_TYPES = {
     "bdist_wheel": Wheel,
-    "bdist_egg": pkginfo.BDist,
-    "sdist": pkginfo.SDist,
+    "bdist_egg": BDist,
+    "sdist": SDist,
 }
 
 DIST_EXTENSIONS = {
@@ -99,14 +112,6 @@ def upload(dists, repository, sign, identity, username, password, comment):
                 os.path.basename(filename)
             )
 
-        if dtype == "bdist_egg":
-            pkgd = pkg_resources.Distribution.from_filename(filename)
-            py_version = pkgd.py_version
-        elif dtype == "bdist_wheel":
-            py_version = meta.py_version
-        else:
-            py_version = None
-
         # Fill in the data - send all the meta-data in case we need to
         # register a new release
         data = {
@@ -120,7 +125,7 @@ def upload(dists, repository, sign, identity, username, password, comment):
 
             # file content
             "filetype": dtype,
-            "pyversion": py_version,
+            "pyversion": meta.py_version,
 
             # additional meta-data
             "metadata_version": meta.metadata_version,


### PR DESCRIPTION
## The goal of this refactor

is to extract a function, that
- will register/upload a distribution
- is as simple as possible - have no branching logic, etc.
- will ***not*** check the `.pypirc` config file

A bit longer term goal is to have a stable up-to-date *library* that supports distribution uploads from files.

Actually there is another package, where the above is almost available: [pkgsync](https://github.com/isotoma/pkgsync)
That package has tests, but most probably does not support wheels, nor it is python3 compatible and it was not recently updated.


Some less important changes have been made, they should be obvious from the diffs, they are mostly cosmetic.


## Testing

Refactoring is usually achieved by first writing passing tests for the original code, then transforming the code while keeping all of the tests green.

I have not added any formal tests, as it requires more domain knowledge about packaging & PyPI than I have - what is important to test?

Instead I tried to make only trivial changes per commit - mostly code extraction.
The possible contribution to testing is that smaller, simpler code should be easier to test.


## Future?

- move `upload_distribution` from `commands/upload.py` to `twine/upload.py`.
  Could it be made public API as `twine.upload_distribution`?!

  This would simplify the role of `commands/upload.py`: it would contain only command line parsing and propagating the upload task to `twine.upload_distribution`

- `Wheel` support can be simplified probably soon:

  [pkginfo Changelog](https://pypi.python.org/pypi/pkginfo/1.2b1)
  > 1.2b1 (2013-12-05)
  > 
  > Added support for the "wheel" distribution format, along with minimal metadata 2.0 support (not including new PEP 426 JSON properties). Code (re-)borrowed from Donald Stuft's twine package.
  
  The only difference is: `Wheel.py_version` is not there.
  
  As one of the refactors put `.py_version` on newly derived `SDist` and `BDist` classes and it should be similarly done with `pkginfo`'s borrowed `Wheel`, this shows, that `.py_version` would have an better place on `pkginfo`'s `Distribution` subclasses.
  
  So adding `.py_version` should be escalated somehow to `pkginfo`.

---

There are certainly some unclear parts, like do we need `session` passed in?
Do `requests` reuse connections within a session? (have not checked)
It would also be better to create a `Repository` class, which knows how to register/upload files (and in the future: knows how to list packages, download files, `pkgsync` has something like this).

I'd like to have a `twine.upload_...(...)` library function or `Repository` class or some other simple reliable API after this refactor.
I am willing to make some more changes, if needed.
