### PR TITLE
Prevent flattening certain upload fields

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Ian Cordasco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from twine import repository
+
+
+def test_gpg_signature_structure_is_preserved():
+    data = {
+        'gpg_signature': ('filename.asc', 'filecontent'),
+    }
+
+    tuples = repository.Repository._convert_data_to_list_of_tuples(data)
+    assert tuples == [('gpg_signature', ('filename.asc', 'filecontent'))]
+
+
+def test_content_structure_is_preserved():
+    data = {
+        'content': ('filename', 'filecontent'),
+    }
+
+    tuples = repository.Repository._convert_data_to_list_of_tuples(data)
+    assert tuples == [('content', ('filename', 'filecontent'))]
+
+
+def test_iterables_are_flattened():
+    data = {
+        'platform': ['UNKNOWN'],
+    }
+
+    tuples = repository.Repository._convert_data_to_list_of_tuples(data)
+    assert tuples == [('platform', 'UNKNOWN')]
+
+    data = {
+        'platform': ['UNKNOWN', 'ANOTHERPLATFORM'],
+    }
+
+    tuples = repository.Repository._convert_data_to_list_of_tuples(data)
+    assert tuples == [('platform', 'UNKNOWN'),
+                      ('platform', 'ANOTHERPLATFORM')]

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -17,6 +17,9 @@ import requests
 from requests_toolbelt.multipart import MultipartEncoder
 
 
+KEYWORDS_TO_NOT_FLATTEN = set(["gpg_signature", "content"])
+
+
 class Repository(object):
     def __init__(self, repository_url, username, password):
         self.url = repository_url
@@ -30,11 +33,12 @@ class Repository(object):
     def _convert_data_to_list_of_tuples(data):
         data_to_send = []
         for key, value in data.items():
-            if isinstance(value, (list, tuple)):
+            if (key in KEYWORDS_TO_NOT_FLATTEN or
+                    not isinstance(value, (list, tuple))):
+                data_to_send.append((key, value))
+            else:
                 for item in value:
                     data_to_send.append((key, item))
-            else:
-                data_to_send.append((key, value))
         return data_to_send
 
     def register(self, package):


### PR DESCRIPTION
The gpg_signature field needs to be passed to MultipartEncoder with a
tuple as the value. This was flattening it causing PyPI to receive two
parts with the same name and parsing them into a list.

The values need to otherwise be flattened because in some cases the
MultipartEncoder cannot handle a sequence value that isn't meant to be a
file-like part (e.g., platform).

Closes #137