### PR TITLE
Do not follow redirects when uploading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import twine
 
 install_requires = [
     "pkginfo",
-    "requests >= 2.0",
+    "requests >= 2.3.0",
     "setuptools >= 0.7.0",
 ]
 

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -1,0 +1,24 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class RedirectDetected(Exception):
+    """A redirect was detected that the user needs to resolve.
+
+    In some cases, requests refuses to issue a new POST request after a
+    redirect. In order to prevent a confusing user experience, we raise this
+    exception to allow users to know the index they're uploading to is
+    redirecting them.
+    """
+    pass


### PR DESCRIPTION
PyPI will never redirect a user during an upload. If a redirect is
found, either the index URL is incorrect or there could be a malicious
redirect at play. requests has well defined behaviour around handling
POSTing data and what happens during a redirect. We shouldn't have to
think too hard about that and there's probably a problem the user needs
to handle if there is a redirect.

Requests added 'is_redirect()' to Response objects in 2.3.0. In order to
rely on that, we need to bump our minimum version.

Closes #92