### PR TITLE
Release 1.11.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,9 +4,11 @@
 Changelog
 =========
 
+* :release:`1.11.0 <2018-03-19>`
 * :bug:`269 major` Avoid uploading to PyPI when given alternate
   repository URL, and require ``http://`` or ``https://`` in
   ``repository_url``.
+* :support:`277` Add instructions on how to use keyring.
 * :support:`314` Add new maintainer, release checklists.
 * :bug:`322 major` Raise exception if attempting upload to deprecated legacy
   PyPI URLs.

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -22,7 +22,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for publishing packages on PyPI"
 __uri__ = "https://twine.readthedocs.io/"
 
-__version__ = "1.11.0rc1"
+__version__ = "1.11.0"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -22,7 +22,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for publishing packages on PyPI"
 __uri__ = "https://twine.readthedocs.io/"
 
-__version__ = "1.10.0"
+__version__ = "1.11.0rc1"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
I'm preparing to release version 1.11.0 at the moment.

I have [a tag up](https://github.com/pypa/twine/releases/tag/1.11.0rc1) for it. I've put 1.11.0rc1 up on [Test PyPI](https://test.pypi.org/project/twine/1.11.0rc1/) and, after testing, on [PyPI](https://pypi.org/project/twine/1.11.0rc1/). I've done approximately all the testing folks recommended in #314.

I'm waiting till Monday or Tuesday to put out a full release, but @di I figured this'd be good enough for you to test with as you work on https://github.com/pypa/warehouse/issues/869#issuecomment-340928703 .