### PR TITLE
Put wheel files first when uploading.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Ian Cordasco <graffatcolmingov@gmail.com>
 Marc Abramowitz <msabramo@gmail.com> (http://marc-abramowitz.com/)
 Tom Myers <tom.stephen.myers@gmail.com>
 Rodrigue Cloutier <rodcloutier@gmail.com>
+Tyrel Souza <tyrelsouza@gmail.com> (https://tyrelsouza.com)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -29,6 +29,14 @@ def test_ensure_wheel_files_uploaded_first():
     assert expected == files
 
 
+def test_ensure_if_no_wheel_files():
+    files = upload.group_wheel_files_first(["twine/foo.py",
+                                            "twine/bar.py"])
+    expected = ["twine/foo.py",
+                "twine/bar.py"]
+    assert expected == files
+
+
 def test_find_dists_expands_globs():
     files = sorted(upload.find_dists(['twine/__*.py']))
     expected = ['twine/__init__.py', 'twine/__main__.py']

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -17,6 +17,18 @@ import pytest
 from twine.commands import upload
 
 
+def test_ensure_wheel_files_uploaded_first():
+    files = upload.group_wheel_files_first(["twine/foo.py",
+                                            "twine/first.whl",
+                                            "twine/bar.py",
+                                            "twine/second.whl"])
+    expected = ["twine/first.whl",
+                "twine/second.whl",
+                "twine/foo.py",
+                "twine/bar.py"]
+    assert expected == files
+
+
 def test_find_dists_expands_globs():
     files = sorted(upload.find_dists(['twine/__*.py']))
     expected = ['twine/__init__.py', 'twine/__main__.py']

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -20,6 +20,7 @@ import hashlib
 import os.path
 import subprocess
 import sys
+import itertools
 
 try:
     from urlparse import urlparse, urlunparse
@@ -57,18 +58,17 @@ def group_wheel_files_first(dist_files):
     if not any(fname for fname in dist_files if fname.endswith(".whl")):
         # Return early if there's no wheel files
         return dist_files
-    wheels, not_wheels = [], []
-    # Loop over the uploads and put the wheels first.
-    for upload in dist_files:
-        _, ext = os.path.splitext(upload)
-        if ext in (".whl",):
-            wheels.append(upload)
-        else:
-            not_wheels.append(upload)
 
-    # Make the new list with wheels first
-    grouped_uploads = wheels + not_wheels
-    return grouped_uploads
+    group_func = lambda x: x.endswith(".whl")
+    sorted_distfiles = sorted(dist_files, key=group_func)
+    wheels, not_wheels = [], []
+    for grp, files in itertools.groupby(sorted_distfiles, key=group_func):
+        if grp:
+            wheels.extend(files)
+        else:
+            not_wheels.extend(files)
+
+    return wheels + not_wheels
 
 
 def find_dists(dists):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -52,22 +52,23 @@ DIST_EXTENSIONS = {
     ".zip": "sdist",
 }
 
-WHEEL_EXTENSIONS = (".whl", )
-
 
 def group_wheel_files_first(dist_files):
+    if not any(fname for fname in dist_files if fname.endswith(".whl")):
+        # Return early if there's no wheel files
+        return dist_files
     wheels, not_wheels = [], []
     # Loop over the uploads and put the wheels first.
     for upload in dist_files:
         _, ext = os.path.splitext(upload)
-        if ext in WHEEL_EXTENSIONS:
+        if ext in (".whl",):
             wheels.append(upload)
         else:
             not_wheels.append(upload)
 
     # Make the new list with wheels first
-    uploads = wheels + not_wheels
-    return uploads
+    grouped_uploads = wheels + not_wheels
+    return grouped_uploads
 
 
 def find_dists(dists):
@@ -82,7 +83,7 @@ def find_dists(dists):
         if not files:
             raise ValueError(
                 "Cannot find file (or expand pattern): '%s'" % filename
-                )
+            )
         # Otherwise, files will be filenames that exist
         uploads.extend(files)
     return group_wheel_files_first(uploads)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -83,7 +83,7 @@ def find_dists(dists):
         if not files:
             raise ValueError(
                 "Cannot find file (or expand pattern): '%s'" % filename
-            )
+                )
         # Otherwise, files will be filenames that exist
         uploads.extend(files)
     return group_wheel_files_first(uploads)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -17,10 +17,10 @@ from __future__ import unicode_literals
 import argparse
 import glob
 import hashlib
+import itertools
 import os.path
 import subprocess
 import sys
-import itertools
 
 try:
     from urlparse import urlparse, urlunparse

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -52,6 +52,23 @@ DIST_EXTENSIONS = {
     ".zip": "sdist",
 }
 
+WHEEL_EXTENSIONS = (".whl", )
+
+
+def group_wheel_files_first(dist_files):
+    wheels, not_wheels = [], []
+    # Loop over the uploads and put the wheels first.
+    for upload in dist_files:
+        _, ext = os.path.splitext(upload)
+        if ext in WHEEL_EXTENSIONS:
+            wheels.append(upload)
+        else:
+            not_wheels.append(upload)
+
+    # Make the new list with wheels first
+    uploads = wheels + not_wheels
+    return uploads
+
 
 def find_dists(dists):
     uploads = []
@@ -68,7 +85,7 @@ def find_dists(dists):
                 )
         # Otherwise, files will be filenames that exist
         uploads.extend(files)
-    return uploads
+    return group_wheel_files_first(uploads)
 
 
 def sign_file(sign_with, filename, identity):


### PR DESCRIPTION
References https://github.com/pypa/twine/issues/106

This groups wheel ".whl" files first for upload order so that the metadata can be displayed immediately while other files are still uploading.

- Added a function upload.group_wheel_files_first
- Added a two tests.
- Ensured coverage for function
