### PR TITLE
add progressbar to uploads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import twine
 
 
 install_requires = [
+    "clint",
     "pkginfo >= 1.0",
     "requests >= 2.3.0",
     "requests-toolbelt >= 0.4.0",


### PR DESCRIPTION
I'm unsure how to unit test this, so I'm putting it up for comment now. :smile: 

Based on @sigmavirus24's example here: https://gitlab.com/sigmavirus24/toolbelt/blob/master/examples/monitor/progress_bar.py

There was one small bug with that example as `__len__` is no longer available on `MultipartEncoder` due to 32-bit size restrictions, but I'll put a PR in to fix that separately.

Edit: would help if I noticed that gitlab is not the canonical respository. The github version is just fine :dancers: 