### PR TITLE
always configure pypitest/testpypi

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,6 +102,18 @@ def test_get_config_no_section(tmpdir):
     }
 
 
+def test_get_config_override_pypi_url(tmpdir):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with open(pypirc, "w") as fp:
+        fp.write(textwrap.dedent("""
+            [pypi]
+            repository = http://pypiproxy
+        """))
+
+    assert utils.get_config(pypirc)['pypi']['repository'] == 'http://pypiproxy'
+
+
 def test_get_config_missing(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,16 @@ def test_get_config_no_distutils(tmpdir):
             "username": "testuser",
             "password": "testpassword",
         },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
+        "pypitest": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
     }
 
 
@@ -111,6 +121,11 @@ def test_get_config_missing(tmpdir):
             "username": None,
             "password": None
         },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None
+        },
     }
 
 
@@ -143,8 +158,18 @@ def test_get_config_deprecated_pypirc():
     assert utils.get_config(deprecated_pypirc_path) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
-            "username": 'testusername',
-            "password": 'testpassword',
+            "username": "testusername",
+            "password": "testpassword",
+        },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": "testusername",
+            "password": "testpassword",
+        },
+        "pypitest": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": "testusername",
+            "password": "testpassword",
         },
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,11 +77,6 @@ def test_get_config_no_distutils(tmpdir):
             "username": None,
             "password": None,
         },
-        "pypitest": {
-            "repository": utils.TEST_REPOSITORY,
-            "username": None,
-            "password": None,
-        },
     }
 
 
@@ -115,11 +110,6 @@ def test_get_config_missing(tmpdir):
             "repository": utils.DEFAULT_REPOSITORY,
             "username": None,
             "password": None,
