### PR TITLE
README.md: nicer display of nested bulleted list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,11 +110,11 @@ Contributing
 2. Make a branch off of master and commit your changes to it.
 3. Run the tests with ``tox``
 
-  - Either use ``tox`` to build against all supported Python versions (if you
-    have them installed) or use ``tox -e py{version}`` to test against a
-    sepcific version, e.g., ``tox -e py27`` or ``tox -e py34``.
-  - Always run ``tox -e pep8``
-
+   - Either use ``tox`` to build against all supported Python versions (if you
+     have them installed) or use ``tox -e py{version}`` to test against a
+     sepcific version, e.g., ``tox -e py27`` or ``tox -e py34``.
+   - Always run ``tox -e pep8``
+  
 4. Ensure that your name is added to the end of the AUTHORS file using the
    format ``Name <email@domain.com> (url)``, where the ``(url)`` portion is
    optional.


### PR DESCRIPTION
by applying reST advice from http://stackoverflow.com/a/5553270/638434

and fix typo: sepcific => , as in https://github.com/pypa/twine/pull/88 to try to stave off merge conflict.

Preview at https://github.com/msabramo/twine/blob/patch-6/README.rst