### PR TITLE
Reorganize user and developer documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,12 +132,16 @@ Options
                             format
 
 
-Twine also includes a ``register`` command which is `not supported
-<https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_ (the
-new PyPI software running on pypi.org) and which is `no longer
-necessary if you are uploading to pypi.org
-<https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_. For
-completeness, its usage:
+Twine also includes a ``register`` command.
+
+.. WARNING:: Warning!
+   ``register`` is `not supported
+   <https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_ (the
+   new PyPI software running on pypi.org) and is `no longer
+   necessary if you are uploading to pypi.org
+   <https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_.
+
+For completeness, its usage:
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -134,12 +134,14 @@ Options
 
 Twine also includes a ``register`` command.
 
-.. WARNING:: Warning!
-   ``register`` is `not supported
-   <https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_ (the
-   new PyPI software running on pypi.org) and is `no longer
-   necessary if you are uploading to pypi.org
-   <https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_.
+.. WARNING::
+   ``register`` is `no longer necessary if you are
+   uploading to pypi.org
+   <https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_. As
+   such, it is `no longer supported
+   <https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_
+   (the new PyPI software running on pypi.org). However, you may need
+   this if you are using a different package index.
 
 For completeness, its usage:
 

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,22 @@
 twine
 =====
 
-Twine is a utility for interacting `with PyPI <https://pypi.org/project/twine/>`_.
+.. rtd-inclusion-marker-do-not-remove
 
-Currently it only supports registering `projects <https://packaging.python.org/glossary/#term-project>`_ and uploading `distributions <https://packaging.python.org/glossary/#term-distribution-package>`_.
+Twine is `a utility`_ for `publishing`_ packages on `PyPI`_.
+
+Currently it only supports registering `projects`_ and uploading `distributions`_.
 
 
 Why Should I Use This?
 ----------------------
 
+The goal of ``twine`` is to improve PyPI interaction by improving
+security and testability.
+
 The biggest reason to use ``twine`` is that it securely authenticates you to PyPI
 over HTTPS using a verified connection, while ``python setup.py upload`` `only
-recently stopped using HTTP <http://bugs.python.org/issue12226>`_ in Python
+recently stopped using HTTP <https://bugs.python.org/issue12226>`_ in Python
 2.7.9+ and Python 3.2+. This means anytime you use ``python setup.py upload``
 with an older Python version, you expose your username and password to being
 easily sniffed. Twine uses only verified TLS to upload to PyPI, protecting your
@@ -34,7 +39,7 @@ and not anything else, since *you* will be the one directly executing
 Features
 --------
 
-- Verified HTTPS Connections
+- Verified HTTPS connections
 - Uploading doesn't require executing ``setup.py``
 - Uploading files that have already been created, allowing testing of
   distributions before release
@@ -66,9 +71,12 @@ Usage
 
 3. Done!
 
+More documentation on using ``twine`` to upload packages to PyPI is in
+the `Python Packaging User Guide`_.
+
 
 Options
-~~~~~~~
+^^^^^^^
 
 .. code-block:: console
 
@@ -124,10 +132,10 @@ Options
                             format
 
 
-Twine also includes a ``register`` command which is `not supported in
-Warehouse (the new PyPI software running on pypi.org)
-<https://github.com/pypa/warehouse/issues/1627>`_ and which is `no
-longer necessary if you are uploading to pypi.org
+Twine also includes a ``register`` command which is `not supported
+<https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_ (the
+new PyPI software running on pypi.org) and which is `no longer
+necessary if you are uploading to pypi.org
 <https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_. For
 completeness, its usage:
 
@@ -175,7 +183,7 @@ completeness, its usage:
 
 
 Environment Variables
-`````````````````````
+^^^^^^^^^^^^^^^^^^^^^
 
 Twine also supports configuration via environment variables. Options passed on
 the command line will take precedence over options set via environment
@@ -194,31 +202,17 @@ example.
 Resources
 ---------
 
