### PR TITLE
add code overview to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,21 @@ and the `Python Packaging User Guide`_ for user documentation. You can
 also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the `pypa-dev
 mailing list`_, to ask questions or get involved.
 
+Overview
+--------
+
+Twine is a command-line tool for interacting with PyPI securely over HTTPS. Its
+command line arguments are parsed in ``twine/twine/cli.py``. Currently, twine
+has two principal functions: uploading new packages and registering new
+`projects`_ . The code for registering new projects is in
+``twine/twine/commands/register.py``, and the code for uploading is in
+``twine/twine/commands/upload.py``. The file ``twine/twine/package.py``
+contains a single class, ``PackageFile``, which hashes the project files and
+extracts their metadata. The file ``twine/twine/repository.py`` contains the
+``Repository`` class, whose methods control the URL the package is uploaded to
+(which the user can specify either as a default, in the ``.pypirc`` file, or
+pass on the command line), and the methods that upload the package securely to
+a URL.
 
 Contents:
 
@@ -33,61 +48,14 @@ Getting Started
 
 We are happy you have decided to contribute to twine.
 
-To set up your development environment, first fork the twine repository on
-GitHub, using the ``fork`` button on the upper right-hand corner of the page
-for the `main twine repository`_.
-
-Then, go to your fork of twine on GitHub. The URL will be in the following
-format:
-
-.. code-block:: console
-
-  https://github.com/<username>/twine
-
-Your GitHub username will appear where ``<username>`` is in the example URL
-above.
-
-Now, use ``git clone`` to download the code from your fork of the repository:
-
-.. code-block:: console
-
-  git clone https://github.com/<username>/twine
-
-As in the URL above, ``<username>`` is your GitHub username.
-
-Add the main twine repository as ``upstream``:
-
-.. code-block:: console
-
-  git remote add upstream https://github.com/pypa/twine
-
-This allows you to easily keep your local copy and your GitHub fork of the code
-current with any changes in the main twine repository.
-
-To make sure you have set up everything correctly, the output of this command:
-
-.. code-block:: console
-
-  git remote -v
-
-Should be the following:
-
-.. code-block:: console
-
-  origin  https://github.com/<username>/twine.git (fetch)
-  origin  https://github.com/<username>/twine.git (push)
-  upstream  https://github.com/pypa/twine.git (fetch)
-  upstream  https://github.com/pypa/twine.git (push)
-
-Your username on GitHub should replace ``<username>`` in the example above.
-
 It is important to keep your development environment isolated, so that twine
 and its dependencies do not interfere with packages already installed on your
 machine.  We will use a virtual environment for the development environment for
 twine. You can use `virtualenv`_ or `pipenv`_ to isolate your development
 environment.
 
-Activate your virtual environment. Then, run the following command:
+Clone the twine repository from GitHub, and then activate your virtual
+environment. Then, run the following command:
 
 .. code-block:: console
 
@@ -113,7 +81,11 @@ Building the documentation
 Additions and edits to twine's documentation are welcome and appreciated. To
 build the docs locally, first set up a virtual environment and activate it,
 using Python 3.6 as the Python version in the virtual environment. Then install
-the following:
+tox:
+
+.. code-block:: console
+
+  pip install tox
 
 Install Sphinx:
 
@@ -128,13 +100,13 @@ Install the ``releases`` `plugin`_ and the Read the Docs theme for Sphinx:
   pip install -e git+https://github.com/bitprophet/releases/#egg=releases
   pip install sphinx_rtd_theme
 
-Change directories to the ``docs`` directory, and then run:
+Then, run the following command:
 
 .. code-block:: console
 
-  sphinx-build -b html . _build
+  tox -e docs
 
-The docs will be visible at ``twine/docs/_build/index.html``.
+The HTML of the docs will be visible in this directory: ``twine/docs/_build/``.
 
 When you have made your changes to the docs, please lint them before making a
 pull request.
@@ -145,11 +117,11 @@ Install the linter:
 
   pip install doc8
 
-Then, run the linter in the ``twine/docs`` directory:
+Then, run the linter:
 
 .. code-block:: console
 
-    doc8 .
+    doc8 docs
 
 
 Indices and tables
@@ -173,3 +145,4 @@ Indices and tables
 .. _`tox`: https://tox.readthedocs.io/en/latest/
 .. _`tox-pipenv`: https://pypi.python.org/pypi/tox-pipenv
 .. _`plugin`: https://github.com/bitprophet/releases
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,13 +24,13 @@ Overview
 --------
 
 Twine is a command-line tool for interacting with PyPI securely over HTTPS. Its
-command line arguments are parsed in ``twine/twine/cli.py``. Currently, twine
+command line arguments are parsed in ``twine/cli.py``. Currently, twine
 has two principal functions: uploading new packages and registering new
-`projects`_ . The code for registering new projects is in
-``twine/twine/commands/register.py``, and the code for uploading is in
-``twine/twine/commands/upload.py``. The file ``twine/twine/package.py``
+`projects`_. The code for registering new projects is in
+``twine/commands/register.py``, and the code for uploading is in
+``twine/commands/upload.py``. The file ``twine/package.py``
 contains a single class, ``PackageFile``, which hashes the project files and
-extracts their metadata. The file ``twine/twine/repository.py`` contains the
+extracts their metadata. The file ``twine/repository.py`` contains the
 ``Repository`` class, whose methods control the URL the package is uploaded to
 (which the user can specify either as a default, in the ``.pypirc`` file, or
 pass on the command line), and the methods that upload the package securely to


### PR DESCRIPTION
This adds a brief overview of twine's architecture to the documentation. Please let me know if there are any additions or changes.