### PR TITLE
Implement retries for package upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import twine
 install_requires = [
     "clint",
     "pkginfo >= 1.0",
-    "requests >= 2.3.0",
+    "requests >= 2.5.0",
     "requests-toolbelt >= 0.5.1",
     "setuptools >= 0.7.0",
 ]

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -102,6 +102,11 @@ def upload(dists, repository, sign, identity, username, password, comment,
     for filename in uploads:
         package = PackageFile.from_filename(filename, comment)
 
+        if repository.package_is_uploaded(package) and skip_existing:
+            print("  Skipping {0} because it appears to already exist".format(
+                package.basefilename))
+            continue
+
         signed_name = package.signed_basefilename
         if signed_name in signatures:
             package.add_gpg_signature(signatures[signed_name], signed_name)
@@ -119,12 +124,6 @@ def upload(dists, repository, sign, identity, username, password, comment,
                 ('"{0}" attempted to redirect to "{1}" during upload.'
                  ' Aborting...').format(config["repository"],
                                         resp.headers["location"]))
-
-        # Otherwise, raise an HTTPError based on the status code.
-        if skip_upload(resp, skip_existing, package):
-            print("  Skipping {0} because it appears to already exist".format(
-                package.basefilename))
-            continue
 
         resp.raise_for_status()
 


### PR DESCRIPTION
Occasionally, PyPI returns a 5xx error when upload fails. There are a
few ways in which the upload can fail but in general, @dstufft
assures us retrying an upload should be safe and generally a good idea.

Closes #167