### PR TITLE
Update PyPI URLs and simplify contributor instructions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :support:`318` `Update PyPI URLs
+  <https://packaging.python.org/guides/migrating-to-pypi-org/>`_.
 * :release:`1.10.0 <2018-03-07>`
 * :bug:`315 major` Degrade gracefully when keyring is unavailable
 * :feature:`304` Reorganize & improve user & developer documentation.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,14 +12,14 @@ Getting started
 ---------------
 
 We recommend you use a development environment. Using a ``virtualenv``
-keeps your development environment isolated, so that ``twine`` and its
-dependencies do not interfere with packages already installed on your
+keeps your development environment isolated, so ``twine`` and its
+dependencies do not interfere with other packages installed on your
 machine.  You can use `virtualenv`_ or `pipenv`_ to isolate your
 development environment.
 
-Clone the twine repository from GitHub, and then make and activate
-your virtual environment, using Python 3.6 as the Python version in
-the virtual environment. Example:
+Clone the twine repository from GitHub, and then make and activate a
+virtual environment that uses Python 3.6 as the default
+Python. Example:
 
 .. code-block:: console
 
@@ -32,7 +32,7 @@ Then, run the following command:
   pip install -e /path/to/your/local/twine
 
 Now, in your virtual environment, ``twine`` is pointing at your local copy, so
-when you have made changes, you can easily see their effect.
+when you make changes, you can easily see their effect.
 
 Building the documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ Submitting changes
 4. Ensure that your name is added to the end of the :file:`AUTHORS`
    file using the format ``Name <email@domain.com> (url)``, where the
    ``(url)`` portion is optional.
-5. Submit a Pull Request to the ``master`` branch on GitHub.
+5. Submit a pull request to the ``master`` branch on GitHub.
 
 
 Architectural overview

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -51,21 +51,15 @@ If you are using ``pipenv`` to manage your virtual environment, you
 may need the `tox-pipenv`_ plugin so that tox can use pipenv
 environments instead of virtualenvs.
 
-To build the docs locally using ``tox``, activate your virtual
-environment, then run:
+After making docs changes, lint and build the docs locally, using
+``tox``, before making a pull request. Activate your virtual
+environment, then, in the root directory, run:
 
 .. code-block:: console
 
   tox -e docs
 
 The HTML of the docs will be visible in :file:`twine/docs/_build/`.
-
-When you have made your changes to the docs, please lint them before making a
-pull request. To run the linter from the root directory:
-
-.. code-block:: console
-
-    doc8 docs
 
 
 Testing
@@ -86,7 +80,7 @@ Submitting changes
 
 1. Fork `the GitHub repository`_.
 2. Make a branch off of ``master`` and commit your changes to it.
-3. Run the tests with ``tox`` and lint any docs changes with ``doc8``.
+3. Run the tests with ``tox`` and lint any docs changes with ``tox -e docs``.
 4. Ensure that your name is added to the end of the :file:`AUTHORS`
    file using the format ``Name <email@domain.com> (url)``, where the
    ``(url)`` portion is optional.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -120,7 +120,7 @@ merge into a single tool; see `ongoing discussion
 .. _`virtualenv`: https://virtualenv.pypa.io/en/stable/installation/
 .. _`pipenv`: https://pipenv.readthedocs.io/en/latest/
 .. _`tox`: https://tox.readthedocs.io/en/latest/
-.. _`tox-pipenv`: https://pypi.python.org/pypi/tox-pipenv
+.. _`tox-pipenv`: https://pypi.org/project/tox-pipenv
 .. _`plugin`: https://github.com/bitprophet/releases
 .. _`projects`: https://packaging.python.org/glossary/#term-project
 .. _`open issues`: https://github.com/pypa/twine/issues

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -14,6 +14,7 @@
 import requests
 
 from twine import repository
+from twine.utils import DEFAULT_REPOSITORY
 
 import pretend
 
@@ -55,7 +56,7 @@ def test_iterables_are_flattened():
 
 def test_set_client_certificate():
     repo = repository.Repository(
-        repository_url='https://pypi.python.org/pypi',
+        repository_url=DEFAULT_REPOSITORY,
         username='username',
         password='password',
     )
@@ -68,7 +69,7 @@ def test_set_client_certificate():
 
 def test_set_certificate_authority():
     repo = repository.Repository(
-        repository_url='https://pypi.python.org/pypi',
+        repository_url=DEFAULT_REPOSITORY,
         username='username',
         password='password',
     )
@@ -81,7 +82,7 @@ def test_set_certificate_authority():
 
 def test_make_user_agent_string():
     repo = repository.Repository(
-        repository_url='https://pypi.python.org/pypi',
+        repository_url=DEFAULT_REPOSITORY,
         username='username',
         password='password',
     )
@@ -107,7 +108,7 @@ def response_with(**kwattrs):
 
 def test_package_is_uploaded_404s():
     repo = repository.Repository(
-        repository_url='https://pypi.python.org/pypi',
+        repository_url=DEFAULT_REPOSITORY,
         username='username',
         password='password',
     )
@@ -124,7 +125,7 @@ def test_package_is_uploaded_404s():
 
 def test_package_is_uploaded_200s_with_no_releases():
     repo = repository.Repository(
-        repository_url='https://pypi.python.org/pypi',
+        repository_url=DEFAULT_REPOSITORY,
         username='username',
         password='password',
     )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -108,7 +108,8 @@ def test_skip_existing_skips_files_already_on_PyPI(monkeypatch):
 
 
 def test_skip_existing_skips_files_already_on_pypiserver(monkeypatch):
-    # pypiserver (https://pypi.python.org/pypi/pypiserver) responds with 409
+    # pypiserver (http://pypi.org/project/pypiserver) responds with a
+    # 409 when the file already exists.
     response = pretend.stub(
         status_code=409,
         reason='A file named "twine-1.5.0-py2.py3-none-any.whl" already '

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps = -rdocs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
+    doc8 docs
     sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
 
 [testenv:release]


### PR DESCRIPTION
[Migrating to the new PyPI](https://packaging.python.org/guides/migrating-to-pypi-org/) means trying to point to pypi.org URLs whenever reasonable.

I also simplified some contributor instructions along the way.