### PR TITLE
Initial version of mypy.ini file

### DIFF
--- a/_stubs/twine/__main__.pyi
+++ b/_stubs/twine/__main__.pyi
@@ -1,0 +1,4 @@
+from typing import Optional
+
+
+def main() -> Optional[str]: ...

--- a/_stubs/twine/cli.pyi
+++ b/_stubs/twine/cli.pyi
@@ -1,0 +1,3 @@
+from typing import Optional, Sequence
+
+def dispatch(argv: Optional[Sequence[str]]) -> None: ...

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,7 @@
 [mypy]
+mypy_path = ./_stubs
 check_untyped_defs = True
-disallow_any_generics = True
-strict_optional = True
-no_implicit_optional = True
-scripts_are_modules = True
+ignore_missing_imports = True
 show_traceback = True
+strict_optional = True
 warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+check_untyped_defs = True
+disallow_any_generics = True
+strict_optional = True
+no_implicit_optional = True
+scripts_are_modules = True
+show_traceback = True
+warn_no_return = True


### PR DESCRIPTION
Related to #231 

This PR adds a new file named `mypy.ini` which is a configuration file of `mypy`.
This is an initial version of `mypy.ini`, as we proceed on type hinting the code we may add more rules.