### PR TITLE
Ask for password input if password is not specified in the command or in...

### DIFF
--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
 
 import argparse
+import getpass
 import hashlib
 import os.path
 import subprocess
@@ -76,6 +77,9 @@ def upload(dists, repository, sign, identity, username, password, comment):
         )
 
     print("Uploading distributions to {0}".format(config["repository"]))
+
+    username = username or config.get("username")
+    password = password or config.get("password") or getpass.getpass()
 
     session = requests.session()
 
@@ -176,8 +180,8 @@ def upload(dists, repository, sign, identity, username, password, comment):
             data=dict((k, v) for k, v in data.items() if v),
             files=filedata,
             auth=(
-                username or config.get("username"),
-                password or config.get("password"),
+                username,
+                password,
             ),
         )
         resp.raise_for_status()


### PR DESCRIPTION
... the .pypirc config file

I added added the getpass module to ask for password input if the -p flag contains no password or if the password is not specified in the config. I'd rather not store my password on disk or in a config file if possible. This allows me to specify my password at runtime. I believe this is the same behavior as the setup.py upload command.

I moved the username and password outside of the request function so getpass does not ask you for your password for each file to be uploaded.
