### PR TITLE
Use RawConfigParser to read .pypirc

### DIFF
--- a/twine/utils.py
+++ b/twine/utils.py
@@ -52,7 +52,7 @@ def get_config(path="~/.pypirc"):
                 }
 
     # Parse the rc file
-    parser = configparser.ConfigParser()
+    parser = configparser.RawConfigParser()
     parser.read(path)
 
     # Get a list of repositories from the config file


### PR DESCRIPTION
If password (for example) in .pypirc contains a %, ConfigParser will try to interpolate it and then raise an InterpolationSyntaxError. RawConfigParser will not attempt to interpolate % in strings. The .pypirc file is simple enough that it is unlikely to need the magic interpolation behaviour that ConfigParser provides. See https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.