### PR TITLE
Allow outputting verbose server response

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Rodrigue Cloutier <rodcloutier@gmail.com>
 Tyrel Souza <tyrelsouza@gmail.com> (https://tyrelsouza.com)
 Adam Talsma <adam@talsma.ca>
 Jens Diemer <github@jensdiemer.de> (http://jensdiemer.de/)
+Pavel Savchenko <asfaltboy@gmail.com>

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import os
 import textwrap
@@ -20,6 +20,19 @@ import pretend
 import pytest
 
 from twine.commands import upload
+
+default_kwargs = {
+    'dists': None,
+    'repository': 'pypi',
+    'sign': False,
+    'identity': None,
+    'username': '',
+    'password': '',
+    'comment': None,
+    'sign_with': 'gpg',
+    'config_file': '',
+    'verbose_response': False,
+}
 
 
 def test_ensure_wheel_files_uploaded_first():
@@ -90,9 +103,9 @@ def test_get_config_old_format(tmpdir):
         """))
 
     try:
-        upload.upload(dists="foo", repository="pypi", sign=None, identity=None,
-                      username=None, password=None, comment=None,
-                      sign_with=None, config_file=pypirc)
+        kwargs = default_kwargs.copy()
+        kwargs.update(dict(dists="foo", config_file=pypirc))
+        upload.upload(**kwargs)
     except KeyError as err:
         assert err.args[0] == (
             "Missing 'pypi' section from the configuration file.\n"

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -99,7 +99,7 @@ def sign_file(sign_with, filename, identity):
 
 
 def upload(dists, repository, sign, identity, username, password, comment,
-           sign_with, config_file):
+           sign_with, config_file, verbose_response):
     # Check that a nonsensical option wasn't given
     if not sign and identity:
         raise ValueError("sign must be given along with identity")
@@ -258,6 +258,10 @@ def upload(dists, repository, sign, identity, username, password, comment,
         resp.close()
         session.close()
 
+        if verbose_response:
+            msg = '\n'.join(('-' * 75, resp.content, '-' * 75))
+            print("Server response:\n%s" % msg)
+
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued
         # by PyPI should never happen in reality. This should catch malicious
@@ -309,6 +313,12 @@ def main(args):
         "--config-file",
         default="~/.pypirc",
         help="The .pypirc config file to use",
+    )
+    parser.add_argument(
+        "-v", "--verbose-response",
+        action="store_true",
+        default=False,
+        help="Show a verbose server response",
     )
     parser.add_argument(
         "dists",


### PR DESCRIPTION
Adds an optional `-v, --verbose-response` argument to
allow simply printing out full server response (calls
`requests.Response.content`).

I found it very useful to inspect why the server 
rejected my package and I can see other potential use-cases.

I tried adding a test, but because the print occurs so late in
`upload` flow, the test ended up stubbing so much internals
until the test was twice as long as the feature - so I gave up.
