### PR TITLE
Place --local-user and argument in middle of sign

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -53,5 +53,5 @@ def test_sign_file_with_identity(monkeypatch):
         pkg.sign('gpg', 'identity')
     except IOError:
         pass
-    args = ('gpg', '--detach-sign', '-a', filename, '--local-user', 'identity')
+    args = ('gpg', '--detach-sign', '--local-user', 'identity', '-a', filename)
     assert replaced_check_call.calls == [pretend.call(args)]

--- a/twine/package.py
+++ b/twine/package.py
@@ -143,9 +143,10 @@ class PackageFile(object):
 
     def sign(self, sign_with, identity):
         print("Signing {0}".format(self.basefilename))
-        gpg_args = (sign_with, "--detach-sign", "-a", self.filename)
+        gpg_args = (sign_with, "--detach-sign")
         if identity:
             gpg_args += ("--local-user", identity)
+        gpg_args += ("-a", self.filename)
         subprocess.check_call(gpg_args)
 
         with open(self.signed_filename, "rb") as gpg:


### PR DESCRIPTION
Placing --local-user and its argument after the filename makes gpg
think it is the file you're trying to sign. This was re-ordered
accidentally during my refacorting efforts which broke signing.

Closes #130

--

cc @ankostis