### PR TITLE
Avoid uploading to PyPI when given alternate repository URL

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+* :bug:`269 major` Avoid uploading to PyPI when given alternate
+  repository URL, and require ``http://`` or ``https://`` in
+  ``repository_url``.
 * :support:`314` Add new maintainer, release checklists.
 * :bug:`322 major` Raise exception if attempting upload to deprecated legacy
   PyPI URLs.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,10 @@ def test_get_config(tmpdir):
 
 
 def test_get_config_no_distutils(tmpdir):
+    """
+    Even if the user hasn't set PyPI has an index server
+    in 'index-servers', default to uploading to PyPI.
+    """
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -36,3 +36,10 @@ class UploadToDeprecatedPyPIDetected(Exception):
     """An upload attempt was detected to deprecated legacy PyPI
     sites pypi.python.org or testpypi.python.org."""
     pass
+
+
+class UnreachableRepositoryURLDetected(Exception):
+    """An upload attempt was detected to a URL without a protocol prefix.
+
+    """
+    pass

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -65,6 +65,7 @@ def get_config(path="~/.pypirc"):
     parser.read(path)
 
     # Get a list of repositories from the config file
+    # format: https://docs.python.org/3/distutils/packageindex.html#pypirc
     if (parser.has_section("distutils") and
             parser.has_option("distutils", "index-servers")):
         repositories = parser.get("distutils", "index-servers").split()
@@ -110,10 +111,10 @@ def get_config(path="~/.pypirc"):
 
 
 def get_repository_from_config(config_file, repository, repository_url=None):
-    # Get our config from the .pypirc file
+    # Get our config from, if provided, command-line values for the
+    # repository name and URL, or the .pypirc file
     if repository_url and "://" in repository_url:
-        # assume that the repository is actually an URL and just sent
-        # them a dummy with the repo set
+        # prefer CLI `repository_url` over `repository` or .pypirc
         return {
             "repository": repository_url,
             "username": None,

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -32,6 +32,8 @@ try:
 except ImportError:
     from urllib.parse import urlparse, urlunparse
 
+import twine.exceptions
+
 # Shim for raw_input in python3
 if sys.version_info > (3,):
     input_func = input
@@ -66,8 +68,13 @@ def get_config(path="~/.pypirc"):
     if (parser.has_section("distutils") and
             parser.has_option("distutils", "index-servers")):
         repositories = parser.get("distutils", "index-servers").split()
+    elif parser.has_section("pypi"):
+        # Special case: if the .pypirc file has a 'pypi' section,
+        # even if there's no list of index servers,
+        # be lenient and include that in our list of repositories.
+        repositories = ['pypi']
     else:
-        repositories = ["pypi"]
+        repositories = []
 
     config = {}
 
@@ -112,6 +119,10 @@ def get_repository_from_config(config_file, repository, repository_url=None):
             "username": None,
             "password": None,
         }
+    if repository_url and "://" not in repository_url:
+        raise twine.exceptions.UnreachableRepositoryURLDetected(
+            "Repository URL {0} has no protocol. Please add 'http://' or "
+            "'https://'. \n".format(repository_url))
     try:
         return get_config(config_file)[repository]
     except KeyError:


### PR DESCRIPTION
Check for repository URL that has no protocol prefix and
raise exception, asking user for https:// or http:// URL.

Assume the user wants to upload to PyPI if there's
no conflicting repository URL given on the command line
AND there's a `pypi` section in .pypirc. Remove assumption
that a 'pypirc' section in .pypirc should override CLI argument.

Fixes #269.