### PR TITLE
Use hashlib.blake2b where available instead of pyblake2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,9 @@ Changelog
     `keyring <https://pypi.org/projects/keyring>`_ if available.
     Module can be required with the ``keyring`` extra.
 
+  * Twine will use ``hashlib.blake2b`` on Python 3.6+ instead of using pyblake2
+    for Blake2 hashes 256 bit hashes.
+
 * :release:`1.8.1 <2016-08-09>`
 
   * Check if a package exists if the URL is one of:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,5 @@ requires-dist =
     pkginfo >= 1.0
     setuptools >= 0.7.0
     argparse; python_version == '2.6'
-    pyblake2; extra == 'with-blake2'
+    pyblake2; extra == 'with-blake2' and python_version < '3.6'
     keyring; extra == 'keyring'

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,14 @@ if sys.version_info[:2] < (2, 7):
     ]
 
 
+blake2_requires = []
+
+if sys.version_info[:2] < (3, 6):
+    blake2_requires += [
+        "pyblake2",
+    ]
+
+
 setup(
     name=twine.__title__,
     version=twine.__version__,
@@ -79,9 +87,7 @@ setup(
 
     install_requires=install_requires,
     extras_require={
-        'with-blake2': [
-            'pyblake2',
-        ],
+        'with-blake2': blake2_requires,
         'keyring': [
             'keyring',
         ],

--- a/twine/package.py
+++ b/twine/package.py
@@ -21,9 +21,12 @@ import pkginfo
 import pkg_resources
 
 try:
-    import pyblake2
+    from hashlib import blake2b
 except ImportError:
-    pyblake2 = None
+    try:
+        from pyblake2 import blake2b
+    except ImportError:
+        blake2b = None
 
 from twine.wheel import Wheel
 from twine.wininst import WinInst
@@ -59,8 +62,8 @@ class PackageFile(object):
         self.gpg_signature = None
 
         blake2_256_hash = None
-        if pyblake2 is not None:
-            blake2_256_hash = pyblake2.blake2b(digest_size=256 // 8)
+        if blake2b is not None:
+            blake2_256_hash = blake2b(digest_size=256 // 8)
         # NOTE(sigmavirus24): We may or may not be able to use blake2 so let's
         # either use the methods or lambdas to do nothing.
         blake_update = getattr(blake2_256_hash, 'update', lambda *args: None)


### PR DESCRIPTION
Starting with Python 3.6, Python itself comes with Blake2 hashes in the standard library. This will prefer to use that when available and will adjust the `with-blake2` extra to avoid installing pyblake2 on Pythons that have `hashlib.blake2b` available.