### PR TITLE
Removed unused verification of supported commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Ralf Schmitt <ralf@systemexit.de>
 Ian Cordasco <graffatcolmingov@gmail.com>
 Marc Abramowitz <msabramo@gmail.com> (http://marc-abramowitz.com/)
 Tom Myers <tom.stephen.myers@gmail.com>
+Rodrigue Cloutier <rodcloutier@gmail.com>

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -25,7 +25,7 @@ import twine
 
 
 def _registered_commands(group='twine.registered_commands'):
-    return {c.name: c for c in pkg_resources.iter_entry_points(group=group)}
+    return dict( (c.name, c) for c in pkg_resources.iter_entry_points(group=group))
 
 
 def dep_versions():

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -25,7 +25,8 @@ import twine
 
 
 def _registered_commands(group='twine.registered_commands'):
-    return dict( (c.name, c) for c in pkg_resources.iter_entry_points(group=group))
+    registered_commands = pkg_resources.iter_entry_points(group=group)
+    return dict((c.name, c) for c in registered_commands)
 
 
 def dep_versions():

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -25,7 +25,7 @@ import twine
 
 
 def _registered_commands(group='twine.registered_commands'):
-    return list(pkg_resources.iter_entry_points(group=group))
+    return {c.name: c for c in pkg_resources.iter_entry_points(group=group)}
 
 
 def dep_versions():
@@ -49,7 +49,7 @@ def dispatch(argv):
     )
     parser.add_argument(
         "command",
-        choices=[c.name for c in registered_commands],
+        choices=registered_commands.keys(),
     )
     parser.add_argument(
         "args",
@@ -59,14 +59,6 @@ def dispatch(argv):
 
     args = parser.parse_args(argv)
 
-    command = args.command
-    for registered_command in registered_commands:
-        if registered_command.name == command:
-            break
-    else:
-        print("{0} is not a valid command.".format(command))
-        raise SystemExit(True)
-
-    main = registered_command.load()
+    main = registered_commands[args.command].load()
 
     main(args.args)


### PR DESCRIPTION
I noticed that the cli.py module coverage was not reported as complete the but the tests seemed to be fine, testing all cases. I noticed that a verification of supported commands was hit by the tests hence the tests succeeding but the coverage not full.

I removed the verification code since the command option uses a choice which will report any unsupported commands.

Test run before

```
$ tox -e py27 --develop
py27 develop-inst-noop: /Users/rod/dev/external/twine
py27 runtests: PYTHONHASHSEED='992522251'
py27 runtests: commands[0] | coverage run --source twine -m pytest tests
========================================================= test session starts =========================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.7.0
rootdir: /Users/rod/dev/external/twine, inifile:
collected 15 items

tests/test_cli.py ..
tests/test_upload.py .....
tests/test_utils.py ........

====================================================== 15 passed in 0.30 seconds ======================================================
py27 runtests: commands[1] | coverage report -m
Name                      Stmts   Miss Branch BrMiss  Cover   Missing
---------------------------------------------------------------------
twine/__init__               11      0      0      0   100%
twine/cli                    27      2      4      2    87%   67-68
twine/commands/__init__       2      0      0      0   100%
twine/commands/upload       103     66     34     26    33%   26-27, 84-218, 222-275
twine/utils                  45      1     27      2    96%   29
twine/wheel                  47     30      8      8    31%   23-24, 44-46, 50-51, 54-78, 81-85
twine/wininst                37     26     10     10    23%   16-18, 22-26, 29-54
---------------------------------------------------------------------
TOTAL                       272    125     83     48    51%
_______________________________________________________________ summary _______________________________________________________________
  py27: commands succeeded
  congratulations :)
```

Test run after

```
 $ tox -e py27 --develop
py27 develop-inst-noop: /Users/rod/dev/external/twine
py27 runtests: PYTHONHASHSEED='1904517968'
py27 runtests: commands[0] | coverage run --source twine -m pytest tests
========================================================= test session starts =========================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.7.0
rootdir: /Users/rod/dev/external/twine, inifile:
collected 15 items

tests/test_cli.py ..
tests/test_upload.py .....
tests/test_utils.py ........

====================================================== 15 passed in 0.30 seconds ======================================================
py27 runtests: commands[1] | coverage report -m
Name                      Stmts   Miss Branch BrMiss  Cover   Missing
---------------------------------------------------------------------
twine/__init__               11      0      0      0   100%
twine/cli                    22      0      2      0   100%
twine/commands/__init__       2      0      0      0   100%
twine/commands/upload       103     66     34     26    33%   26-27, 84-218, 222-275
twine/utils                  45      1     27      2    96%   29
twine/wheel                  47     30      8      8    31%   23-24, 44-46, 50-51, 54-78, 81-85
twine/wininst                37     26     10     10    23%   16-18, 22-26, 29-54
---------------------------------------------------------------------
TOTAL                       267    123     81     46    51%
_______________________________________________________________ summary _______________________________________________________________
  py27: commands succeeded
  congratulations :)
```