### PR TITLE
Do not use broken dependencies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@
 Changelog
 =========
 
+* :release:`1.9.1 <2017-05-27>`
+
+  * Blacklist known bad versions of Requests. See also :bug:`253`
+
 * :release:`1.9.0 <2017-05-22>`
 
   * Twine will now resolve passwords using the

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore =
 [metadata]
 requires-dist =
     tqdm >= 4.11
-    requests >= 2.5.0
+    requests >= 2.5.0, != 2.15, != 2.16
     requests-toolbelt >= 0.8.0
     pkginfo >= 1.0
     setuptools >= 0.7.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import twine
 install_requires = [
     "tqdm >= 4.11",
     "pkginfo >= 1.0",
-    "requests >= 2.5.0",
+    "requests >= 2.5.0, != 2.15, != 2.16",
     "requests-toolbelt >= 0.8.0",
     "setuptools >= 0.7.0",
 ]

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -22,7 +22,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for interacting with PyPI"
 __uri__ = "https://github.com/pypa/twine"
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
Requests v2.15.x was released and found to be awfully broken.

Requests v2.16.x was released and is horribly backwards incompatible.

See also https://github.com/kennethreitz/requests/issues/4069

Related to gh-253