### PR TITLE
Declare support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
     - env: TOXENV=docs
     - env: TOXENV=pep8
     - env: TOXENV=pypy

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,docs,pep8
+envlist = py27,pypy,py33,py34,py35,py36,docs,pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Enable tests under Python 3.6 in `tox.ini` and `.travis.yml` and add
language classifier to `setup.py`.