### PR TITLE
Update changelog and bump version for new release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,8 @@ extensions = [
 releases_issue_uri = "https://github.com/pypa/twine/issues/%s"
 releases_release_uri = "https://github.com/pypa/twine/tree/%s"
 
+releases_debug = False  # Change to True to see debug output
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "twine"
-copyright = "2013, Donald Stufft and individual contributors"
+copyright = "2018, Donald Stufft and individual contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft
+# Copyright 2018 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft
+# Copyright 2018 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ __all__ = (
 )
 
 __title__ = "twine"
-__summary__ = "Collection of utilities for interacting with PyPI"
-__uri__ = "https://github.com/pypa/twine"
+__summary__ = "Collection of utilities for publishing packages on PyPI"
+__uri__ = "http://twine.readthedocs.io/"
 
-__version__ = "1.9.1"
+__version__ = "1.10.0rc1"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"
 
 __license__ = "Apache License, Version 2.0"
-__copyright__ = "Copyright 2013 Donald Stufft"
+__copyright__ = "Copyright 2018 Donald Stufft and individual contributors"


### PR DESCRIPTION
As a new maintainer of twine, here's what I believe I have to do in order to make a new release of twine. Please correct me if I'm wrong and tell me if I'm right.

- [x] get maintainership of the repo on GitHub
- [x] update `docs/changelog.rst` with the newest changes (done in #308) and the new release (done in this PR)
- [x] update the `__version__` string in `twine/__init__.py`
- [x] run `python setup.py check -r -s` to check that the `long_description` and other metadata will render fine
- [x] run `tox -e py{27,34,25,36}` and `tox -e pep8` to check tests haven't broken (I did this with all but Python 3.4, which I don't have installed yet)
- [ ] create a git tag for 1.10.0 per Ian's https://github.com/pypa/twine/pull/306#issuecomment-369707788
- [ ] create distributions with `python setup.py sdist bdist_wheel`
- [x] get maintainership on [our Test PyPI project](https://test.pypi.org/project/twine/) and set my username/password with `keyring` (**need privileges**, username `brainwane`)
- [ ] upload to Test PyPI: `twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*`
- [ ] verify that everything looks good, downloads ok, etc.
- [x] get maintainership on [our PyPI project](https://pypi.org/project/twine/) and set my username/password with `keyring` (**need privileges**, username `brainwane`)
- [ ] On a Monday or Tuesday, release to canon PyPI with: ``twine upload --skip-existing dist/*`` (to someday in the future be superseded by `tox -e release`)
- [ ] send an announcement email to [`pypa-announce`](https://groups.google.com/forum/#!forum/pypa-announce) (need to subscribe and then **get posting privileges**)