### PR TITLE
Restrict requests to at least 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import twine
 
 
 install_requires = [
-    "requests",
+    "requests >= 2.0",
     "pkginfo",
 ]
 


### PR DESCRIPTION
This will prevent some of the more bizarre bugs we've seen with older versions of requests.
