### PR TITLE
Take repository URL form the commandline.

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -82,7 +82,8 @@ def test_get_config_old_format(tmpdir):
                       sign_with=None, config_file=pypirc, skip_existing=False)
     except KeyError as err:
         assert err.args[0] == (
-            "Missing 'pypi' section from the configuration file.\n"
+            "Missing 'pypi' section from the configuration file\n"
+            "or not a complete URL in --repository.\n"
             "Maybe you have a out-dated '{0}' format?\n"
             "more info: "
             "https://docs.python.org/distutils/packageindex.html#pypirc\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,8 +18,8 @@ import os.path
 import textwrap
 import pytest
 
-from twine.utils import (DEFAULT_REPOSITORY, get_config, get_userpass_value,
-                         get_repository_from_config)
+from twine.utils import (DEFAULT_REPOSITORY, TEST_REPOSITORY, get_config,
+                         get_userpass_value, get_repository_from_config)
 
 
 def test_get_config(tmpdir):
@@ -93,6 +93,11 @@ def test_get_config_missing(tmpdir):
             "repository": DEFAULT_REPOSITORY,
             "username": None,
             "password": None,
+        },
+        "pypitest": {
+            "repository": TEST_REPOSITORY,
+            "username": None,
+            "password": None
         },
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,8 @@ import os.path
 import textwrap
 import pytest
 
-from twine.utils import DEFAULT_REPOSITORY, get_config, get_userpass_value
+from twine.utils import (DEFAULT_REPOSITORY, get_config, get_userpass_value,
+                         get_repository_from_config)
 
 
 def test_get_config(tmpdir):
@@ -94,6 +95,24 @@ def test_get_config_missing(tmpdir):
             "password": None,
         },
     }
+
+
+def test_get_repository_config_missing(tmpdir):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    repo = "https://notexisting.python.org/pypi"
+    exp = {
+            "repository": repo,
+            "username": None,
+            "password": None,
+        }
+    assert get_repository_from_config(pypirc, repo) == exp
+    exp = {
+            "repository": DEFAULT_REPOSITORY,
+            "username": None,
+            "password": None,
+        }
+    assert get_repository_from_config(pypirc, "pypi") == exp
 
 
 def test_get_config_deprecated_pypirc():

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -63,7 +63,8 @@ def main(args):
     parser.add_argument(
         "-r", "--repository",
         default="pypi",
-        help="The repository to register the package to (default: "
+        help="The repository to register the package to. Can be a section in "
+             "the config file or a full URL to the repository (default: "
              "%(default)s)",
     )
     parser.add_argument(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -137,7 +137,9 @@ def main(args):
     parser.add_argument(
         "-r", "--repository",
         default="pypi",
-        help="The repository to upload the files to (default: %(default)s)",
+        help="The repository to register the package to. Can be a section in "
+             "the config file or a full URL to the repository (default: "
+             "%(default)s)",
     )
     parser.add_argument(
         "-s", "--sign",

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -97,8 +97,14 @@ def get_repository_from_config(config_file, repository):
     try:
         return get_config(config_file)[repository]
     except KeyError:
+        if repository and "://" in repository:
+            # assume that the repsoitory is actually an URL and just sent
+            # them a dummy with the repo set
+            return {"repository": repository, "username": None,
+                    "password": None}
         msg = (
-            "Missing '{repo}' section from the configuration file.\n"
+            "Missing '{repo}' section from the configuration file\n"
+            "or not a complete URL in --repository.\n"
             "Maybe you have a out-dated '{cfg}' format?\n"
             "more info: "
             "https://docs.python.org/distutils/packageindex.html#pypirc\n"

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -38,6 +38,7 @@ else:
 
 
 DEFAULT_REPOSITORY = "https://pypi.python.org/pypi"
+TEST_REPOSITORY = "https://testpypi.python.org/pypi"
 
 
 def get_config(path="~/.pypirc"):
@@ -48,7 +49,11 @@ def get_config(path="~/.pypirc"):
         return {"pypi": {"repository": DEFAULT_REPOSITORY,
                          "username": None,
                          "password": None
-                         }
+                         },
+                "pypitest": {"repository": TEST_REPOSITORY,
+                             "username": None,
+                             "password": None
+                             },
                 }
 
     # Parse the rc file


### PR DESCRIPTION
To make usage of twine within a CI setup easier, make it possible to
run twin without a pypirc file. This commit adds the possibility to
specify the repository URL directly on the commandline.

This is done by overloading the `--repository` switch: this can now be
a section in the pypirc file (as before) or a full URL (e.g. something
with `://` in it).

Note that this is only needed when you don't want to upload to PyPI,
for PyPI we already have a fallback in place.

Closes: https://github.com/pypa/twine/issues/143