### PR TITLE
Support using commands not named gpg for signing

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,3 +1,17 @@
+# Copyright 2014 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pretend
 import pytest
 
 from twine.commands import upload
@@ -19,3 +33,22 @@ def test_find_dists_handles_real_files():
                 'twine/utils.py', 'twine/wheel.py']
     files = upload.find_dists(expected)
     assert expected == files
+
+
+def test_sign_file(monkeypatch):
+    replaced_check_call = pretend.call_recorder(lambda args: None)
+    monkeypatch.setattr(upload.subprocess, 'check_call', replaced_check_call)
+
+    upload.sign_file('gpg2', 'my_file.tar.gz', None)
+    args = ['gpg2', '--detach-sign', '-a', 'my_file.tar.gz']
+    assert replaced_check_call.calls == [pretend.call(args)]
+
+
+def test_sign_file_with_identity(monkeypatch):
+    replaced_check_call = pretend.call_recorder(lambda args: None)
+    monkeypatch.setattr(upload.subprocess, 'check_call', replaced_check_call)
+
+    upload.sign_file('gpg', 'my_file.tar.gz', 'identity')
+    args = ['gpg', '--detach-sign', '--local-user', 'identity', '-a',
+            'my_file.tar.gz']
+    assert replaced_check_call.calls == [pretend.call(args)]

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -70,6 +70,14 @@ def find_dists(dists):
     return uploads
 
 
+def sign_file(sign_with, filename, identity):
+    print("Signing {0}".format(os.path.basename(filename)))
+    gpg_args = [sign_with, "--detach-sign", "-a", filename]
+    if identity:
+        gpg_args[2:2] = ["--local-user", identity]
+    subprocess.check_call(gpg_args)
+
+
 def upload(dists, repository, sign, identity, username, password, comment,
            sign_with):
     # Check that a nonsensical option wasn't given
@@ -110,11 +118,7 @@ def upload(dists, repository, sign, identity, username, password, comment,
     for filename in uploads:
         # Sign the dist if requested
         if sign:
-            print("Signing {0}".format(os.path.basename(filename)))
-            gpg_args = [sign_with, "--detach-sign", "-a", filename]
-            if identity:
-                gpg_args[2:2] = ["--local-user", identity]
-            subprocess.check_call(gpg_args)
+            sign_file(sign_with, filename, identity)
 
         # Extract the metadata from the package
         for ext, dtype in DIST_EXTENSIONS.items():


### PR DESCRIPTION
Fixes #29 

Example usage:

```
$ twine -s --sign-with gpg2 dist/foo-1.0.1.tar.gz
```
- [x] Need to write tests
