### PR TITLE
Fixes #50, exception when .pypirc is missing

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,17 @@ def test_get_config_no_section(tmpdir):
             "password": "testpassword",
         },
     }
+    
+def test_get_config_missing(tmpdir):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    assert get_config(pypirc) == {
+        "pypi": {
+            "repository": DEFAULT_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
+    }
 
 
 @pytest.mark.parametrize(

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -39,10 +39,10 @@ def get_config(path="~/.pypirc"):
     path = os.path.expanduser(path)
 
     if not os.path.isfile(path):
-        return {None: {"repository": DEFAULT_REPOSITORY,
-                       "username": None,
-                       "password": None
-                       }
+        return {"pypi": {"repository": DEFAULT_REPOSITORY,
+                         "username": None,
+                         "password": None
+                         }
                 }
 
     # Parse the rc file


### PR DESCRIPTION
Simple problem, simple test, simple fix.
