### PR TITLE
Fully drop support for Python 3.3

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :feature:`392 major` Drop support for Python 3.3
 * :release:`1.11.0 <2018-03-19>`
 * :bug:`269 major` Avoid uploading to PyPI when given alternate
   repository URL, and require ``http://`` or ``https://`` in

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27,pypy,py33,py34,py35,py36,docs
+envlist = lint,py27,pypy,py34,py35,py36,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
#287 didn't fully drop support for 3.3, this PR removes the 3.3 classifier and removes the 3.3 test environment from the tox configuration.