### PR TITLE
Add 409 status code support to --skip-existing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Rodrigue Cloutier <rodcloutier@gmail.com>
 Tyrel Souza <tyrelsouza@gmail.com> (https://tyrelsouza.com)
 Adam Talsma <adam@talsma.ca>
 Jens Diemer <github@jensdiemer.de> (http://jensdiemer.de/)
+Andrew Watts <andrewwatts@gmail.com>

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -101,6 +101,19 @@ def test_skip_existing_skips_files_already_on_PyPI(monkeypatch):
                               package=pkg) is True
 
 
+def test_skip_existing_skips_files_already_on_pypiserver(monkeypatch):
+    # pypiserver (https://pypi.python.org/pypi/pypiserver) responds with 409
+    response = pretend.stub(
+        status_code=409,
+        reason='A file named "twine-1.5.0-py2.py3-none-any.whl" already '
+               'exists for twine-1.5.0.')
+
+    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
+    assert upload.skip_upload(response=response,
+                              skip_existing=True,
+                              package=pkg) is True
+
+
 def test_skip_upload_respects_skip_existing(monkeypatch):
     response = pretend.stub(
         status_code=400,

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -56,7 +56,7 @@ def find_dists(dists):
 def skip_upload(response, skip_existing, package):
     filename = package.basefilename
     msg = 'A file named "{0}" already exists for'.format(filename)
-    return (response.status_code == 400 and
+    return (response.status_code in [400, 409] and
             response.reason.startswith(msg) and
             skip_existing)
 


### PR DESCRIPTION
twine only supported the 400 status code when deciding to skip an upload.  However, alternative implementations of pypi, for example [pypiserver](http://github.com/pypiserver/pypiserver), use a 409 status code.