### PR TITLE
Print progress to stdout, not stderr

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import absolute_import, unicode_literals, print_function
 
+import sys
+
 from tqdm import tqdm
 
 import requests
@@ -137,7 +139,7 @@ class Repository(object):
             encoder = MultipartEncoder(data_to_send)
             with ProgressBar(total=encoder.len,
                              unit='B', unit_scale=True, unit_divisor=1024,
-                             miniters=1) as bar:
+                             miniters=1, file=sys.stdout) as bar:
                 monitor = MultipartEncoderMonitor(
                     encoder, lambda monitor: bar.update_to(monitor.bytes_read)
                 )


### PR DESCRIPTION
Should prevent problems for people who use Twine from Appveyor.  (Any
output to stderr is helpfully treated as a failure by the PowerShell
scripting host, and causes the entire Appveyor job to be marked as
failed.)

Fixes #268.

Note: I have not tested this manually, only ran the test suite.