-        },
-        "pypitest": {
-            "repository": utils.TEST_REPOSITORY,
-            "username": None,
-            "password": None
         },
         "testpypi": {
             "repository": utils.TEST_REPOSITORY,
@@ -162,11 +152,6 @@ def test_get_config_deprecated_pypirc():
             "password": "testpassword",
         },
         "testpypi": {
-            "repository": utils.TEST_REPOSITORY,
-            "username": "testusername",
-            "password": "testpassword",
-        },
-        "pypitest": {
             "repository": utils.TEST_REPOSITORY,
             "username": "testusername",
             "password": "testpassword",

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -93,7 +93,7 @@ def get_config(path="~/.pypirc"):
                 config[repository][key] = parser.get(repository, key)
 
     # convert the defaultdict to a regular dict at this point
-    # to prevent unsurprising behavior later on
+    # to prevent surprising behavior later on
     return dict(config)
 
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -21,6 +21,7 @@ import getpass
 import sys
 import argparse
 import warnings
+import collections
 
 from requests.exceptions import HTTPError
 
@@ -48,68 +49,56 @@ TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 
 
 def get_config(path="~/.pypirc"):
+    # even if the config file does not exist, set up the parser
+    # variable to reduce the number of if/else statements
+    parser = configparser.RawConfigParser()
+
+    # this list will only be used if index-servers
+    # is not defined in the config file
+    index_servers = ["pypi", "pypitest", "testpypi"]
+
+    # default configuration for each repository
+    defaults = {"username": None, "password": None}
+
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
-    if not os.path.isfile(path):
-        return {"pypi": {"repository": DEFAULT_REPOSITORY,
-                         "username": None,
-                         "password": None
-                         },
-                "pypitest": {"repository": TEST_REPOSITORY,
-                             "username": None,
-                             "password": None
-                             },
-                }
-
     # Parse the rc file
-    parser = configparser.RawConfigParser()
-    parser.read(path)
+    if os.path.isfile(path):
+        parser.read(path)
 
-    # Get a list of repositories from the config file
-    # format: https://docs.python.org/3/distutils/packageindex.html#pypirc
-    if (parser.has_section("distutils") and
-            parser.has_option("distutils", "index-servers")):
-        repositories = parser.get("distutils", "index-servers").split()
-    elif parser.has_section("pypi"):
-        # Special case: if the .pypirc file has a 'pypi' section,
-        # even if there's no list of index servers,
-        # be lenient and include that in our list of repositories.
-        repositories = ['pypi']
-    else:
-        repositories = []
+        # Get a list of index_servers from the config file
+        # format: https://docs.python.org/3/distutils/packageindex.html#pypirc
+        if (parser.has_section("distutils") and
+                parser.has_option("distutils", "index-servers")):
+            index_servers = parser.get("distutils", "index-servers").split()
 
-    config = {}
+        if parser.has_section("server-login"):
+            for key in ["username", "password"]:
+                if parser.has_option("server-login", key):
+                    defaults[key] = parser.get("server-login", key)
 
-    defaults = {"username": None, "password": None}
-    if parser.has_section("server-login"):
-        for key in ["username", "password"]:
-            if parser.has_option("server-login", key):
-                defaults[key] = parser.get("server-login", key)
+    config = collections.defaultdict(lambda: defaults.copy())
 
-    for repository in repositories:
-        # Skip this repository if it doesn't exist in the config file
-        if not parser.has_section(repository):
-            continue
+    # always configure pypi, regardless of index_servers
+    config["pypi"]["repository"] = DEFAULT_REPOSITORY
 
-        # Mandatory configuration and defaults
-        config[repository] = {
-            "repository": DEFAULT_REPOSITORY,
-            "username": None,
-            "password": None,
-        }
+    # if testpypi/pypitest is in index_servers, configure those as well
+    for repository in ("testpypi", "pypitest"):
+        if repository in index_servers:
+            config[repository]["repository"] = TEST_REPOSITORY
 
-        # Optional configuration values
-        for key in [
-            "username", "repository", "password",
-            "ca_cert", "client_cert",
-        ]:
-            if parser.has_option(repository, key):
-                config[repository][key] = parser.get(repository, key)
-            elif defaults.get(key):
-                config[repository][key] = defaults[key]
+    # optional configuration values for individual repositories
+    for repository in index_servers:
+        if parser.has_section(repository):
+            for key in [
+                "username", "repository", "password",
+                "ca_cert", "client_cert",
+            ]:
+                if parser.has_option(repository, key):
+                    config[repository][key] = parser.get(repository, key)
 
-    return config
+    return dict(config)
 
 
 def get_repository_from_config(config_file, repository, repository_url=None):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -79,9 +79,9 @@ def get_config(path="~/.pypirc"):
     config = collections.defaultdict(lambda: defaults.copy())
 
     # don't require users to manually configure URLs for these repositories
-    config["pypi"].setdefault("repository", DEFAULT_REPOSITORY)
+    config["pypi"]["repository"] = DEFAULT_REPOSITORY
     if "testpypi" in index_servers:
-        config["testpypi"].setdefault("repository", TEST_REPOSITORY)
+        config["testpypi"]["repository"] = TEST_REPOSITORY
 
     # optional configuration values for individual repositories
     for repository in index_servers:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -55,7 +55,7 @@ def get_config(path="~/.pypirc"):
 
     # this list will only be used if index-servers
     # is not defined in the config file
-    index_servers = ["pypi", "pypitest", "testpypi"]
+    index_servers = ["pypi", "testpypi"]
 
     # default configuration for each repository
     defaults = {"username": None, "password": None}
@@ -78,13 +78,10 @@ def get_config(path="~/.pypirc"):
 
     config = collections.defaultdict(lambda: defaults.copy())
 
-    # always configure pypi, regardless of index_servers
-    config["pypi"]["repository"] = DEFAULT_REPOSITORY
-
-    # if testpypi/pypitest is in index_servers, configure those as well
-    for repository in ("testpypi", "pypitest"):
-        if repository in index_servers:
-            config[repository]["repository"] = TEST_REPOSITORY
+    # don't require users to manually configure URLs for these repositories
+    config["pypi"].setdefault("repository", DEFAULT_REPOSITORY)
+    if "testpypi" in index_servers:
+        config["testpypi"].setdefault("repository", TEST_REPOSITORY)
 
     # optional configuration values for individual repositories
     for repository in index_servers:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -92,6 +92,8 @@ def get_config(path="~/.pypirc"):
             if parser.has_option(repository, key):
                 config[repository][key] = parser.get(repository, key)
 
+    # convert the defaultdict to a regular dict at this point
+    # to prevent unsurprising behavior later on
     return dict(config)
 
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -69,14 +69,12 @@ def get_config(path="~/.pypirc"):
 
         # Get a list of index_servers from the config file
         # format: https://docs.python.org/3/distutils/packageindex.html#pypirc
-        if (parser.has_section("distutils") and
-                parser.has_option("distutils", "index-servers")):
+        if parser.has_option("distutils", "index-servers"):
             index_servers = parser.get("distutils", "index-servers").split()
 
-        if parser.has_section("server-login"):
-            for key in ["username", "password"]:
-                if parser.has_option("server-login", key):
-                    defaults[key] = parser.get("server-login", key)
+        for key in ["username", "password"]:
+            if parser.has_option("server-login", key):
+                defaults[key] = parser.get("server-login", key)
 
     config = collections.defaultdict(lambda: defaults.copy())
 
@@ -90,13 +88,12 @@ def get_config(path="~/.pypirc"):
 
     # optional configuration values for individual repositories
     for repository in index_servers:
-        if parser.has_section(repository):
-            for key in [
-                "username", "repository", "password",
-                "ca_cert", "client_cert",
-            ]:
-                if parser.has_option(repository, key):
-                    config[repository][key] = parser.get(repository, key)
+        for key in [
+            "username", "repository", "password",
+            "ca_cert", "client_cert",
+        ]:
+            if parser.has_option(repository, key):
+                config[repository][key] = parser.get(repository, key)
 
     return dict(config)
 


### PR DESCRIPTION
I was trying to configure testpypi today and got super confused that I had to 1. add it to `index-servers` and 2. documentation and twine was inconsistent about whether I should do testpypi or pypitest.

This PR configures `pypitest` and `testpypi` by default, unless you override `index-servers`. Note that we still configure the `pypi` repository even if it's not in `index-url`, so this is a bit inconsistent now. I could make all 3 repos configured by default for consistency, if we want.

I had to refactor `get_config` a bit to get it working properly.

Fixes #364 