### PR TITLE
Activated coverage report in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pretend
     pytest
 commands =
-    coverage run --source {envsitepackagesdir}/twine -m pytest {posargs:tests}
+    coverage run --source twine -m pytest {posargs:tests}
     coverage report -m
 
 [testenv:docs]


### PR DESCRIPTION
The current tox setup does run the tests but coverage does not find any data since where are not running the test with the package in the root directory. py.test runs with the root directory as the current working directory and will import twine from the local package.

