### PR TITLE
Release v1.6.5

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@
 Changelog
 =========
 
+* :release:`1.6.5 <2015-12-16>`
+
+  * :bug:`155` Bump requests-toolbelt version to ensure we avoid
+    ConnectionErrors
+
 * :release:`1.6.4 <2015-10-27>`
 
   * :bug:`145` Paths with hyphens in them break the Wheel regular expression.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import twine
 install_requires = [
     "pkginfo >= 1.0",
     "requests >= 2.3.0",
-    "requests-toolbelt >= 0.4.0",
+    "requests-toolbelt >= 0.5.1",
     "setuptools >= 0.7.0",
 ]
 

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -23,7 +23,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for interacting with PyPI"
 __uri__ = "https://github.com/pypa/twine"
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
Bump requests-toolbelt dependency to be >= 0.5.1 to account for
https://github.com/sigmavirus24/requests-toolbelt/issues/117

Closes #155