### PR TITLE
Use Travis' PyPy environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,10 @@ matrix:
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=docs
-    - python: 3.6
+    - python: pypy
       env: TOXENV=pypy
 
 install:
-  # Add the PyPy repository
-  - "if [[ $TOXENV == 'pypy' ]]; then sudo add-apt-repository -y ppa:pypy/ppa; fi"
-  - "if [[ $TOXENV == 'pypy' ]]; then sudo sudo apt-get -y update; fi"
-  # Upgrade PyPy
-  - "if [[ $TOXENV == 'pypy' ]]; then sudo apt-get -y install pypy; fi"
-  # This is required because we need to get rid of the Travis installed PyPy
-  # or it'll take precedence over the PPA installed one.
-  - "if [[ $TOXENV == 'pypy' ]]; then sudo rm -rf /usr/local/pypy/bin; fi"
   - pip install tox codecov
 
 script:


### PR DESCRIPTION
It's no longer necessary for us to install PyPy from elsewhere, the Travis environment is sufficient.

As-is, this is giving us a weird Python 3.6/PyPY environment which lacks the ability to build dependencies with C extensions (like [`cmarkgfm`](https://pypi.org/project/cmarkgfm/)).