### PR TITLE
helpful messages if ~/.pypirc format is out-dated

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Tom Myers <tom.stephen.myers@gmail.com>
 Rodrigue Cloutier <rodcloutier@gmail.com>
 Tyrel Souza <tyrelsouza@gmail.com> (https://tyrelsouza.com)
 Adam Talsma <adam@talsma.ca>
+Jens Diemer <github@jensdiemer.de> (http://jensdiemer.de/)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -114,11 +114,16 @@ def upload(dists, repository, sign, identity, username, password, comment,
     try:
         config = get_config(config_file)[repository]
     except KeyError:
-        raise KeyError(
-            "Missing '{0}' section from the configuration file".format(
-                repository,
-            ),
+        msg = (
+            "Missing '{repo}' section from the configuration file.\n"
+            "Maybe you have a out-dated '{cfg}' format?\n"
+            "more info: "
+            "https://docs.python.org/distutils/packageindex.html#pypirc\n"
+        ).format(
+            repo=repository,
+            cfg=config_file
         )
+        raise KeyError(msg)
 
     parsed = urlparse(config["repository"])
     if parsed.netloc in ["pypi.python.org", "testpypi.python.org"]:


### PR DESCRIPTION
see also:
https://github.com/pypa/twine/issues/111