### PR TITLE
Readthedocs build fix and updated sphinx documentation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+# Docs
+Sphinx==1.2.2
+releases==0.6.1
+
+# Testing
+tox==1.7.1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,20 +3,92 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to twine's documentation!
-=================================
+twine
+=====
 
-Contents:
+Twine is a utility for interacting with PyPI.
 
-.. toctree::
-   :maxdepth: 2
-
+Currently it only supports uploading distributions.
 
 
-Indices and tables
-==================
+Why Should I Use This?
+----------------------
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+The biggest reason to use twine is that ``python setup.py upload`` uploads
+files over plaintext. This means anytime you use it you expose your username
+and password to a MITM attack. Twine uses only verified TLS to upload to PyPI
+protecting your credentials from theft.
 
+Secondly it allows you to precreate your distribution files.
+``python setup.py upload`` only allows you to upload something that you've
+created in the same command invocation. This means that you cannot test the
+exact file you're going to upload to PyPI to ensure that it works before
+uploading it.
+
+Finally it allows you to pre-sign your files and pass the .asc files into
+the command line invocation
+(``twine upload twine-1.0.1.tar.gz twine-1.0.1.tar.gz.asc``). This enables you
+to be assured that you're typing your gpg passphrase into gpg itself and not
+anything else since *you* will be the one directly executing
+``gpg --detach-sign -a <filename>``.
+
+
+Features
+--------
+
+* Verified HTTPS Connections
+* Uploading doesn't require executing setup.py
+* Uploading files that have already been created, allowing testing of
+  distributions before release
+* Supports uploading any packaging format (including wheels).
+
+Installation
+------------
+
+Installing twine is easy, just use `pip <http://www.pip-installer.org/en/latest/>`_.
+
+.. code-block:: text
+
+   $ pip install twine
+
+
+PyPI Configuration
+------------------
+
+To upload a package with Twine you will need to either create a ``.pypirc`` config in your home folder or supply Twine with
+your PyPI repository and user credentials. If you do not wish to store your password on disk you can alternatively
+leave your password blank and Twine will prompt you for your password information before uploading your files.
+
+The ``.pypirc`` config looks like this.
+
+.. code-block:: ini
+
+   [pypi]
+   repository: https://pypi.python.org
+   username: <username>
+   password: <password>
+
+
+Alternatively you can supply the necessary pypi information through commandline arguments. You can find all the
+upload commandline options by viewing the upload commands help text.
+
+.. code-block:: text
+
+    $ twine upload -h
+
+Usage
+-----
+
+1. Create some distributions in the normal way:
+
+.. code:: bash
+
+    $ python setup.py sdist bdist_wheel
+
+2. Upload with twine:
+
+.. code:: bash
+
+    $ twine upload dist/*
+
+3. Done!


### PR DESCRIPTION
I was told to use Twine at Pycon for uploading packages to PyPI. I just set it up and ran into a few issues. I thought it would be helpful to get readthedocs setup with more detailed documentation. 