### PR TITLE
twine can now register too

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ twine
 
 Twine is a utility for interacting `with PyPI <https://pypi.python.org/pypi/twine>`_.
 
-Currently it only supports uploading distributions.
+Currently it only supports registering projects and uploading distributions.
 
 
 Why Should I Use This?


### PR DESCRIPTION
I wasn't sure if Twine supported registering projects yet, so I checked the README, and this particular sentence convinced me things hadn't changed since the last time I checked.

Perhaps I was too hasty in jumping to conclusions, but why not update it and remove ambiguity?