### PR TITLE
Give us information about setuptools in --version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ import twine
 
 
 install_requires = [
-    "requests >= 2.0",
     "pkginfo",
+    "requests >= 2.0",
+    "setuptools >= 0.7.0",
 ]
 
 if sys.version_info[:2] < (2, 7):

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 
 import argparse
 import pkg_resources
+import setuptools
 
 import requests
 import pkginfo
@@ -28,11 +29,12 @@ def _registered_commands(group='twine.registered_commands'):
 
 
 def dep_versions():
-    return 'pkginfo: {0}, requests: {1}'.format(
+    return 'pkginfo: {0}, requests: {1}, setuptools: {2}'.format(
         pkginfo.Installed(pkginfo).version,
         # __version__ is always defined but requests does not always have
         # PKG-INFO to read from
         requests.__version__,
+        setuptools.__version__,
     )
 
 


### PR DESCRIPTION
Avoid 0.6 series of setuptools - pkg_resources is broken on those versions

Fixes #85