### PR TITLE
Noting that pkginfo needs to be at least 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import twine
 
 
 install_requires = [
-    "pkginfo",
+    "pkginfo >= 1.0",
     "requests >= 2.3.0",
     "requests-toolbelt >= 0.4.0",
     "setuptools >= 0.7.0",


### PR DESCRIPTION
Somehow I had an old 0.9 pkginfo in a project and twine subsequently failed with:

    Uploading distributions to https://pypi.python.org/pypi
    AttributeError: 'module' object has no attribute 'must_decode'

Twine uses `pkginfo.distribution.must_decode` in `wheel.py`. pkginfo 1.0 is the first version that actually has that function.