### PR TITLE
Treat filenames from the Wheel file

### DIFF
--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -28,3 +28,20 @@ def example_wheel(request):
 
 def test_version_parsing(example_wheel):
     assert example_wheel.py_version == 'py2.py3'
+
+
+def test_find_metadata_files():
+    names = [
+        b'package/lib/__init__.py',
+        b'package/lib/version.py',
+        b'package/METADATA.txt',
+        b'package/METADATA.json',
+        b'package/METADATA',
+    ]
+    expected = [
+        ['package', 'METADATA'],
+        ['package', 'METADATA.json'],
+        ['package', 'METADATA.txt'],
+    ]
+    candidates = wheel.Wheel.find_candidate_metadata_files(names)
+    assert expected == candidates


### PR DESCRIPTION
Filenames in a Wheel are returned as bytestrings. When we check to find
METADATA files, we need to juggle the fact that strings are unicode by
default and that the filenames are bytestrings.

Closes gh-235