### PR TITLE
Check if --skip-existing is set before hitting PyPI

### DIFF
--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -105,7 +105,10 @@ def upload(dists, repository, sign, identity, username, password, comment,
     for filename in uploads:
         package = PackageFile.from_filename(filename, comment)
 
-        if repository.package_is_uploaded(package) and skip_existing:
+        # Note: The skip_existing check *needs* to be first, because otherwise
+        #       we're going to generate extra HTTP requests against a hardcoded
+        #       URL for no reason.
+        if skip_existing and repository.package_is_uploaded(package):
             print("  Skipping {0} because it appears to already exist".format(
                 package.basefilename))
             continue


### PR DESCRIPTION
Currently ``--skip-existing`` only works for uploading to PyPI itself, not to any other implementation or instance. This PR doesn't change that, but avoids hitting PyPI on every upload unless you're using the ``--skip-existing`` feature (which only works on PyPI at the moment).