### PR TITLE
Print the response content when upload fails

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Andrew Watts <andrewwatts@gmail.com>
 Anna Martelli Ravenscroft <annaraven@gmail.com>
 Sumana Harihareswara <sh@changeset.nyc>
 Dustin Ingram <di@di.codes> (https://di.codes)
+Jesse Jarzynka <jesse@jessejoe.com> (http://jessejoe.com)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -83,7 +83,7 @@ def test_get_config_old_format(tmpdir):
                       username=None, password=None, comment=None,
                       cert=None, client_cert=None,
                       sign_with=None, config_file=pypirc, skip_existing=False,
-                      repository_url=None,
+                      repository_url=None, verbose=None,
                       )
     except KeyError as err:
         assert err.args[0] == (
@@ -112,7 +112,7 @@ def test_deprecated_repo(tmpdir):
                       username=None, password=None, comment=None,
                       cert=None, client_cert=None,
                       sign_with=None, config_file=pypirc, skip_existing=False,
-                      repository_url=None,
+                      repository_url=None, verbose=None,
                       )
 
         assert err.args[0] == (

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -73,7 +73,7 @@ def skip_upload(response, skip_existing, package):
 
 def upload(dists, repository, sign, identity, username, password, comment,
            sign_with, config_file, skip_existing, cert, client_cert,
-           repository_url):
+           repository_url, verbose):
     # Check that a nonsensical option wasn't given
     if not sign and identity:
         raise ValueError("sign must be given along with identity")
@@ -159,8 +159,7 @@ def upload(dists, repository, sign, identity, username, password, comment,
         if skip_upload(resp, skip_existing, package):
             print(skip_message)
             continue
-
-        utils.check_status_code(resp)
+        utils.check_status_code(resp, verbose)
 
     # Bug 28. Try to silence a ResourceWarning by clearing the connection
     # pool.
@@ -261,6 +260,11 @@ def main(args):
              "(package index). Usually dist/* . May additionally contain "
              "a .asc file to include an existing signature with the "
              "file upload.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show verbose output."
     )
 
     args = parser.parse_args(args)

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -22,6 +22,8 @@ import sys
 import argparse
 import warnings
 
+from requests.exceptions import HTTPError
+
 try:
     import configparser
 except ImportError:  # pragma: no cover
@@ -151,7 +153,7 @@ def normalize_repository_url(url):
     return urlunparse(parsed)
 
 
-def check_status_code(response):
+def check_status_code(response, verbose):
     """
     Shouldn't happen, thanks to the UploadToDeprecatedPyPIDetected
     exception, but this is in case that breaks and it does.
@@ -167,7 +169,16 @@ def check_status_code(response):
               "(or https://test.pypi.org/legacy/) to upload your packages "
               "instead. These are the default URLs for Twine now. More at "
               "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except HTTPError as err:
+        if response.text:
+            if verbose:
+                print('Content received from server:\n{}'.format(
+                    response.text))
+            else:
+                print('NOTE: Try --verbose to see response content.')
+        raise err
 
 
 def get_userpass_value(cli_value, config, key, prompt_strategy=None):


### PR DESCRIPTION
Recently we hit an issue using twine to upload to artifactory where uploads would fail with a suspicious `HTTPError: 400 Client Error: Bad Request for url`. This happened to coincide very close to SSL certificate changes, so we were debugging the certs, debugging the docker images, pretty much everything except twine itself. After many dead-ends I thought I would debug the HTTP response that twine is getting from the artifactory server where our internal PyPi repo is. This finally gave me an error message from the response that I could look into:
```python
ipdb> print(response.text)
{
  "errors" : [ {
    "status" : 400,
    "message" : "No enum constant org.jfrog.repomd.pypi.model.PypiMetadata.MetadataVersion.v2_1"
  } ]
}
```

This led me to https://www.jfrog.com/jira/browse/RTFACT-16189 which is a bug in artifactory not being able to handle packages built with newer versions of `wheel`/`setuptools`/`twine` that have metadata increased to v2.1.

Had the content from the server been in the output from twine, it would have saved so much time. It's very common for servers to reply with error messages in the content, so it seems this could help lots of debugging out there.

I'm not _positive_ this is the best place to put the change. My change catches the requests exception from `raise_for_status()`, prints the response content, and then re-raises the exception. I'm happy to change this if another approach is better.

Here is the output from twine without my change:
```
Uploading distributions to https://xxx/artifactory/api/pypi/pypi
Uploading xxx-2.3.0.post117+g0206843-py2.py3-none-any.whl
100%|███████████████████████████████████████████████████████████████████████████████████████| 810k/810k [00:00<00:00, 1.92MB/s]
HTTPError: 400 Client Error: Bad Request for url: https://xxx/artifactory/api/pypi/pypi
```

Here is the output with my change:
```
Uploading distributions to https://xxx/artifactory/api/pypi/pypi
Uploading xxx-2.3.0.post117+g0206843-py2.py3-none-any.whl
100%|███████████████████████████████████████████████████████████████████████████████████████| 810k/810k [00:00<00:00, 1.84MB/s]
Content received from server:
{
  "errors" : [ {
    "status" : 400,
    "message" : "No enum constant org.jfrog.repomd.pypi.model.PypiMetadata.MetadataVersion.v2_1"
  } ]
}
HTTPError: 400 Client Error: Bad Request for url: https://xxx/artifactory/api/pypi/pypi
```

# UPDATE
See [#issuecomment-381730323](#issuecomment-381730323) for updated changes to this PR.