### PR TITLE
Update changelog and bump version for 1.10.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :release:`1.10.0 <2018-03-07>`
+* :bug:`315 major` Degrade gracefully when keyring is unavailable
 * :feature:`304` Reorganize & improve user & developer documentation.
 * :feature:`46` Link to changelog from ``README``
 * :feature:`295` Add doc building instructions

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,11 @@ setup(
     long_description=open("README.rst").read(),
     license=twine.__license__,
     url=twine.__uri__,
+    project_urls={
+        'Packaging tutorial': 'https://packaging.python.org/tutorials/distributing-packages/',
+        'Twine documentation': 'https://twine.readthedocs.io/en/latest/',
+        'Twine source': 'https://github.com/pypa/twine/',
+    },
 
     author=twine.__author__,
     author_email=twine.__email__,

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -22,7 +22,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for publishing packages on PyPI"
 __uri__ = "http://twine.readthedocs.io/"
 
-__version__ = "1.10.0rc1"
+__version__ = "1.10.0"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
* Remove trove classifier for Python 3.2, followup for c1113da3d3ff0d1b248d80514568564a801f81ff
* Add project URLs to `setup.py` per https://packaging.python.org/tutorials/distributing-packages/#project-urls
* Bump version, add changelog items