### PR TITLE
Allow setting ca_cert and client_cert in config

### DIFF
--- a/twine/utils.py
+++ b/twine/utils.py
@@ -90,7 +90,10 @@ def get_config(path="~/.pypirc"):
         }
 
         # Optional configuration values
-        for key in ["username", "repository", "password", "ca_cert", "client_cert"]:
+        for key in [
+            "username", "repository", "password",
+            "ca_cert", "client_cert",
+        ]:
             if parser.has_option(repository, key):
                 config[repository][key] = parser.get(repository, key)
             elif defaults.get(key):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -90,7 +90,7 @@ def get_config(path="~/.pypirc"):
         }
 
         # Optional configuration values
-        for key in ["username", "repository", "password"]:
+        for key in ["username", "repository", "password", "ca_cert", "client_cert"]:
             if parser.has_option(repository, key):
                 config[repository][key] = parser.get(repository, key)
             elif defaults.get(key):


### PR DESCRIPTION
Right now, the settings code expects you to be able to set `ca_cert` and `client_cert` in the `pypirc` as properties of the repository (that's what `get_userpass_value` does). However, the parsing code doesn't read those properties in! This minor change fixes that issue, finally allowing the cert to be set anywhere, not just on the command line.