### PR TITLE
Fetch default password and username from the environment

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -14,6 +14,7 @@
 from __future__ import unicode_literals
 
 import os
+from os.path import join as pj
 import textwrap
 
 import pretend
@@ -74,7 +75,7 @@ def test_ensure_if_no_wheel_files():
 
 def test_find_dists_expands_globs():
     files = sorted(upload.find_dists(['twine/__*.py']))
-    expected = ['twine/__init__.py', 'twine/__main__.py']
+    expected = [pj('twine', '__init__.py'), pj('twine', '__main__.py')]
     assert expected == files
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -164,5 +164,5 @@ def test_password_and_username_from_env(monkeypatch):
     assert "pypipassword" == result_kwargs["password"]
     assert "pypiuser" == result_kwargs["username"]
     result_kwargs = replaced_upload.calls[1].kwargs
-    assert None == result_kwargs["password"]
-    assert None == result_kwargs["username"]
+    assert None is result_kwargs["password"]
+    assert None is result_kwargs["username"]

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -67,14 +67,16 @@ def main(args):
              "%(default)s)",
     )
     parser.add_argument(
-        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER', required=False,
-        help="The username to authenticate to the repository as (can also be set via %(env)s "
-             "environment variable)",
+        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER',
+        required=False, help="The username to authenticate to the repository "
+                             "as (can also be set via %(env)s environment "
+                             "variable)",
     )
     parser.add_argument(
-        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD', required=False,
-        help="The password to authenticate to the repository with (can also be set via %(env)s "
-             "environment variable)",
+        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD',
+        required=False, help="The password to authenticate to the repository "
+                             "with (can also be set via %(env)s environment "
+                             "variable)",
     )
     parser.add_argument(
         "-c", "--comment",

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -67,12 +67,14 @@ def main(args):
              "%(default)s)",
     )
     parser.add_argument(
-        "-u", "--username",
-        help="The username to authenticate to the repository as",
+        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER', required=False,
+        help="The username to authenticate to the repository as (can also be set via %(env)s "
+             "environment variable)",
     )
     parser.add_argument(
-        "-p", "--password",
-        help="The password to authenticate to the repository with",
+        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD', required=False,
+        help="The password to authenticate to the repository with (can also be set via %(env)s "
+             "environment variable)",
     )
     parser.add_argument(
         "-c", "--comment",

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -156,12 +156,14 @@ def main(args):
         help="GPG identity used to sign files",
     )
     parser.add_argument(
-        "-u", "--username",
-        help="The username to authenticate to the repository as",
+        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER', required=False,
+        help="The username to authenticate to the repository as (can also be set via %(env)s "
+             "environment variable)",
     )
     parser.add_argument(
-        "-p", "--password",
-        help="The password to authenticate to the repository with",
+        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD', required=False,
+        help="The password to authenticate to the repository with (can also be set via %(env)s "
+             "environment variable)",
     )
     parser.add_argument(
         "-c", "--comment",

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -156,14 +156,16 @@ def main(args):
         help="GPG identity used to sign files",
     )
     parser.add_argument(
-        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER', required=False,
-        help="The username to authenticate to the repository as (can also be set via %(env)s "
-             "environment variable)",
+        "-u", "--username", action=utils.EnvDefault, env='PYPI_USER',
+        required=False, help="The username to authenticate to the repository "
+                             "as (can also be set via %(env)s environment "
+                             "variable)",
     )
     parser.add_argument(
-        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD', required=False,
-        help="The password to authenticate to the repository with (can also be set via %(env)s "
-             "environment variable)",
+        "-p", "--password", action=utils.EnvDefault, env='PYPI_PASSWORD',
+        required=False, help="The password to authenticate to the repository "
+                             "with (can also be set via %(env)s environment "
+                             "variable)",
     )
     parser.add_argument(
         "-c", "--comment",

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -185,7 +185,8 @@ class EnvDefault(argparse.Action):
         self.env = env
         if default:
             required = False
-        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
+        super(EnvDefault, self).__init__(default=default, required=required,
+                                         **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -19,6 +19,8 @@ import os.path
 import functools
 import getpass
 import sys
+import argparse
+
 
 try:
     import configparser
@@ -172,3 +174,18 @@ get_clientcert = functools.partial(
     get_userpass_value,
     key='client_cert',
 )
+
+
+class EnvDefault(argparse.Action):
+    """Get default from environment variable
+    """
+
+    def __init__(self, env, required=True, default=None, **kwargs):
+        default = os.environ.get(env, default)
+        self.env = env
+        if default:
+            required = False
+        super().__init__(default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -185,7 +185,7 @@ class EnvDefault(argparse.Action):
         self.env = env
         if default:
             required = False
-        super().__init__(default=default, required=required, **kwargs)
+        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)


### PR DESCRIPTION
To make using twine on CI services easier, get the default username and password from the environment. You can set  these values via the normal CI service ways. The result is that you do not need to worry about exposing these values via the (usually visible) commandline or the need to handle a (encrypted  or generated) pypirc file.

Closes: https://github.com/pypa/twine/issues/144