### PR TITLE
Fix tests under python2 when future pkg provides builtins module

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,9 +19,9 @@ import os.path
 import textwrap
 
 try:
-    import builtins
-except ImportError:
     import __builtin__ as builtins
+except ImportError:
+    import builtins
 
 import pytest
 


### PR DESCRIPTION
When running tests under python2 on a system with the future pkg
installed, the previous try/except statement would load the builtins
module provided by future instead of properly falling back to the
python2 __builtin__ module.

To fix this, first try loading the py2 module then fallback to py3.