### PR TITLE
Fix --skip-existing with a new package upload

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -188,7 +188,10 @@ class Repository(object):
                                                     url=LEGACY_PYPI)
             headers = {'Accept': 'application/json'}
             response = self.session.get(url, headers=headers)
-            releases = response.json()['releases']
+            if response.status_code == 200:
+                releases = response.json()['releases']
+            else:
+                releases = {}
             self._releases_json_data[safe_name] = releases
 
         packages = releases.get(package.metadata.version, [])


### PR DESCRIPTION
Users may want to use --skip-existing even if this is the first time
they're uploading a package. This allows that use-case to be successful.

Closes gh-220