### PR TITLE
Fixes Travis build failure - Mypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 2.7
+    - python: 3.6
       env: TOXENV=lint
     - python: 3.4
       env: TOXENV=py34

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,6 @@ Sumana Harihareswara <sh@changeset.nyc>
 Dustin Ingram <di@di.codes> (https://di.codes)
 Jesse Jarzynka <jesse@jessejoe.com> (http://jessejoe.com)
 László Kiss Kollár <kiss.kollar.laszlo@gmail.com>
+Frances Hocutt <frances.hocutt@gmail.com>
+Tathagata Dasgupta <tathagatadg@gmail.com>
+Wasim Thabraze <wasim@thabraze.me>

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,7 +73,7 @@ Either use ``tox`` to build against all supported Python versions (if
 you have them installed) or use ``tox -e py{version}`` to test against
 a specific version, e.g., ``tox -e py27`` or ``tox -e py34``.
 
-Also, always run ``tox -e pep8`` before submitting a pull request.
+Also, always run ``tox -e lint`` before submitting a pull request.
 
 Submitting changes
 ^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ A checklist for creating, testing, and distributing a new version.
 #. Run Twine tests:
 
    #. ``tox -e py{27,34,35,36,py}``
-   #. ``tox -e pep8`` for the linter
+   #. ``tox -e lint`` for the linter
    #. ``tox -e docs`` (this checks the Sphinx docs and uses
       ``readme_renderer`` to check that the ``long_description`` and other
       metadata will render fine on the PyPI description)

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     readme_renderer
     mypy
 commands =
-    flake8 twine/ tests/ docs/
+    flake8 twine/ tests/
     check-manifest -v
     python setup.py check -r -s
     -mypy -s twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36,docs,lint
+envlist = lint,py27,pypy,py33,py34,py35,py36,docs
 
 [testenv]
 deps =
@@ -30,13 +30,14 @@ commands =
     twine upload --skip-existing dist/*
 
 [testenv:lint]
-basepython = python2.7
+basepython = python3.6
 deps =
     flake8
     check-manifest
     readme_renderer
+    mypy
 commands =
     flake8 twine/ tests/ docs/
     check-manifest -v
     python setup.py check -r -s
-
+    -mypy -s twine/ tests/

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -41,7 +41,8 @@ import twine.exceptions
 if sys.version_info > (3,):
     input_func = input
 else:
-    input_func = raw_input
+    # Ignore "undefined name" for flake8/python3
+    input_func = raw_input  # noqa: F821
 
 
 DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"


### PR DESCRIPTION
This PR is based on #357 

PR #357 was failing because in `.travis.yml`  the `lint` job in `matrix / include` has the Python version 2.7. Changing the Python version to 3.6 resolves the issue.

@fhocutt Thanks for your work on this.