### PR TITLE
Clean up MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,9 @@
 include LICENSE
 include README.rst
 include AUTHORS
+include .coveragerc
 
-recursive-include tests *.py
-recursive-include docs *.bat
-recursive-include docs *.empty
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
+recursive-include tests *.py *.whl deprecated-pypirc
+recursive-include docs *.bat *.empty *.py *.rst Makefile *.txt
+
+prune docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ recursive-include tests *.py *.whl deprecated-pypirc
 recursive-include docs *.bat *.empty *.py *.rst Makefile *.txt
 
 prune docs/_build
+prune *.yml

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,6 @@ deps =
     readme_renderer
 commands =
     flake8 twine/ tests/ docs/
-    -check-manifest -v
+    check-manifest -v --ignore *.yml
     python setup.py check -r -s
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,6 @@ deps =
     readme_renderer
 commands =
     flake8 twine/ tests/ docs/
-    check-manifest -v --ignore *.yml
+    check-manifest -v
     python setup.py check -r -s
 


### PR DESCRIPTION
Due to #358 a few issues have been flagged in MANIFEST.in so we had to disable `check-manifest` errors in `tox.ini`.