### PR TITLE
Add two new optional configuration locations to consider.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Andrew Watts <andrewwatts@gmail.com>
 Anna Martelli Ravenscroft <annaraven@gmail.com>
 Sumana Harihareswara <sh@changeset.nyc>
 Dustin Ingram <di@di.codes> (https://di.codes)
+Gary Reynolds <gary.reynolds@optiver.com.au>

--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,17 @@ For completeness, its usage:
                             containing the private key and the certificate in PEM
                             format.
 
+Configuration File
+^^^^^^^^^^^^^^^^^^
+
+Twine will search for a `.pypirc` file in the following locations when it is not
+specified on the command line.
+
+1. In the twine folder of the user's configuration directory
+2. In the user's home directory
+3. In the twine folder of the system configuration directory
+
+
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ import twine
 
 
 install_requires = [
+    "appdirs >= 1.4.3",
+    "first >= 2.0.1",
     "tqdm >= 4.14",
     "pkginfo >= 1.4.2",
     "requests >= 2.5.0, != 2.15, != 2.16",

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -108,7 +108,7 @@ def main(args):
     )
     parser.add_argument(
         "--config-file",
-        default="~/.pypirc",
+        default=utils.PYPIRC,
         help="The .pypirc config file to use.",
     )
     parser.add_argument(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -226,7 +226,7 @@ def main(args):
     )
     parser.add_argument(
         "--config-file",
-        default="~/.pypirc",
+        default=utils.PYPIRC,
         help="The .pypirc config file to use.",
     )
     parser.add_argument(


### PR DESCRIPTION
While earlier Python package uploading tooling only looked only for ~/.pypirc file there is no need to stick to this convention forever.

This patch introduces a secondary user level configuration path, namespaced to this tool, and also a system-wide location that allows system administrators to provide a sensible default.

This implementation uses the appdirs project to handle the cross platform decision making for us (initial use case is to provide a Windows user experience managed across a fleet of workstations equally
to Linux development environments).

Linux precedence for jsmith:

  - `/home/jsmith/.config/twine/.pypirc`
  - `/home/jsmith/.pypirc`
  - `/etc/xdg/twine/.pypirc`

Windows precedence for jsmith:

  - `c:\Users\jsmith\AppData\Local\twine\.pypirc`
  - `c:\Users\jsmith\AppData\Roaming\twine\.pypirc`
  - `c:\Users\jsmith\.pypirc`
  - `c:\ProgramData\twine\.pypirc`

This does not attempt to teach twine to overload a lower precedence configuration with a higher one.

Refs #349.