### PR TITLE
Correctly generate the signed filename

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -55,3 +55,18 @@ def test_sign_file_with_identity(monkeypatch):
         pass
     args = ('gpg', '--detach-sign', '--local-user', 'identity', '-a', filename)
     assert replaced_check_call.calls == [pretend.call(args)]
+
+
+def test_package_signed_name_is_correct():
+    filename = 'tests/fixtures/deprecated-pypirc'
+
+    pkg = package.PackageFile(
+        filename=filename,
+        comment=None,
+        metadata=pretend.stub(name="deprecated-pypirc"),
+        python_version=None,
+        filetype=None
+    )
+
+    assert pkg.signed_basefilename == "deprecated-pypirc.asc"
+    assert pkg.signed_filename == (filename + '.asc')

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -66,6 +66,7 @@ def test_find_dists_handles_real_files():
 
 def test_get_config_old_format(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
+    dists = ["tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"]
 
     with open(pypirc, "w") as fp:
         fp.write(textwrap.dedent("""
@@ -75,7 +76,7 @@ def test_get_config_old_format(tmpdir):
         """))
 
     try:
-        upload.upload(dists="foo", repository="pypi", sign=None, identity=None,
+        upload.upload(dists=dists, repository="pypi", sign=None, identity=None,
                       username=None, password=None, comment=None,
                       sign_with=None, config_file=pypirc, skip_existing=False)
     except KeyError as err:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -67,11 +67,13 @@ def upload(dists, repository, sign, identity, username, password, comment,
     if not sign and identity:
         raise ValueError("sign must be given along with identity")
 
+    dists = find_dists(dists)
+
     # Determine if the user has passed in pre-signed distributions
     signatures = dict(
         (os.path.basename(d), d) for d in dists if d.endswith(".asc")
     )
-    dists = [i for i in dists if not i.endswith(".asc")]
+    uploads = [i for i in dists if not i.endswith(".asc")]
 
     config = utils.get_repository_from_config(config_file, repository)
 
@@ -85,8 +87,6 @@ def upload(dists, repository, sign, identity, username, password, comment,
     password = utils.get_password(password, config)
 
     repository = Repository(config["repository"], username, password)
-
-    uploads = find_dists(dists)
 
     for filename in uploads:
         package = PackageFile.from_filename(filename, comment)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -90,20 +90,12 @@ def upload(dists, repository, sign, identity, username, password, comment,
 
     for filename in uploads:
         package = PackageFile.from_filename(filename, comment)
-        # Sign the dist if requested
-        # if sign:
-        #     sign_file(sign_with, filename, identity)
 
-        # signed_name = os.path.basename(filename) + ".asc"
-        signed_name = package.signed_filename
+        signed_name = package.signed_basefilename
         if signed_name in signatures:
-            with open(signatures[signed_name], "rb") as gpg:
-                package.gpg_signature = (signed_name, gpg.read())
-                # data["gpg_signature"] = (signed_name, gpg.read())
+            package.add_gpg_signature(signatures[signed_name], signed_name)
         elif sign:
             package.sign(sign_with, identity)
-            # with open(filename + ".asc", "rb") as gpg:
-            #     data["gpg_signature"] = (signed_name, gpg.read())
 
         resp = repository.upload(package)
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -49,6 +49,7 @@ class PackageFile(object):
         self.filetype = filetype
         self.safe_name = pkg_resources.safe_name(metadata.name)
         self.signed_filename = self.filename + '.asc'
+        self.signed_basefilename = self.basefilename + '.asc'
         self.gpg_signature = None
 
         md5_hash = hashlib.md5()
@@ -141,6 +142,13 @@ class PackageFile(object):
 
         return data
 
+    def add_gpg_signature(self, signature_filepath, signature_filename):
+        if self.gpg_signature is not None:
+            raise ValueError('GPG Signature can only be added once')
+
+        with open(signature_filepath, "rb") as gpg:
+            self.gpg_signature = (signature_filename, gpg.read())
+
     def sign(self, sign_with, identity):
         print("Signing {0}".format(self.basefilename))
         gpg_args = (sign_with, "--detach-sign")
@@ -149,5 +157,4 @@ class PackageFile(object):
         gpg_args += ("-a", self.filename)
         subprocess.check_call(gpg_args)
 
-        with open(self.signed_filename, "rb") as gpg:
-            self.pg_signature = (self.signed_filename, gpg.read())
+        self.add_gpg_signature(self.signed_filename, self.signed_basefilename)


### PR DESCRIPTION
Remove commented out code that is no longer relevant. Conveniently,
those comments also confirmed the bug report (in that I had refactored
incorrectly).

This commit:

- Adds signed_basefilename to PackageFile
- Uses signed_basefilename appropriately
- Corrects typo in PackageFile.sign
- Uses signed_basefilename in PackageFile.sign
- Adds PackageFile.add_gpg_signature to reduce duplication

Closes #132