### PR TITLE
 Raise exception if attempting upload to deprecated legacy PyPI URLs 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :bug:`322 major` Raise exception if attempting upload to deprecated legacy
+  PyPI URLs.
 * :feature:`320` Remove PyPI as default ``register`` package index.
 * :feature:`319` Support Metadata 2.1 (:pep:`566`), including Markdown
   for ``description`` fields.

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -21,7 +21,7 @@ import sys
 
 import twine.exceptions as exc
 from twine.package import PackageFile
-from twine.repository import Repository, LEGACY_PYPI
+from twine.repository import Repository, LEGACY_PYPI, LEGACY_TEST_PYPI
 from twine import utils
 
 
@@ -98,11 +98,20 @@ def upload(dists, repository, sign, identity, username, password, comment,
 
     print("Uploading distributions to {0}".format(config["repository"]))
 
-    if config["repository"].startswith(LEGACY_PYPI):
-        print(
-            "Note: you are uploading to the old upload URL. It's recommended "
-            "to use the new URL \"{0}\" or to leave the URL unspecified and "
-            "allow twine to choose.".format(utils.DEFAULT_REPOSITORY))
+    if config["repository"].startswith((LEGACY_PYPI, LEGACY_TEST_PYPI)):
+        raise exc.UploadToDeprecatedPyPIDetected(
+            "You're trying to upload to the legacy PyPI site '{0}'. "
+            "Uploading to those sites is deprecated. \n "
+            "The new sites are pypi.org and test.pypi.org. Try using "
+            "{1} (or {2}) to upload your packages instead. "
+            "These are the default URLs for Twine now. \n More at "
+            "https://packaging.python.org/guides/migrating-to-pypi-org/ "
+            ".".format(
+                config["repository"],
+                utils.DEFAULT_REPOSITORY,
+                utils.TEST_REPOSITORY
+                )
+            )
 
     username = utils.get_username(username, config)
     password = utils.get_password(

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -30,3 +30,9 @@ class PackageNotFound(Exception):
     This is only used when attempting to register a package.
     """
     pass
+
+
+class UploadToDeprecatedPyPIDetected(Exception):
+    """An upload attempt was detected to deprecated legacy PyPI
+    sites pypi.python.org or testpypi.python.org."""
+    pass

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -31,6 +31,7 @@ import twine
 KEYWORDS_TO_NOT_FLATTEN = set(["gpg_signature", "content"])
 
 LEGACY_PYPI = 'https://pypi.python.org/'
+LEGACY_TEST_PYPI = 'https://testpypi.python.org/'
 WAREHOUSE = 'https://upload.pypi.org/'
 OLD_WAREHOUSE = 'https://upload.pypi.io/'
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -140,11 +140,15 @@ def normalize_repository_url(url):
 
 
 def check_status_code(response):
-    if (response.status_code == 500 and
+    """
+    Shouldn't happen, thanks to the UploadToDeprecatedPyPIDetected
+    exception, but this is in case that breaks and it does.
+    """
+    if (response.status_code == 410 and
             response.url.startswith(("https://pypi.python.org",
                                      "https://testpypi.python.org"))):
         print("It appears you're uploading to pypi.python.org (or "
-              "testpypi.python.org). You've received a 500 error response. "
+              "testpypi.python.org). You've received a 410 error response. "
               "Uploading to those sites is deprecated. The new sites are "
               "pypi.org and test.pypi.org. Try using "
               "https://upload.pypi.org/legacy/ "


### PR DESCRIPTION
Now that legacy (deprecated) URLs give a `410 Gone`, Twine should just watch for those URLs and give an actionable error rather than transmit the upload request.

Fixes #307.