### PR TITLE
Upload refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     entry_points={
         "twine.registered_commands": [
             "upload = twine.commands.upload:main",
+            "register = twine.commands.register:main",
         ],
         "console_scripts": [
             "twine = twine.__main__:main",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -33,7 +33,7 @@ def test_sign_file(monkeypatch):
         pkg.sign('gpg2', None)
     except IOError:
         pass
-    args = ['gpg2', '--detach-sign', '-a', filename]
+    args = ('gpg2', '--detach-sign', '-a', filename)
     assert replaced_check_call.calls == [pretend.call(args)]
 
 
@@ -53,5 +53,5 @@ def test_sign_file_with_identity(monkeypatch):
         pkg.sign('gpg', 'identity')
     except IOError:
         pass
-    args = ['gpg', '--detach-sign', '-a', filename, '--local-user', 'identity']
+    args = ('gpg', '--detach-sign', '-a', filename, '--local-user', 'identity')
     assert replaced_check_call.calls == [pretend.call(args)]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,57 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import unicode_literals
+from twine import package
+
+import pretend
+
+
+def test_sign_file(monkeypatch):
+    replaced_check_call = pretend.call_recorder(lambda args: None)
+    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
+    filename = 'tests/fixtures/deprecated-pypirc'
+
+    pkg = package.PackageFile(
+        filename=filename,
+        comment=None,
+        metadata=pretend.stub(name="deprecated-pypirc"),
+        python_version=None,
+        filetype=None
+    )
+    try:
+        pkg.sign('gpg2', None)
+    except IOError:
+        pass
+    args = ['gpg2', '--detach-sign', '-a', filename]
+    assert replaced_check_call.calls == [pretend.call(args)]
+
+
+def test_sign_file_with_identity(monkeypatch):
+    replaced_check_call = pretend.call_recorder(lambda args: None)
+    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
+    filename = 'tests/fixtures/deprecated-pypirc'
+
+    pkg = package.PackageFile(
+        filename=filename,
+        comment=None,
+        metadata=pretend.stub(name="deprecated-pypirc"),
+        python_version=None,
+        filetype=None
+    )
+    try:
+        pkg.sign('gpg', 'identity')
+    except IOError:
+        pass
+    args = ['gpg', '--detach-sign', '-a', filename, '--local-user', 'identity']
+    assert replaced_check_call.calls == [pretend.call(args)]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,7 +16,6 @@ from __future__ import unicode_literals
 import os
 import textwrap
 
-import pretend
 import pytest
 
 from twine.commands import upload
@@ -58,25 +57,6 @@ def test_find_dists_handles_real_files():
                 'twine/utils.py', 'twine/wheel.py']
     files = upload.find_dists(expected)
     assert expected == files
-
-
-def test_sign_file(monkeypatch):
-    replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(upload.subprocess, 'check_call', replaced_check_call)
-
-    upload.sign_file('gpg2', 'my_file.tar.gz', None)
-    args = ['gpg2', '--detach-sign', '-a', 'my_file.tar.gz']
-    assert replaced_check_call.calls == [pretend.call(args)]
-
-
-def test_sign_file_with_identity(monkeypatch):
-    replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(upload.subprocess, 'check_call', replaced_check_call)
-
-    upload.sign_file('gpg', 'my_file.tar.gz', 'identity')
-    args = ['gpg', '--detach-sign', '--local-user', 'identity', '-a',
-            'my_file.tar.gz']
-    assert replaced_check_call.calls == [pretend.call(args)]
 
 
 def test_get_config_old_format(tmpdir):

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -1,0 +1,93 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, unicode_literals, print_function
+
+import argparse
+import os.path
+import sys
+
+from twine import exceptions as exc
+from twine.package import PackageFile
+from twine.repository import Repository
+from twine import utils
+
+
+def register(package, repository, username, password, comment, config_file):
+    config = utils.get_repository_from_config(config_file, repository)
+    config["repository"] = utils.normalize_repository_url(
+        config["repository"]
+    )
+
+    print("Registering package to {0}".format(config["repository"]))
+
+    username = utils.get_username(username, config)
+    password = utils.get_password(password, config)
+
+    repository = Repository(config["repository"], username, password)
+
+    if not os.path.exists(package):
+        raise exc.PackageNotFound(
+            '"{0}" does not exist on the file system.'.format(package)
+        )
+
+    resp = repository.register(PackageFile.from_filename(package, comment))
+    repository.close()
+
+    if resp.is_redirect:
+        raise exc.RedirectDetected(
+            ('"{0}" attempted to redirect to "{1}" during upload.'
+             ' Aborting...').format(config["respository"],
+                                    resp.headers["location"]))
+
+    resp.raise_for_status()
+
+
+def main(args):
+    parser = argparse.ArgumentParser(prog="twine register")
+    parser.add_argument(
+        "-r", "--repository",
+        default="pypi",
+        help="The repository to register the package to (default: "
+             "%(default)s)",
+    )
+    parser.add_argument(
+        "-u", "--username",
+        help="The username to authenticate to the repository as",
+    )
+    parser.add_argument(
+        "-p", "--password",
+        help="The password to authenticate to the repository with",
+    )
+    parser.add_argument(
+        "-c", "--comment",
+        help="The comment to include with the distribution file",
+    )
+    parser.add_argument(
+        "--config-file",
+        default="~/.pypirc",
+        help="The .pypirc config file to use",
+    )
+    parser.add_argument(
+        "package",
+        metavar="package",
+        help="File from which we read the package metadata",
+    )
+
+    args = parser.parse_args(args)
+
+    # Call the register function with the args from the command line
+    try:
+        register(**vars(args))
+    except Exception as exc:
+        sys.exit("{exc.__class__.__name__}: {exc}".format(exc=exc))

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -22,3 +22,11 @@ class RedirectDetected(Exception):
     redirecting them.
     """
     pass
+
+
+class PackageNotFound(Exception):
+    """A package file was provided that could not be found on the file system.
+
+    This is only used when attempting to register a package.
+    """
+    pass

--- a/twine/package.py
+++ b/twine/package.py
@@ -1,0 +1,144 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, unicode_literals, print_function
+import hashlib
+import os
+import subprocess
+
+import pkginfo
+import pkg_resources
+
+from twine.wheel import Wheel
+from twine.wininst import WinInst
+
+DIST_TYPES = {
+    "bdist_wheel": Wheel,
+    "bdist_wininst": WinInst,
+    "bdist_egg": pkginfo.BDist,
+    "sdist": pkginfo.SDist,
+}
+
+DIST_EXTENSIONS = {
+    ".whl": "bdist_wheel",
+    ".exe": "bdist_wininst",
+    ".egg": "bdist_egg",
+    ".tar.bz2": "sdist",
+    ".tar.gz": "sdist",
+    ".zip": "sdist",
+}
+
+
+class PackageFile(object):
+    def __init__(self, filename, comment, metadata, python_version, filetype):
+        self.filename = filename
+        self.basefilename = os.path.basename(filename)
+        self.comment = comment
+        self.metadata = metadata
+        self.python_version = python_version
+        self.filetype = filetype
+        self.safe_name = pkg_resources.safe_name(metadata.name)
+        self.signed_filename = self.filename + '.asc'
+        self.gpg_signature = None
+
+        md5_hash = hashlib.md5()
+        with open(filename, "rb") as fp:
+            content = fp.read(4096)
+            while content:
+                md5_hash.update(content)
+                content = fp.read(4096)
+
+        self.md5_digest = md5_hash.hexdigest()
+
+    @classmethod
+    def from_filename(cls, filename, comment):
+        # Extract the metadata from the package
+        for ext, dtype in DIST_EXTENSIONS.items():
+            if filename.endswith(ext):
+                meta = DIST_TYPES[dtype](filename)
+                break
+        else:
+            raise ValueError(
+                "Unknown distribution format: '%s'" %
+                os.path.basename(filename)
+            )
+
+        if dtype == "bdist_egg":
+            pkgd = pkg_resources.Distribution.from_filename(filename)
+            py_version = pkgd.py_version
+        elif dtype == "bdist_wheel":
+            py_version = meta.py_version
+        elif dtype == "bdist_wininst":
+            py_version = meta.py_version
+        else:
+            py_version = None
+
+        return cls(filename, comment, meta, py_version, dtype)
+
+    def metadata_dictionary(self):
+        meta = self.metadata
+        data = {
+            # identify release
+            "name": self.safe_name,
+            "version": meta.version,
+
+            # file content
+            "filetype": self.filetype,
+            "pyversion": self.python_version,
+
+            # additional meta-data
+            "metadata_version": meta.metadata_version,
+            "summary": meta.summary,
+            "home_page": meta.home_page,
+            "author": meta.author,
+            "author_email": meta.author_email,
+            "maintainer": meta.maintainer,
+            "maintainer_email": meta.maintainer_email,
+            "license": meta.license,
+            "description": meta.description,
+            "keywords": meta.keywords,
+            "platform": meta.platforms,
+            "classifiers": meta.classifiers,
+            "download_url": meta.download_url,
+            "supported_platform": meta.supported_platforms,
+            "comment": self.comment,
+            "md5_digest": self.md5_digest,
+
+            # PEP 314
+            "provides": meta.provides,
+            "requires": meta.requires,
+            "obsoletes": meta.obsoletes,
+
+            # Metadata 1.2
+            "project_urls": meta.project_urls,
+            "provides_dist": meta.provides_dist,
+            "obsoletes_dist": meta.obsoletes_dist,
+            "requires_dist": meta.requires_dist,
+            "requires_external": meta.requires_external,
+            "requires_python": meta.requires_python,
+        }
+
+        if self.gpg_signature is not None:
+            data['gpg_signature'] = self.gpg_signature
+
+        return data
+
+    def sign(self, sign_with, identity):
+        print("Signing {0}".format(self.basefilename))
+        gpg_args = (sign_with, "--detach-sign", "-a", self.filename)
+        if identity:
+            gpg_args += ("--local-user", identity)
+        subprocess.check_call(gpg_args)
+
+        with open(self.signed_filename, "rb") as gpg:
+            self.pg_signature = (self.signed_filename, gpg.read())

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -1,0 +1,61 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, unicode_literals, print_function
+
+import requests
+from requests_toolbelt.multipart import MultipartEncoder
+
+
+class Repository(object):
+    def __init__(self, repository_url, username, password):
+        self.url = repository_url
+        self.session = requests.session()
+        self.session.auth = (username, password)
+
+    def close(self):
+        self.session.close()
+
+    def upload(self, package):
+        data = package.metadata_dictionary()
+        data.update({
+            # action
+            ":action": "file_upload",
+            "protcol_version": "1",
+        })
+
+        data_to_send = []
+        for key, value in data.items():
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    data_to_send.append((key, item))
+            else:
+                data_to_send.append((key, value))
+
+        print("Uploading {0}".format(package.basefilename))
+
+        with open(package.filename, "rb") as fp:
+            data_to_send.append((
+                "content",
+                (package.basefilename, fp, "application/octet-stream"),
+            ))
+            encoder = MultipartEncoder(data_to_send)
+
+            resp = self.session.post(
+                self.url,
+                data=encoder,
+                allow_redirects=False,
+                headers={'Content-Type': encoder.content_type},
+            )
+
+        return resp


### PR DESCRIPTION
This properly splits out the logic between repository, package, and command wrappers.

This also adds a `register` command which has been often requested to show off the power of the refactor.

Currently the tests are failing but I can't determine what the difference is between pretend calls via the pytest output. Here's hoping they don't fail here.