### PR TITLE
Switch from upload.pypi.io to upload.pypi.org

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -29,7 +29,7 @@ import twine
 KEYWORDS_TO_NOT_FLATTEN = set(["gpg_signature", "content"])
 
 LEGACY_PYPI = 'https://pypi.python.org/'
-WAREHOUSE = 'https://upload.pypi.io/'
+WAREHOUSE = 'https://upload.pypi.org/'
 
 
 class Repository(object):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -37,7 +37,7 @@ else:
     input_func = raw_input
 
 
-DEFAULT_REPOSITORY = "https://upload.pypi.io/legacy/"
+DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
 
 
 def get_config(path="~/.pypirc"):


### PR DESCRIPTION
The PSF has finally acquired the pypi.org domain name, and thus is switching Warehouse from using upload.pypi.io to upload.pypi.org, while supporting both. This will move Twine over to using the ``.org`` name by default.