-* `IRC <http://webchat.freenode.net?channels=%23pypa>`_
+* `IRC <http://webchat.freenode.net/?channels=%23pypa>`_
   (``#pypa`` - irc.freenode.net)
 * `GitHub repository <https://github.com/pypa/twine>`_
-* `Python Packaging User Guide <https://packaging.python.org/en/latest/distributing/>`_
+* User and developer `documentation`_
+* `Python Packaging User Guide`_
 
 Contributing
 ------------
 
-1. Fork the `repository <https://github.com/pypa/twine>`_ on GitHub.
-2. Make a branch off of master and commit your changes to it.
-3. Run the tests with ``tox``.
-
-   - Either use ``tox`` to build against all supported Python versions (if you
-     have them installed) or use ``tox -e py{version}`` to test against a
-     specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
-   - Always run ``tox -e pep8``.
-
-4. Ensure that your name is added to the end of the AUTHORS file using the
-   format ``Name <email@domain.com> (url)``, where the ``(url)`` portion is
-   optional.
-5. Submit a Pull Request to the master branch on GitHub.
-
-If you'd like to have a development environment for twine, you should create a
-virtualenv and then do ``pip install -e .`` from within the directory.
-
+See our `developer documentation`_ for how to get started, an
+architectural overview, and our future development plans.
 
 Code of Conduct
 ---------------
@@ -227,4 +221,13 @@ Everyone interacting in the ``twine`` project's codebases, issue
 trackers, chat rooms, and mailing lists is expected to follow the
 `PyPA Code of Conduct`_.
 
-.. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. _`a utility`: https://pypi.org/project/twine/
+.. _`publishing`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`PyPI`: https://pypi.org
+.. _`Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`documentation`: http://twine.readthedocs.io/
+.. _`developer documentation`: https://twine.readthedocs.io/en/latest/contributing.html
+.. _`projects`: https://packaging.python.org/glossary/#term-project
+.. _`distributions`: https://packaging.python.org/glossary/#term-distribution-package
+.. _`PyPA Code of Conduct`: https://www.pypa.io/en/latest/code-of-conduct/
+.. _`Warehouse`: https://github.com/pypa/warehouse

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,121 @@
+Contributing
+============
+
+We are happy you have decided to contribute to ``twine``.
+
+Please see `the GitHub repository`_ for code and more documentation,
+and the `official Python Packaging User Guide`_ for user documentation. You can
+also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the `pypa-dev
+mailing list`_, to ask questions or get involved.
+
+Getting started
+---------------
+
+We recommend you use a development environment. Using a ``virtualenv``
+keeps your development environment isolated, so that ``twine`` and its
+dependencies do not interfere with packages already installed on your
+machine.  You can use `virtualenv`_ or `pipenv`_ to isolate your
+development environment.
+
+Clone the twine repository from GitHub, and then activate your virtual
+environment. Then, run the following command:
+
+.. code-block:: console
+
+  pip install -e /path/to/your/local/twine
+
+Now, in your virtual environment, ``twine`` is pointing at your local copy, so
+when you have made changes, you can easily see their effect.
+
+Testing
+^^^^^^^
+
+Tests with twine are run using `tox`_, and tested against the following Python
+versions: 2.7, 3.4, 3,5, and 3.6. To run these tests locally, you will need to
+have these versions of Python installed on your machine.
+
+If you are using ``pipenv`` to manage your virtual environment, you
+may need the `tox-pipenv`_ plugin so that tox can use pipenv
+environments instead of virtualenvs.
+
+Building the documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Additions and edits to twine's documentation are welcome and appreciated. To
+build the docs locally, first set up a virtual environment and activate it,
+using Python 3.6 as the Python version in the virtual environment. Example:
+
+.. code-block:: console
+
+  mkvirtualenv -p /usr/bin/python3.6 twine
+
+Then install ``tox`` and build the docs using ``tox``:
+
+.. code-block:: console
+
+  pip install tox
+  tox -e docs
+
+The HTML of the docs will be visible in this directory: ``twine/docs/_build/``.
+
+When you have made your changes to the docs, please lint them before making a
+pull request. To run the linter from the root directory:
+
+.. code-block:: console
+
+    doc8 docs
+
+Submitting changes
+^^^^^^^^^^^^^^^^^^
+
+1. Fork `the GitHub repository`_.
+2. Make a branch off of ``master`` and commit your changes to it.
+3. Run the tests with ``tox``.
+
+   - Either use ``tox`` to build against all supported Python versions (if you
+     have them installed) or use ``tox -e py{version}`` to test against a
+     specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
+   - Always run ``tox -e pep8``.
+
+4. Ensure that your name is added to the end of the AUTHORS file using the
+   format ``Name <email@domain.com> (url)``, where the ``(url)`` portion is
+   optional.
+5. Submit a Pull Request to the ``master`` branch on GitHub.
+
+
+Architectural overview
+----------------------
+
+Twine is a command-line tool for interacting with PyPI securely over HTTPS. Its
+command line arguments are parsed in ``twine/cli.py``. Currently, twine
+has two principal functions: uploading new packages and registering new
+`projects`_. The code for registering new projects is in
+``twine/commands/register.py``, and the code for uploading is in
+``twine/commands/upload.py``. The file ``twine/package.py``
+contains a single class, ``PackageFile``, which hashes the project files and
+extracts their metadata. The file ``twine/repository.py`` contains the
+``Repository`` class, whose methods control the URL the package is uploaded to
+(which the user can specify either as a default, in the ``.pypirc`` file, or
+pass on the command line), and the methods that upload the package securely to
+a URL.
+
+Future development
+------------------
+
+See our `open issues`_.
+
+In the future, ``pip`` and ``twine`` may
+merge into a single tool; see `ongoing discussion
+<https://github.com/pypa/packaging-problems/issues/60>`_.
+
+.. _`official Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`the GitHub repository`: https://github.com/pypa/twine
+.. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
+.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
+.. _`virtualenv`: https://virtualenv.pypa.io/en/stable/installation/
+.. _`pipenv`: https://pipenv.readthedocs.io/en/latest/
+.. _`tox`: https://tox.readthedocs.io/en/latest/
+.. _`tox-pipenv`: https://pypi.python.org/pypi/tox-pipenv
+.. _`plugin`: https://github.com/bitprophet/releases
+.. _`projects`: https://packaging.python.org/glossary/#term-project
+.. _`open issues`: https://github.com/pypa/twine/issues

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,8 +17,15 @@ dependencies do not interfere with packages already installed on your
 machine.  You can use `virtualenv`_ or `pipenv`_ to isolate your
 development environment.
 
-Clone the twine repository from GitHub, and then activate your virtual
-environment. Then, run the following command:
+Clone the twine repository from GitHub, and then make and activate
+your virtual environment, using Python 3.6 as the Python version in
+the virtual environment. Example:
+
+.. code-block:: console
+
+  mkvirtualenv -p /usr/bin/python3.6 twine
+
+Then, run the following command:
 
 .. code-block:: console
 
@@ -27,33 +34,28 @@ environment. Then, run the following command:
 Now, in your virtual environment, ``twine`` is pointing at your local copy, so
 when you have made changes, you can easily see their effect.
 
-Testing
-^^^^^^^
+Building the documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tests with twine are run using `tox`_, and tested against the following Python
-versions: 2.7, 3.4, 3,5, and 3.6. To run these tests locally, you will need to
-have these versions of Python installed on your machine.
+Additions and edits to twine's documentation are welcome and
+appreciated.
+
+We use ``tox`` to build docs. Activate your virtual environment, then
+install ``tox``.
+
+.. code-block:: console
+
+  pip install tox
 
 If you are using ``pipenv`` to manage your virtual environment, you
 may need the `tox-pipenv`_ plugin so that tox can use pipenv
 environments instead of virtualenvs.
 
-Building the documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Additions and edits to twine's documentation are welcome and appreciated. To
-build the docs locally, first set up a virtual environment and activate it,
-using Python 3.6 as the Python version in the virtual environment. Example:
+To build the docs locally using ``tox``, activate your virtual
+environment, then run:
 
 .. code-block:: console
 
-  mkvirtualenv -p /usr/bin/python3.6 twine
-
-Then install ``tox`` and build the docs using ``tox``:
-
-.. code-block:: console
-
-  pip install tox
   tox -e docs
 
 The HTML of the docs will be visible in this directory: ``twine/docs/_build/``.
@@ -65,18 +67,26 @@ pull request. To run the linter from the root directory:
 
     doc8 docs
 
+
+Testing
+^^^^^^^
+
+Tests with twine are run using `tox`_, and tested against the following Python
+versions: 2.7, 3.4, 3,5, and 3.6. To run these tests locally, you will need to
+have these versions of Python installed on your machine.
+
+Either use ``tox`` to build against all supported Python versions (if
+you have them installed) or use ``tox -e py{version}`` to test against
+a specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
+
+Also, always run ``tox -e pep8`` before submitting a pull request.
+
 Submitting changes
 ^^^^^^^^^^^^^^^^^^
 
 1. Fork `the GitHub repository`_.
 2. Make a branch off of ``master`` and commit your changes to it.
-3. Run the tests with ``tox``.
-
-   - Either use ``tox`` to build against all supported Python versions (if you
-     have them installed) or use ``tox -e py{version}`` to test against a
-     specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
-   - Always run ``tox -e pep8``.
-
+3. Run the tests with ``tox`` and lint any docs changes with ``doc8``.
 4. Ensure that your name is added to the end of the AUTHORS file using the
    format ``Name <email@domain.com> (url)``, where the ``(url)`` portion is
    optional.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. twine documentation master file, created by
+.. twine documentation master file, originally created by
    sphinx-quickstart on Tue Aug 13 11:51:54 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -6,123 +6,20 @@
 Welcome to twine's documentation!
 =================================
 
-Twine is `a utility`_ for interacting with PyPI.
+.. contents:: Table of Contents
+   :local:
 
-Currently it only supports registering `projects`_ and uploading
-`distributions`_.
-
-The goal of ``twine`` is to improve PyPI interaction by improving
-security and testability. In the future, ``pip`` and ``twine`` may
-merge into a single tool; see `discussion
-<https://github.com/pypa/packaging-problems/issues/60>`_ for ongoing
-discussion.
-
-Please see `the GitHub repository`_ for code and more documentation,
-and the `Python Packaging User Guide`_ for user documentation. You can
-also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the `pypa-dev
-mailing list`_, to ask questions or get involved.
-
-Overview
---------
-
-Twine is a command-line tool for interacting with PyPI securely over HTTPS. Its
-command line arguments are parsed in ``twine/cli.py``. Currently, twine
-has two principal functions: uploading new packages and registering new
-`projects`_. The code for registering new projects is in
-``twine/commands/register.py``, and the code for uploading is in
-``twine/commands/upload.py``. The file ``twine/package.py``
-contains a single class, ``PackageFile``, which hashes the project files and
-extracts their metadata. The file ``twine/repository.py`` contains the
-``Repository`` class, whose methods control the URL the package is uploaded to
-(which the user can specify either as a default, in the ``.pypirc`` file, or
-pass on the command line), and the methods that upload the package securely to
-a URL.
-
-Contents:
+Twine user documentation
+------------------------
+.. include:: ../README.rst
+  :start-after: rtd-inclusion-marker-do-not-remove
 
 .. toctree::
-   :maxdepth: 2
+   :caption: Further documentation
+   :maxdepth: 3
 
+   contributing
    changelog
+   Python Packaging User Guide <https://packaging.python.org/tutorials/distributing-packages/>
 
-Getting Started
----------------
-
-We are happy you have decided to contribute to twine.
-
-It is important to keep your development environment isolated, so that twine
-and its dependencies do not interfere with packages already installed on your
-machine.  We will use a virtual environment for the development environment for
-twine. You can use `virtualenv`_ or `pipenv`_ to isolate your development
-environment.
-
-Clone the twine repository from GitHub, and then activate your virtual
-environment. Then, run the following command:
-
-.. code-block:: console
-
-  pip install -e /path/to/your/local/twine
-
-Now, in your virtual environment, ``twine`` is pointing at your local copy, so
-when you have made changes, you can easily see their effect.
-
-Testing
--------
-
-Tests with twine are run using `tox`_, and tested against the following Python
-versions: 2.7, 3.4, 3,5, and 3.6. To run these tests locally, you will need to
-have these versions of Python installed on your machine.
-
-If you are using ``pipenv`` to manage your virtual environment, you
-may need the `tox-pipenv`_ plugin so that tox can use pipenv
-environments instead of virtualenvs.
-
-Building the documentation
---------------------------
-
-Additions and edits to twine's documentation are welcome and appreciated. To
-build the docs locally, first set up a virtual environment and activate it,
-using Python 3.6 as the Python version in the virtual environment. Example:
-
-.. code-block:: console
-
-  mkvirtualenv -p /usr/bin/python3.6 twine
-
-Then install ``tox`` and build the docs using ``tox``:
-
-.. code-block:: console
-
-  pip install tox
-  tox -e docs
-
-The HTML of the docs will be visible in this directory: ``twine/docs/_build/``.
-
-When you have made your changes to the docs, please lint them before making a
-pull request. To run the linter from the root directory:
-
-.. code-block:: console
-
-    doc8 docs
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
-
-.. _`a utility`: https://pypi.python.org/pypi/twine
-.. _`projects`: https://packaging.python.org/glossary/#term-project
-.. _`distributions`: https://packaging.python.org/glossary/#term-distribution-package
-.. _`Warehouse`: https://github.com/pypa/warehouse
-.. _`the GitHub repository`: https://github.com/pypa/twine
-.. _`Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
-.. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
-.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
-.. _`main twine repository`: https://github.com/pypa/twine
-.. _`virtualenv`: https://virtualenv.pypa.io/en/stable/installation/
-.. _`pipenv`: https://pipenv.readthedocs.io/en/latest/
-.. _`tox`: https://tox.readthedocs.io/en/latest/
-.. _`tox-pipenv`: https://pypi.python.org/pypi/tox-pipenv
-.. _`plugin`: https://github.com/bitprophet/releases


### PR DESCRIPTION
* Deduplicate user documentation by putting more of it in `README.rst` and transcluding the README into the Read the Docs site index
* split the contributor docs out into `contributing.rst`
* add warning box about ``register`` command 
* improve styling and linking throughout

You can see the proposed RtD change at my test site: https://my-fork-of-twine.readthedocs.io 