### PR TITLE
Env config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Tom Myers <tom.stephen.myers@gmail.com>
 Rodrigue Cloutier <rodcloutier@gmail.com>
 Tyrel Souza <tyrelsouza@gmail.com> (https://tyrelsouza.com)
 Adam Talsma <adam@talsma.ca>
+Borys Pierov <borys.pierov@nih.gov>

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,38 @@ Options
       --config-file FILE    
                             The .pypirc config file to use
 
+Note that on top of .pypirc config file you also can define repositories
+to be used with twine using environment variables using following format:
+
+..
+
+    PYPI_REPO_<REPO_NAME>=URL
+
+For example following environment variables:
+
+..
+
+    PYPI_REPO_INTERNAL_STORE=https://john:secret@pypi.local:42/stuff
+    PYPI_REPO_ADDITIONAL=https://john:@pypi.additional
+    PYPI_REPO_ONE_MORE=https://john@pypi.more
+    PYPI_REPO_PYPI=https://pypi.external
+
+define:
+
+* a repository called 'internal-store' (repository names are normalized
+  to lowercase and '_' replaced with '-') that will be accessed with username
+  'john' and password 'secret'.
+
+* a repository called 'additional' that will be accessed with username 'john'
+  and **with empty password**
+
+* a repository called 'one-more' that will be accessed with username 'john'
+  and password will be asked during runtime
+
+* override url for the 'default' repository called 'pypi'
+
+With such environment you can specify any of 'internal-store', 'additional',
+'one-more' and 'pypi' in -r/--repository parameter.
 
 Resources
 ---------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,75 @@ def test_get_config_missing(tmpdir):
     }
 
 
+def test_get_config_with_env(tmpdir, monkeypatch):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    # correct repos
+    monkeypatch.setenv(
+        'PYPI_REPO_SUPER_RePo', 'https://user:pass@super.repo:42/stuff')
+
+    monkeypatch.setenv('PYPI_REPO_EMPTY_PASS_repo', 'https://user:@super.repo')
+    monkeypatch.setenv('PYPI_REPO_NO_PASS_repo', 'https://user@super.repo')
+    monkeypatch.setenv('PYPI_REPO_SIMPLE', 'super.repo')
+
+    # wrong repos - ignored
+    monkeypatch.setenv('pypi_repo_SUPER_REPO', 'ignored')
+    monkeypatch.setenv('PYPI_REPO_', 'whatever')
+
+    assert get_config(pypirc) == {
+        "pypi": {
+            "repository": DEFAULT_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
+        "super-repo": {
+            "repository": "https://super.repo:42/stuff",
+            "username": "user",
+            "password": "pass",
+        },
+        "empty-pass-repo": {
+            "repository": "https://super.repo",
+            "username": "user",
+            "password": "",
+        },
+        "no-pass-repo": {
+            "repository": "https://super.repo",
+            "username": "user",
+            "password": None,
+        },
+        "simple": {
+            "repository": "super.repo",
+            "username": None,
+            "password": None,
+        },
+    }
+
+
+def test_get_config_env_overrides_config(tmpdir, monkeypatch):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with open(pypirc, "w") as fp:
+        fp.write(textwrap.dedent("""
+            [distutils]
+            index-servers = pypi
+
+            [pypi]
+            username = testuser
+            password = testpassword
+        """))
+
+    monkeypatch.setenv(
+        'PYPI_REPO_PyPI', 'https://user:pass@super.repo:42/stuff')
+
+    assert get_config(pypirc) == {
+        "pypi": {
+            "repository": "https://super.repo:42/stuff",
+            "username": "user",
+            "password": "pass",
+        },
+    }
+
+
 def test_get_config_deprecated_pypirc():
     tests_dir = os.path.dirname(os.path.abspath(__file__))
     deprecated_pypirc_path = os.path.join(tests_dir, 'fixtures',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,7 @@ def test_get_config_deprecated_pypirc():
         ('cli', {}, 'key', lambda: 'fallback', 'cli'),
         (None, {'key': 'value'}, 'key', lambda: 'fallback', 'value'),
         (None, {}, 'key', lambda: 'fallback', 'fallback'),
+        (None, {'key': ''}, 'key', lambda: 'fallback', ''),
     ),
 )
 def test_get_userpass_value(cli_value, config, key, strategy, expected):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -108,7 +108,7 @@ def get_userpass_value(cli_value, config, key, prompt_strategy):
     """
     if cli_value is not None:
         return cli_value
-    elif config.get(key):
+    elif config.get(key) is not None:
         return config[key]
     else:
         return prompt_strategy()

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -128,7 +128,7 @@ def _parse_pypi_repo_connection_string(conn_str):
     netloc = parsed.hostname
 
     if parsed.port:
-        netloc += ':{}'.format(parsed.port)
+        netloc += ':%s' % parsed.port
 
     repository = urlunparse((parsed[0], netloc) + parsed[2:])
     return {

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -14,10 +14,16 @@
 from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
 
+import os
 import os.path
 import functools
 import getpass
 import sys
+
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
 
 try:
     import configparser
@@ -38,13 +44,26 @@ def get_config(path="~/.pypirc"):
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
-    if not os.path.isfile(path):
-        return {"pypi": {"repository": DEFAULT_REPOSITORY,
-                         "username": None,
-                         "password": None
-                         }
-                }
+    if os.path.isfile(path):
+        config = _read_config_file(path)
+    else:
+        config = _get_default_config()
 
+    env_config = _get_env_config()
+
+    config.update(env_config)
+    return config
+
+
+def _get_default_config():
+    return {"pypi": {"repository": DEFAULT_REPOSITORY,
+                     "username": None,
+                     "password": None
+                     }
+            }
+
+
+def _read_config_file(path):
     # Parse the rc file
     parser = configparser.ConfigParser()
     parser.read(path)
@@ -84,6 +103,39 @@ def get_config(path="~/.pypirc"):
                 config[repository][key] = defaults[key]
 
     return config
+
+
+def _get_env_config(prefix='pypi_repo_'):
+    prefix_norm = prefix.upper()
+    prefix_len = len(prefix_norm)
+
+    config = {}
+
+    for key, val in os.environ.items():
+        if key.startswith(prefix_norm):
+            repo_name = key[prefix_len:].strip().lower().replace('_', '-')
+            if not repo_name:
+                continue  # wrong repo name, should we log?
+            config[repo_name] = _parse_pypi_repo_connection_string(val)
+
+    return config
+
+
+def _parse_pypi_repo_connection_string(conn_str):
+    parsed = urlparse(conn_str)
+
+    # Extract username and password out of netloc
+    netloc = parsed.hostname
+
+    if parsed.port:
+        netloc += ':{}'.format(parsed.port)
+
+    repository = urlunparse((parsed[0], netloc) + parsed[2:])
+    return {
+        "repository": repository,
+        "username": parsed.username,
+        "password": parsed.password,
+    }
 
 
 def get_userpass_value(cli_value, config, key, prompt_strategy):


### PR DESCRIPTION
Allow repositories configuration in env variables using following format:

    PYPI_REPO_<REPO_NAME>=URL

Details in README.rst

Also allow empty passwords in config.

Rationale: here, at NCBI, we have a number of internal Python package repositories. We're using twine to upload our Python artifacts into both internal repositories and central PyPI. Since we're following http://12factor.net/ guidelines we prefer to keep all configuration in environment variables.

I tried to implement this feature in least-intrusive way and also added a number of tests.