### PR TITLE
Started documenting the API.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Adam Talsma <adam@talsma.ca>
 Jens Diemer <github@jensdiemer.de> (http://jensdiemer.de/)
 Andrew Watts <andrewwatts@gmail.com>
 Anna Martelli Ravenscroft <annaraven@gmail.com>
+Maurits van Rees <m.van.rees@zestsoftware.nl> (http://maurits.vanrees.org)

--- a/README.rst
+++ b/README.rst
@@ -59,13 +59,13 @@ Usage
        $ python setup.py sdist bdist_wheel
 
 2. Register your project (if necessary):
- 
+
    .. code-block:: bash
 
        $ # One needs to be explicit here, globbing dist/* would fail.
        $ twine register dist/project_name-x.y.z.tar.gz
        $ twine register dist/mypkg-0.1-py2.py3-none-any.whl
-  
+
 3. Upload with twine [#]_:
 
    .. code-block:: bash
@@ -79,16 +79,63 @@ Usage
 4. Done!
 
 
-Options
-~~~~~~~
+Options for register
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ twine register -h
+
+    usage: twine register [-h] [-r REPOSITORY] [--repository-url REPOSITORY_URL]
+                          [-u USERNAME] [-p PASSWORD] [-c COMMENT]
+                          [--config-file CONFIG_FILE] [--cert path]
+                          [--client-cert path]
+                          package
+
+    positional arguments:
+      package               File from which we read the package metadata
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -r REPOSITORY, --repository REPOSITORY
+                            The repository to register the package to. Can be a
+                            section in the config file or a full URL to the
+                            repository (default: pypi). (Can also be set via
+                            TWINE_REPOSITORY environment variable)
+      --repository-url REPOSITORY_URL
+                            The repository URL to upload the package to. This can
+                            be specified with --repository because it will be used
+                            if there is no configuration for the value passed to
+                            --repository. (Can also be set via
+                            TWINE_REPOSITORY_URL environment variable.)
+      -u USERNAME, --username USERNAME
+                            The username to authenticate to the repository as (can
+                            also be set via TWINE_USERNAME environment variable)
+      -p PASSWORD, --password PASSWORD
+                            The password to authenticate to the repository with
+                            (can also be set via TWINE_PASSWORD environment
+                            variable)
+      -c COMMENT, --comment COMMENT
+                            The comment to include with the distribution file
+      --config-file CONFIG_FILE
+                            The .pypirc config file to use
+      --cert path           Path to alternate CA bundle
+      --client-cert path    Path to SSL client certificate, a single file
+                            containing the private key and the certificate in PEM
+                            format
+
+
+Options for upload
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
     $ twine upload -h
 
-    usage: twine upload [-h] [-r REPOSITORY] [-s] [--sign-with SIGN_WITH]
-                        [-i IDENTITY] [-u USERNAME] [-p PASSWORD] [-c COMMENT]
-                        [--config-file CONFIG_FILE] [--skip-existing]
+    usage: twine upload [-h] [-r REPOSITORY] [--repository-url REPOSITORY_URL]
+                        [-s] [--sign-with SIGN_WITH] [-i IDENTITY] [-u USERNAME]
+                        [-p PASSWORD] [-c COMMENT] [--config-file CONFIG_FILE]
+                        [--skip-existing] [--cert path] [--client-cert path]
                         dist [dist ...]
 
     positional arguments:
@@ -99,21 +146,181 @@ Options
     optional arguments:
       -h, --help            show this help message and exit
       -r REPOSITORY, --repository REPOSITORY
-                            The repository to upload the files to (default: pypi)
+                            The repository to register the package to. Can be a
+                            section in the config file or a full URL to the
+                            repository (default: pypi). (Can also be set via
+                            TWINE_REPOSITORY environment variable)
+      --repository-url REPOSITORY_URL
+                            The repository URL to upload the package to. This can
+                            be specified with --repository because it will be used
+                            if there is no configuration for the value passed to
+                            --repository. (Can also be set via
+                            TWINE_REPOSITORY_URL environment variable.)
       -s, --sign            Sign files to upload using gpg
       --sign-with SIGN_WITH
                             GPG program used to sign uploads (default: gpg)
       -i IDENTITY, --identity IDENTITY
                             GPG identity used to sign files
       -u USERNAME, --username USERNAME
-                            The username to authenticate to the repository as
+                            The username to authenticate to the repository as (can
+                            also be set via TWINE_USERNAME environment variable)
       -p PASSWORD, --password PASSWORD
                             The password to authenticate to the repository with
+                            (can also be set via TWINE_PASSWORD environment
+                            variable)
       -c COMMENT, --comment COMMENT
                             The comment to include with the distribution file
       --config-file CONFIG_FILE
                             The .pypirc config file to use
-      --skip-existing       Continue uploading files if one already exists
+      --skip-existing       Continue uploading files if one already exists. (Only
+                            valid when uploading to PyPI. Other implementations
+                            may not support this.)
+      --cert path           Path to alternate CA bundle
+      --client-cert path    Path to SSL client certificate, a single file
+                            containing the private key and the certificate in PEM
+                            format
+
+
+API
+---
+
+``twine`` is written in Python.  Of course.  So if you work on a
+Python tool that uses ``twine`` for uploading or registering, you can
+import it.
+
+Note that reading environment variables, for example
+``TWINE_REPOSITORY``, is a feature of the command line tool.  the API
+does not try to read this.
+
+
+API package
+~~~~~~~~~~~
+
+Create a package object:
+
+.. code-block:: python
+
+    from twine.package import PackageFile
+    package = PackageFile.from_filename(filename, comment)
+
+Here ``filename`` is the name of a distribution (usually a wheel or a
+source distribution) and comment is a comment to include with the
+distribution file.  The comment may be ``None``.
+
+You can add a gpg signature:
+
+.. code-block:: python
+
+    package.add_gpg_signature(signature_filepath, signature_filename)
+
+You can sign a package:
+
+.. code-block:: python
+
+    package.sign(sign_with, identity)
+
+
+API repository
+~~~~~~~~~~~~~~
+
+Define a repository:
+
+.. code-block:: python
+
+    from twine.repository import Repository
+    repository = Repository(config["repository"], username, password)
+    repository.set_certificate_authority(ca_cert)
+    repository.set_client_certificate(client_cert)
+
+
+Register a package:
+
+.. code-block:: python
+
+    package = PackageFile.from_filename(filename, comment)
+    response = repository.register()
+
+Upload a package:
+
+.. code-block:: python
+
+    if repository.package_is_uploaded(package):
+        ...
+    response = repository.upload(package)
+    repository.close()
+
+
+API exceptions
+~~~~~~~~~~~~~~
+
+When things go wrong:
+
+.. code-block:: python
+
+    # A redirect was detected that the user needs to resolve.
+    from twine.exceptions import RedirectDetected
+
+    # A package file was provided that could not be found on the file system.
+    from twine.exceptions import PackageNotFound
+
+
+API register
+~~~~~~~~~~~~
+
+Since version 2.0 you can use this:
+
+.. code-block:: python
+
+    from twine.commands.register import register
+    upload('dist/mypkg-0.1-py2.py3-none-any.whl')
+
+It takes as only required argument the name of a file from which we
+read the package metadata.  This is usually a wheel or a source
+distribution.
+
+You can pass several optional keyword arguments.  This is the list,
+including the default values:
+
+.. code-block:: python
+
+   repository="pypi",
+   username=None,
+   password=None,
+   comment=None,
+   config_file="~/.pypirc",
+   cert=None,
+   client_cert=None,
+   repository_url=None,
+
+
+API upload
+~~~~~~~~~~
+
+Since version 2.0 you can use this:
+
+.. code-block:: python
+
+    from twine.commands.upload import upload
+    upload(['dist/project_name-x.y.z.tar.gz', 'dist/mypkg-0.1-py2.py3-none-any.whl'])
+
+Only a list of files to upload is required.  You can pass several
+optional keyword arguments.  This is the list, including the default
+values:
+
+.. code-block:: python
+
+        repository="pypi",
+        sign=False,
+        identity=None,
+        username=None,
+        password=None,
+        comment=None,
+        sign_with="gpg",
+        config_file="~/.pypirc",
+        skip_existing=False,
+        cert=None,
+        client_cert=None,
+        repository_url=None,
 
 
 Resources
@@ -135,7 +342,7 @@ Contributing
      have them installed) or use ``tox -e py{version}`` to test against a
      specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
    - Always run ``tox -e pep8``
-  
+
 4. Ensure that your name is added to the end of the AUTHORS file using the
    format ``Name <email@domain.com> (url)``, where the ``(url)`` portion is
    optional.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 * :release:`1.9.0 <...>`
 
+  * Changed the register and upload commands to accept keyword arguments.
+
+  * Started documenting the API.
+
   * Twine will now resolve passwords using the
     `keyring <https://pypi.org/projects/keyring>`_ if available.
     Module can be required with the ``keyring`` extra.

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -23,8 +23,21 @@ from twine.repository import Repository
 from twine import utils
 
 
-def register(package, repository, username, password, comment, config_file,
-             cert, client_cert, repository_url):
+def register(
+        package,
+        repository="pypi",
+        username=None,
+        password=None,
+        comment=None,
+        config_file="~/.pypirc",
+        cert=None,
+        client_cert=None,
+        repository_url=None,
+):
+    # IMPORTANT: Before version 2.0 there were only arguments here, not keywork
+    # arguments.  So for compatibility, please do not change the orde.  New
+    # keyword arguments should be added at the end.  Please update the
+    # README.rst file too.
     config = utils.get_repository_from_config(
         config_file,
         repository,
@@ -73,7 +86,8 @@ def main(args):
         default="pypi",
         help="The repository to register the package to. Can be a section in "
              "the config file or a full URL to the repository (default: "
-             "%(default)s)",
+             "%(default)s). (Can also be set via %(env)s environment "
+             "variable)",
     )
     parser.add_argument(
         "--repository-url",
@@ -83,7 +97,8 @@ def main(args):
         required=False,
         help="The repository URL to upload the package to. This can be "
              "specified with --repository because it will be used if there is "
-             "no configuration for the value passed to --repository."
+             "no configuration for the value passed to --repository. "
+             "(Can also be set via %(env)s environment variable.)"
     )
     parser.add_argument(
         "-u", "--username",
@@ -119,7 +134,7 @@ def main(args):
         "--client-cert",
         metavar="path",
         help="Path to SSL client certificate, a single file containing the "
-             "private key and the certificate in PEM forma",
+             "private key and the certificate in PEM format",
     )
     parser.add_argument(
         "package",

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -71,9 +71,26 @@ def skip_upload(response, skip_existing, package):
             (response.status_code == 400 and response.reason.startswith(msg))))
 
 
-def upload(dists, repository, sign, identity, username, password, comment,
-           sign_with, config_file, skip_existing, cert, client_cert,
-           repository_url):
+def upload(
+        dists,
+        repository="pypi",
+        sign=False,
+        identity=None,
+        username=None,
+        password=None,
+        comment=None,
+        sign_with="gpg",
+        config_file="~/.pypirc",
+        skip_existing=False,
+        cert=None,
+        client_cert=None,
+        repository_url=None,
+):
+    # IMPORTANT: Before version 2.0 there were only arguments here, not keywork
+    # arguments.  So for compatibility, please do not change the orde.  New
+    # keyword arguments should be added at the end.  Please update the
+    # README.rst file too.
+
     # Check that a nonsensical option wasn't given
     if not sign and identity:
         raise ValueError("sign must be given along with identity")
@@ -161,7 +178,8 @@ def main(args):
         default="pypi",
         help="The repository to register the package to. Can be a section in "
              "the config file or a full URL to the repository (default: "
-             "%(default)s)",
+             "%(default)s). (Can also be set via %(env)s environment "
+             "variable)",
     )
     parser.add_argument(
         "--repository-url",
@@ -171,7 +189,8 @@ def main(args):
         required=False,
         help="The repository URL to upload the package to. This can be "
              "specified with --repository because it will be used if there is "
-             "no configuration for the value passed to --repository."
+             "no configuration for the value passed to --repository. "
+             "(Can also be set via %(env)s environment variable.)"
     )
     parser.add_argument(
         "-s", "--sign",
@@ -230,7 +249,7 @@ def main(args):
         "--client-cert",
         metavar="path",
         help="Path to SSL client certificate, a single file containing the "
-             "private key and the certificate in PEM forma",
+             "private key and the certificate in PEM format",
     )
     parser.add_argument(
         "dists",


### PR DESCRIPTION
Also changed the register and upload commands to accept keyword arguments.

This refs issue https://github.com/pypa/twine/issues/194

I started out making the commands more usable as API, although @sigmavirus said he did not view the commands as an API. It may still be useful. It is the most logical first step someone would try when he currently does:
```
os.system('twine upload stuff')
```

and wants to try it in pure Python instead:

```
from twine.commands.upload import upload
upload([stuff])
```

It would be nice if that worked, instead of having to supply twelve extra arguments, most of which can be `None`.

So I changed the main functions of the commands to accept keywords.  This makes it easy to use them, without needing to change code when someone adds an another argument to the function in twine.

Then I started documenting that, and also started on documenting what is more meant as an API: the stuff in the exceptions, package and repository modules. To me, *these* seem more like internals that could change at any given moment, but apparently they are meant to be reasonably stable.  Instead, the call signature for the commands can change at a moment's notice.

So after starting to document the 'semi-public' API, I could see better how it would be possible for a utility like `zest.releaser` to use this API without calling the commands.

So....: at this point this pull request feels more like a basis to have a small discussion on. The question then is: what do we want to keep from this? It can be all, or a selection of these, or none:

- Changing the commands to accept keyword arguments. If this is accepted, `zest.releaser` is likely to keep using this way, instead of looking at the more official API.
- Adding the API docs for exceptions, package, and repository. (An edit would be good, especially by someone who knows how to use the gpg/signing parts, which I don't currently use.)
- Adding the API docs for the commands. We can choose not to do this, if we don't want those commands as an official API.

What do you think?