### PR TITLE
Use get_password with correct args in register command.

### DIFF
--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -37,7 +37,9 @@ def register(package, repository, username, password, comment, config_file,
     print("Registering package to {0}".format(config["repository"]))
 
     username = utils.get_username(username, config)
-    password = utils.get_password(password, config)
+    password = utils.get_password(
+        config["repository"], username, password, config,
+    )
     ca_cert = utils.get_cacert(cert, config)
     client_cert = utils.get_clientcert(client_cert, config)
 


### PR DESCRIPTION
Same as already done in the upload command.
This fix is only needed for master, not for the latests 1.8.1 release.