### PR TITLE
update and tweak tqdm progressbar

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ ignore =
 
 [metadata]
 requires-dist =
-    tqdm >= 4.11
+    tqdm >= 4.14
     requests >= 2.5.0, != 2.15, != 2.16
     requests-toolbelt >= 0.8.0
     pkginfo >= 1.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import twine
 
 
 install_requires = [
-    "tqdm >= 4.11",
+    "tqdm >= 4.14",
     "pkginfo >= 1.0",
     "requests >= 2.5.0, != 2.15, != 2.16",
     "requests-toolbelt >= 0.8.0",

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -34,14 +34,13 @@ OLD_WAREHOUSE = 'https://upload.pypi.io/'
 
 
 class ProgressBar(tqdm):
-
     def update_to(self, n):
         """Update the bar in the way compatible with requests-toolbelt.
 
         This is identical to tqdm.update, except ``n`` will be the current
         value - not the delta as tqdm expects.
         """
-        self.update(n - self.n)
+        self.update(n - self.n)  # will also do self.n = n
 
 
 class Repository(object):
@@ -136,8 +135,9 @@ class Repository(object):
                 (package.basefilename, fp, "application/octet-stream"),
             ))
             encoder = MultipartEncoder(data_to_send)
-            with ProgressBar(total=encoder.len, unit='bytes',
-                             unit_scale=True, leave=False) as bar:
+            with ProgressBar(total=encoder.len,
+                             unit='B', unit_scale=True, unit_divisor=1024,
+                             miniters=1) as bar:
                 monitor = MultipartEncoderMonitor(
                     encoder, lambda monitor: bar.update_to(monitor.bytes_read)
                 )


### PR DESCRIPTION
This is a follow-on from #242.

- [x] update to latest version of `tqdm>=4.14`
    - [x] use `unit_divisor=1024` instead of `1000`
- [x] use `'B'` as units instead of `'bytes'`
- [x] leave progressbar upon completion (to match old behaviour when clint was used, and to look pretty and provide permanent info)

external:

- [x] ensure users can download `tqdm>=4.14` via:
    + [x] `pypi`
    + [x] `conda`

thanks for using `tqdm`!