### PR TITLE
better "register" guidance and pypi.org migration advice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,13 +63,19 @@ Usage
 
        $ python setup.py sdist bdist_wheel
 
-2. Upload with ``twine``:
+2. Upload with ``twine`` to `Test PyPI`_ and verify things look right:
+
+   .. code-block:: console
+
+       $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+3. Upload to `PyPI`_:
 
    .. code-block:: console
 
        $ twine upload dist/*
 
-3. Done!
+4. Done!
 
 More documentation on using ``twine`` to upload packages to PyPI is in
 the `Python Packaging User Guide`_.
@@ -230,6 +236,7 @@ trackers, chat rooms, and mailing lists is expected to follow the
 .. _`a utility`: https://pypi.org/project/twine/
 .. _`publishing`: https://packaging.python.org/tutorials/distributing-packages/
 .. _`PyPI`: https://pypi.org
+.. _`Test PyPI`: https://packaging.python.org/guides/using-testpypi/
 .. _`Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
 .. _`documentation`: http://twine.readthedocs.io/
 .. _`developer documentation`: https://twine.readthedocs.io/en/latest/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,14 @@ Why Should I Use This?
 The goal of ``twine`` is to improve PyPI interaction by improving
 security and testability.
 
-The biggest reason to use ``twine`` is that it securely authenticates you to PyPI
-over HTTPS using a verified connection, while ``python setup.py upload`` `only
-recently stopped using HTTP <https://bugs.python.org/issue12226>`_ in Python
-2.7.9+ and Python 3.2+. This means anytime you use ``python setup.py upload``
-with an older Python version, you expose your username and password to being
-easily sniffed. Twine uses only verified TLS to upload to PyPI, protecting your
-credentials from theft.
+The biggest reason to use ``twine`` is that it securely authenticates
+you to `PyPI`_ over HTTPS using a verified connection, while ``python
+setup.py upload`` `only recently stopped using HTTP
+<https://bugs.python.org/issue12226>`_ in Python 2.7.9+ and Python
+3.2+. This means anytime you use ``python setup.py upload`` with an
+older Python version, you expose your username and password to being
+easily sniffed. Twine uses only verified TLS to upload to PyPI,
+protecting your credentials from theft.
 
 Secondly, it allows you to precreate your distribution files.
 ``python setup.py upload`` only allows you to upload something that you've
@@ -28,12 +29,12 @@ created in the same command invocation. This means that you cannot test the
 exact file you're going to upload to PyPI to ensure that it works before
 uploading it.
 
-Finally, it allows you to pre-sign your files and pass the ``.asc``
-files into the command line invocation (``twine upload
-twine-1.0.1.tar.gz twine-1.0.1.tar.gz.asc``). This enables you to be
-assured that you're typing your ``gpg`` passphrase into ``gpg`` itself
-and not anything else, since *you* will be the one directly executing
-``gpg --detach-sign -a <filename>``.
+Finally, ``twine`` allows you to pre-sign your files and pass the
+``.asc`` files into the command line invocation (``twine upload
+myproject-1.0.1.tar.gz myproject-1.0.1.tar.gz.asc``). This enables you
+to be assured that you're typing your ``gpg`` passphrase into ``gpg``
+itself and not anything else, since *you* will be the one directly
+executing ``gpg --detach-sign -a <filename>``.
 
 
 Features
@@ -43,7 +44,7 @@ Features
 - Uploading doesn't require executing ``setup.py``
 - Uploading files that have already been created, allowing testing of
   distributions before release
-- Supports uploading any packaging format (including wheels)
+- Supports uploading any packaging format (including `wheels`_)
 
 
 Installation
@@ -95,48 +96,47 @@ Options
                         dist [dist ...]
 
     positional arguments:
-      dist                  The distribution files to upload to the repository,
-                            may additionally contain a .asc file to include an
-                            existing signature with the file upload
+      dist                  The distribution files to upload to the repository
+                            (package index). Usually dist/* . May additionally
+                            contain a .asc file to include an existing signature
+                            with the file upload.
 
     optional arguments:
       -h, --help            show this help message and exit
       -r REPOSITORY, --repository REPOSITORY
-                            The repository to upload the package to. Can be a
-                            section in the config file or a full URL to the
-                            repository (default: pypi). (Can also be set via
-                            TWINE_REPOSITORY environment variable)
+                            The repository (package index) to upload the package
+                            to. Should be a section in the config file (default:
+                            pypi). (Can also be set via TWINE_REPOSITORY
+                            environment variable.)
       --repository-url REPOSITORY_URL
-                            The repository URL to upload the package to. This can
-                            be specified with --repository because it will be used
-                            if there is no configuration for the value passed to
-                            --repository. (Can also be set via
-                            TWINE_REPOSITORY_URL environment variable.)
-      -s, --sign            Sign files to upload using gpg
+                            The repository (package index) URL to upload the
+                            package to. This overrides --repository. (Can also be
+                            set via TWINE_REPOSITORY_URL environment variable.)
+      -s, --sign            Sign files to upload using GPG.
       --sign-with SIGN_WITH
-                            GPG program used to sign uploads (default: gpg)
+                            GPG program used to sign uploads (default: gpg).
       -i IDENTITY, --identity IDENTITY
-                            GPG identity used to sign files
+                            GPG identity used to sign files.
       -u USERNAME, --username USERNAME
-                            The username to authenticate to the repository as (can
-                            also be set via TWINE_USERNAME environment variable)
+                            The username to authenticate to the repository
+                            (package index) as. (Can also be set via
+                            TWINE_USERNAME environment variable.)
       -p PASSWORD, --password PASSWORD
-                            The password to authenticate to the repository with
-                            (can also be set via TWINE_PASSWORD environment
-                            variable)
+                            The password to authenticate to the repository
+                            (package index) with. (Can also be set via
+                            TWINE_PASSWORD environment variable.)
       -c COMMENT, --comment COMMENT
-                            The comment to include with the distribution file
+                            The comment to include with the distribution file.
       --config-file CONFIG_FILE
-                            The .pypirc config file to use
+                            The .pypirc config file to use.
       --skip-existing       Continue uploading files if one already exists. (Only
                             valid when uploading to PyPI. Other implementations
                             may not support this.)
       --cert path           Path to alternate CA bundle (can also be set via
-                            TWINE_CERT environment variable)
+                            TWINE_CERT environment variable).
       --client-cert path    Path to SSL client certificate, a single file
                             containing the private key and the certificate in PEM
-                            format
-
+                            format.
 
 Twine also includes a ``register`` command.
 
@@ -154,45 +154,47 @@ For completeness, its usage:
 .. code-block:: console
 
     $ twine register -h
-    usage: twine register [-h] [-r REPOSITORY] [--repository-url REPOSITORY_URL]
+
+    usage: twine register [-h] -r REPOSITORY [--repository-url REPOSITORY_URL]
                           [-u USERNAME] [-p PASSWORD] [-c COMMENT]
                           [--config-file CONFIG_FILE] [--cert path]
                           [--client-cert path]
                           package
 
     positional arguments:
-      package               File from which we read the package metadata
+      package               File from which we read the package metadata.
 
     optional arguments:
       -h, --help            show this help message and exit
       -r REPOSITORY, --repository REPOSITORY
-                            The repository to register the package to. Can be a
-                            section in the config file or a full URL to the
-                            repository (default: pypi). (Can also be set via
-                            TWINE_REPOSITORY environment variable)
+                            The repository (package index) to register the package
+                            to. Should be a section in the config file. (Can also
+                            be set via TWINE_REPOSITORY environment variable.)
+                            Initial package registration no longer necessary on
+                            pypi.org:
+                            https://packaging.python.org/guides/migrating-to-pypi-
+                            org/
       --repository-url REPOSITORY_URL
-                            The repository URL to upload the package to. This can
-                            be specified with --repository because it will be used
-                            if there is no configuration for the value passed to
-                            --repository. (Can also be set via
-                            TWINE_REPOSITORY_URL environment variable.)
+                            The repository (package index) URL to register the
+                            package to. This overrides --repository. (Can also be
+                            set via TWINE_REPOSITORY_URL environment variable.)
       -u USERNAME, --username USERNAME
-                            The username to authenticate to the repository as (can
-                            also be set via TWINE_USERNAME environment variable)
+                            The username to authenticate to the repository
+                            (package index) as. (Can also be set via
+                            TWINE_USERNAME environment variable.)
       -p PASSWORD, --password PASSWORD
-                            The password to authenticate to the repository with
-                            (can also be set via TWINE_PASSWORD environment
-                            variable)
+                            The password to authenticate to the repository
+                            (package index) with. (Can also be set via
+                            TWINE_PASSWORD environment variable.)
       -c COMMENT, --comment COMMENT
-                            The comment to include with the distribution file
+                            The comment to include with the distribution file.
       --config-file CONFIG_FILE
-                            The .pypirc config file to use
+                            The .pypirc config file to use.
       --cert path           Path to alternate CA bundle (can also be set via
-                            TWINE_CERT environment variable)
+                            TWINE_CERT environment variable).
       --client-cert path    Path to SSL client certificate, a single file
                             containing the private key and the certificate in PEM
-                            format
-
+                            format.
 
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
@@ -238,9 +240,10 @@ trackers, chat rooms, and mailing lists is expected to follow the
 .. _`PyPI`: https://pypi.org
 .. _`Test PyPI`: https://packaging.python.org/guides/using-testpypi/
 .. _`Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
-.. _`documentation`: http://twine.readthedocs.io/
+.. _`documentation`: https://twine.readthedocs.io/
 .. _`developer documentation`: https://twine.readthedocs.io/en/latest/contributing.html
 .. _`projects`: https://packaging.python.org/glossary/#term-project
 .. _`distributions`: https://packaging.python.org/glossary/#term-distribution-package
 .. _`PyPA Code of Conduct`: https://www.pypa.io/en/latest/code-of-conduct/
 .. _`Warehouse`: https://github.com/pypa/warehouse
+.. _`wheels`: https://packaging.python.org/glossary/#term-wheel

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@
 Changelog
 =========
 
-* :feature:`319` Support Metadata 2.1 (`PEP 566
-  <https://www.python.org/dev/peps/pep-0566/>`_).
+* :feature:`320` Remove PyPI as default ``register`` package index.
+* :feature:`319` Support Metadata 2.1 (:pep:`566`), including Markdown
+  for ``description`` fields.
 * :support:`318` `Update PyPI URLs
   <https://packaging.python.org/guides/migrating-to-pypi-org/>`_.
 * :release:`1.10.0 <2018-03-07>`

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -69,11 +69,12 @@ def main(args):
         "-r", "--repository",
         action=utils.EnvironmentDefault,
         env="TWINE_REPOSITORY",
-        default="pypi",
-        help="The repository to register the package to. "
-             "Should be a section in the config file (default: "
-             "%(default)s). (Can also be set via %(env)s environment "
-             "variable)",
+        default=None,
+        help="The repository (package index) to register the package to. "
+             "Should be a section in the config file. (Can also be set "
+             "via %(env)s environment variable.) "
+             "Initial package registration no longer necessary on pypi.org: "
+             "https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata",
     )
     parser.add_argument(
         "--repository-url",

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -74,7 +74,7 @@ def main(args):
              "Should be a section in the config file. (Can also be set "
              "via %(env)s environment variable.) "
              "Initial package registration no longer necessary on pypi.org: "
-             "https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata",
+             "https://packaging.python.org/guides/migrating-to-pypi-org/",
     )
     parser.add_argument(
         "--repository-url",
@@ -82,8 +82,8 @@ def main(args):
         env="TWINE_REPOSITORY_URL",
         default=None,
         required=False,
-        help="The repository URL to register the package to. "
-             "This overrides --repository."
+        help="The repository (package index) URL to register the package to. "
+             "This overrides --repository. "
              "(Can also be set via %(env)s environment variable.)"
     )
     parser.add_argument(
@@ -91,25 +91,25 @@ def main(args):
         action=utils.EnvironmentDefault,
         env="TWINE_USERNAME",
         required=False, help="The username to authenticate to the repository "
-                             "as (can also be set via %(env)s environment "
-                             "variable)",
+                             "(package index) as. (Can also be set via "
+                             "%(env)s environment variable.)",
     )
     parser.add_argument(
         "-p", "--password",
         action=utils.EnvironmentDefault,
         env="TWINE_PASSWORD",
         required=False, help="The password to authenticate to the repository "
-                             "with (can also be set via %(env)s environment "
-                             "variable)",
+                             "(package index) with. (Can also be set via "
+                             "%(env)s environment variable.)",
     )
     parser.add_argument(
         "-c", "--comment",
-        help="The comment to include with the distribution file",
+        help="The comment to include with the distribution file.",
     )
     parser.add_argument(
         "--config-file",
         default="~/.pypirc",
-        help="The .pypirc config file to use",
+        help="The .pypirc config file to use.",
     )
     parser.add_argument(
         "--cert",
@@ -119,18 +119,18 @@ def main(args):
         required=False,
         metavar="path",
         help="Path to alternate CA bundle (can also be set via %(env)s "
-             "environment variable)",
+             "environment variable).",
     )
     parser.add_argument(
         "--client-cert",
         metavar="path",
         help="Path to SSL client certificate, a single file containing the "
-             "private key and the certificate in PEM format",
+             "private key and the certificate in PEM format.",
     )
     parser.add_argument(
         "package",
         metavar="package",
-        help="File from which we read the package metadata",
+        help="File from which we read the package metadata.",
     )
 
     args = parser.parse_args(args)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -165,10 +165,10 @@ def main(args):
         action=utils.EnvironmentDefault,
         env="TWINE_REPOSITORY",
         default="pypi",
-        help="The repository to upload the package to. "
+        help="The repository (package index) to upload the package to. "
              "Should be a section in the config file (default: "
              "%(default)s). (Can also be set via %(env)s environment "
-             "variable)",
+             "variable.)",
     )
     parser.add_argument(
         "--repository-url",
@@ -176,49 +176,49 @@ def main(args):
         env="TWINE_REPOSITORY_URL",
         default=None,
         required=False,
-        help="The repository URL to upload the package to. "
-             "This overrides --repository."
+        help="The repository (package index) URL to upload the package to. "
+             "This overrides --repository. "
              "(Can also be set via %(env)s environment variable.)"
     )
     parser.add_argument(
         "-s", "--sign",
         action="store_true",
         default=False,
-        help="Sign files to upload using gpg",
+        help="Sign files to upload using GPG.",
     )
     parser.add_argument(
         "--sign-with",
         default="gpg",
-        help="GPG program used to sign uploads (default: %(default)s)",
+        help="GPG program used to sign uploads (default: %(default)s).",
     )
     parser.add_argument(
         "-i", "--identity",
-        help="GPG identity used to sign files",
+        help="GPG identity used to sign files.",
     )
     parser.add_argument(
         "-u", "--username",
         action=utils.EnvironmentDefault,
         env="TWINE_USERNAME",
         required=False, help="The username to authenticate to the repository "
-                             "as (can also be set via %(env)s environment "
-                             "variable)",
+                             "(package index) as. (Can also be set via "
+                             "%(env)s environment variable.)",
     )
     parser.add_argument(
         "-p", "--password",
         action=utils.EnvironmentDefault,
         env="TWINE_PASSWORD",
         required=False, help="The password to authenticate to the repository "
-                             "with (can also be set via %(env)s environment "
-                             "variable)",
+                             "(package index) with. (Can also be set via "
+                             "%(env)s environment variable.)",
     )
     parser.add_argument(
         "-c", "--comment",
-        help="The comment to include with the distribution file",
+        help="The comment to include with the distribution file.",
     )
     parser.add_argument(
         "--config-file",
         default="~/.pypirc",
-        help="The .pypirc config file to use",
+        help="The .pypirc config file to use.",
     )
     parser.add_argument(
         "--skip-existing",
@@ -236,21 +236,22 @@ def main(args):
         required=False,
         metavar="path",
         help="Path to alternate CA bundle (can also be set via %(env)s "
-             "environment variable)",
+             "environment variable).",
     )
     parser.add_argument(
         "--client-cert",
         metavar="path",
         help="Path to SSL client certificate, a single file containing the "
-             "private key and the certificate in PEM format",
+             "private key and the certificate in PEM format.",
     )
     parser.add_argument(
         "dists",
         nargs="+",
         metavar="dist",
-        help="The distribution files to upload to the repository, may "
-             "additionally contain a .asc file to include an existing "
-             "signature with the file upload",
+        help="The distribution files to upload to the repository "
+             "(package index). Usually dist/* . May additionally contain "
+             "a .asc file to include an existing signature with the "
+             "file upload.",
     )
 
     args = parser.parse_args(args)

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -143,11 +143,14 @@ def check_status_code(response):
     if (response.status_code == 500 and
             response.url.startswith(("https://pypi.python.org",
                                      "https://testpypi.python.org"))):
-        print("It appears you're uploading to pypi.python.org (or testpypi) "
-              "you've received a 500 error response. PyPI is being phased "
-              "out for pypi.org. Try using https://upload.pypi.org/legacy/ "
+        print("It appears you're uploading to pypi.python.org (or "
+              "testpypi.python.org). You've received a 500 error response. "
+              "Uploading to those sites is deprecated. The new sites are "
+              "pypi.org and test.pypi.org. Try using "
+              "https://upload.pypi.org/legacy/ "
               "(or https://test.pypi.org/legacy/) to upload your packages "
-              "instead. These are the default URLs for Twine now.")
+              "instead. These are the default URLs for Twine now. More at "
+              "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
     response.raise_for_status()
 
 


### PR DESCRIPTION
Address part of #11 and #311 by removing the pypi.org default for `register`, and improving command-line usage for `register`. Also improve style and provide better guidance in the `README` and in other usage help for `register` and `upload`, including suggesting users use Test PyPI before uploading distributions to pypi.org.

Once we get the usage wording down I'll also update the `README` in this PR to reflect the new usage text for `upload` and `register`.

Key line to review: https://github.com/pypa/twine/compare/pypi-migration-register?expand=1#diff-2190788b5d7d5b86131d0daf63dac4d1R72 in which I remove the default of `pypi` for the `register` command.