### PR TITLE
(231) Add mypy checks to CI, change lint python to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - python: 2.7
       env: TOXENV=py27
     - python: 2.7
-      env: TOXENV=pep8
+      env: TOXENV=lint
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,5 @@ Anna Martelli Ravenscroft <annaraven@gmail.com>
 Sumana Harihareswara <sh@changeset.nyc>
 Dustin Ingram <di@di.codes> (https://di.codes)
 Jesse Jarzynka <jesse@jessejoe.com> (http://jessejoe.com)
+Frances Hocutt <frances.hocutt@gmail.com>
+Tathagata Dasgupta <tathagatadg@gmail.com>

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,7 +73,7 @@ Either use ``tox`` to build against all supported Python versions (if
 you have them installed) or use ``tox -e py{version}`` to test against
 a specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
 
-Also, always run ``tox -e pep8`` before submitting a pull request.
+Also, always run ``tox -e lint`` before submitting a pull request.
 
 Submitting changes
 ^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ A checklist for creating, testing, and distributing a new version.
 #. Run Twine tests:
 
    #. ``tox -e py{27,34,35,36,py}``
-   #. ``tox -e pep8`` for the linter
+   #. ``tox -e lint`` for the linter
    #. ``tox -e docs`` (this checks the Sphinx docs and uses
       ``readme_renderer`` to check that the ``long_description`` and other
       metadata will render fine on the PyPI description)

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ deps =
     mypy
 commands =
     flake8 twine/ tests/
-    mypy -s twine/ tests/
+    -mypy -s twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,5 @@ deps =
     flake8
     mypy
 commands =
-    flake8 twine/ tests/ docs/
+    flake8 twine/ tests/
     mypy -s twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36,docs,pep8
+envlist = lint,py27,pypy,py33,py34,py35,py36,docs
 
 [testenv]
 deps =
@@ -28,7 +28,11 @@ commands =
     python setup.py -q bdist_wheel sdist
     twine upload --skip-existing dist/*
 
-[testenv:pep8]
-basepython = python2.7
-deps = flake8
-commands = flake8 twine/ tests/ docs/
+[testenv:lint]
+basepython = python3.6
+deps =
+    flake8
+    mypy
+commands =
+    flake8 twine/ tests/ docs/
+    mypy -s twine/ tests/

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -40,7 +40,8 @@ import twine.exceptions
 if sys.version_info > (3,):
     input_func = input
 else:
-    input_func = raw_input
+    # Ignore "undefined name" for flake8/python3
+    input_func = raw_input  # noqa: F821
 
 
 DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"


### PR DESCRIPTION
* Rename the pep8 tox environment to lint and add mypy
* Use basepython 3.6 since mypy requires >= 3.4
* Update twine/utils.py so flake8/python 3.6 passes

Mypy is making the `lint` check fail right now. This is expected and we are working on that.

Paired with Tathagata Dasgupta.