### PR TITLE
Add docs requirements file, update tox & Travis config to fix RtD and builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=pep8
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - env: TOXENV=docs
-    - env: TOXENV=pep8
-    - env: TOXENV=pypy
+    - python: 3.6
+      env: TOXENV=docs
+    - python: 3.6
+      env: TOXENV=pypy
 
 install:
   # Add the PyPy repository

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,53 +56,32 @@ Tests with twine are run using `tox`_, and tested against the following Python
 versions: 2.7, 3.4, 3,5, and 3.6. To run these tests locally, you will need to
 have these versions of Python installed on your machine.
 
-If you are using pipenv to manage your virtual environment, you may need the
-`tox-pipenv`_ plugin so that tox can use pipenv environments instead of
-virtualenvs.
+If you are using ``pipenv`` to manage your virtual environment, you
+may need the `tox-pipenv`_ plugin so that tox can use pipenv
+environments instead of virtualenvs.
 
 Building the documentation
 --------------------------
 
 Additions and edits to twine's documentation are welcome and appreciated. To
 build the docs locally, first set up a virtual environment and activate it,
-using Python 3.6 as the Python version in the virtual environment. Then install
-tox:
+using Python 3.6 as the Python version in the virtual environment. Example:
+
+.. code-block:: console
+
+  mkvirtualenv -p /usr/bin/python3.6 twine
+
+Then install ``tox`` and build the docs using ``tox``:
 
 .. code-block:: console
 
   pip install tox
-
-Install Sphinx:
-
-.. code-block:: console
-
-  pip install Sphinx
-
-Install the ``releases`` `plugin`_ and the Read the Docs theme for Sphinx:
-
-.. code-block:: console
-
-  pip install -e git+https://github.com/bitprophet/releases/#egg=releases
-  pip install sphinx_rtd_theme
-
-Then, run the following command:
-
-.. code-block:: console
-
   tox -e docs
 
 The HTML of the docs will be visible in this directory: ``twine/docs/_build/``.
 
 When you have made your changes to the docs, please lint them before making a
-pull request.
-
-Install the linter:
-
-.. code-block:: console
-
-  pip install doc8
-
-Then, run the linter:
+pull request. To run the linter from the root directory:
 
 .. code-block:: console
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+doc8>=0.8.0
+releases>=1.4.0
+Sphinx>=1.7.0
+sphinx_rtd_theme>=0.2.4
+tox>=2.9.1
+twine>=1.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -29,5 +29,6 @@ commands =
     twine upload --skip-existing dist/*
 
 [testenv:pep8]
+basepython = python2.7
 deps = flake8
 commands = flake8 twine/ tests/ docs/

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,8 @@ commands =
     coverage report -m
 
 [testenv:docs]
-basepython = python2.7
-deps =
-    sphinx!=1.6.1
-    sphinx_rtd_theme
-    releases
+basepython = python3.6
+deps = -rdocs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
For http://twine.readthedocs.io/ to build, the Read the Docs configuration needs a `requirements.txt` file in `docs/`.

I tested this at https://my-fork-of-twine.readthedocs.io/ and verified that this `requirements.txt` file makes it work. For reference, other configuration bits I had to twiddle in the Admin: Advanced Settings page on RtD:

* check the "Install your project inside a virtualenv using `setup.py install`" box
* point to `docs/requirements.txt` in the "Requirements file" box
* Python interpreter: CPython 3.x