### PR TITLE
Add "check" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,11 @@ The next time you run ``twine`` it will prompt you for a username and will grab 
 Options
 -------
 
+``twine upload``
+^^^^^^^^^^^^^^^^
+
+Uploads one or more distributions to a repository.
+
 .. code-block:: console
 
     $ twine upload -h
@@ -191,16 +196,29 @@ Options
                             containing the private key and the certificate in PEM
                             format.
 
-Twine also includes a ``register`` command.
+``twine check``
+^^^^^^^^^^^^^^^
 
-.. WARNING::
-   ``register`` is `no longer necessary if you are
-   uploading to pypi.org
-   <https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata>`_. As
-   such, it is `no longer supported
-   <https://github.com/pypa/warehouse/issues/1627>`_ in `Warehouse`_
-   (the new PyPI software running on pypi.org). However, you may need
-   this if you are using a different package index.
+Checks whether your distributions long description will render correctly on PyPI.
+
+.. code-block:: console
+
+    $ twine check -h
+    usage: twine check [-h] dist [dist ...]
+
+    positional arguments:
+    dist        The distribution files to check, usually dist/*
+
+    optional arguments:
+    -h, --help  show this help message and exit
+
+``twine register``
+^^^^^^^^^^^^^^^^^^
+
+**WARNING**: The ``register`` command is `no longer necessary if you are uploading to
+pypi.org`_.  As such, it is `no longer supported`_ in `Warehouse`_ (the new
+PyPI software running on pypi.org). However, you may need this if you are using
+a different package index.
 
 For completeness, its usage:
 
@@ -300,3 +318,5 @@ trackers, chat rooms, and mailing lists is expected to follow the
 .. _`PyPA Code of Conduct`: https://www.pypa.io/en/latest/code-of-conduct/
 .. _`Warehouse`: https://github.com/pypa/warehouse
 .. _`wheels`: https://packaging.python.org/glossary/#term-wheel
+.. _`no longer necessary if you are uploading to pypi.org`: https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata
+.. _`no longer supported`: https://github.com/pypa/warehouse/issues/1627

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :feature:`395 major` Add ``twine check`` command to check long description
 * :feature:`392 major` Drop support for Python 3.3
 * :release:`1.11.0 <2018-03-19>`
 * :bug:`269 major` Avoid uploading to PyPI when given alternate

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ import twine
 install_requires = [
     "tqdm >= 4.14",
     "pkginfo >= 1.4.2",
+    "readme_renderer >= 21.0",
     "requests >= 2.5.0, != 2.15, != 2.16",
     "requests-toolbelt >= 0.8.0",
     "setuptools >= 0.7.0",
@@ -81,6 +82,7 @@ setup(
 
     entry_points={
         "twine.registered_commands": [
+            "check = twine.commands.check:main",
             "upload = twine.commands.upload:main",
             "register = twine.commands.register:main",
         ],

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,119 @@
+# Copyright 2018 Dustin Ingram
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import unicode_literals
+
+import pretend
+
+from twine.commands import check
+
+
+def test_warningstream_write_match():
+    stream = check._WarningStream()
+    stream.output = pretend.stub(write=pretend.call_recorder(lambda a: None))
+
+    stream.write("<string>:2: (WARNING/2) Title underline too short.")
+
+    assert stream.output.write.calls == [
+        pretend.call("line 2: Warning: Title underline too short.\n")
+    ]
+
+
+def test_warningstream_write_nomatch():
+    stream = check._WarningStream()
+    stream.output = pretend.stub(write=pretend.call_recorder(lambda a: None))
+
+    stream.write("this does not match")
+
+    assert stream.output.write.calls == [pretend.call("this does not match")]
+
+
+def test_warningstream_str():
+    stream = check._WarningStream()
+    stream.output = pretend.stub(getvalue=lambda: "result")
+
+    assert str(stream) == "result"
+
+
+def test_check_no_distributions(monkeypatch):
+    stream = check.StringIO()
+
+    monkeypatch.setattr(check, "_find_dists", lambda a: [])
+
+    assert not check.check("dist/*", output_stream=stream)
+    assert stream.getvalue() == ""
+
+
+def test_check_passing_distribution(monkeypatch):
+    renderer = pretend.stub(
+        render=pretend.call_recorder(lambda *a, **kw: "valid")
+    )
+    package = pretend.stub(metadata_dictionary=lambda: {"description": "blah"})
+    output_stream = check.StringIO()
+    warning_stream = ""
+
+    monkeypatch.setattr(check, "_RENDERERS", {"": renderer})
+    monkeypatch.setattr(check, "_find_dists", lambda a: ["dist/dist.tar.gz"])
+    monkeypatch.setattr(
+        check,
+        "PackageFile",
+        pretend.stub(from_filename=lambda *a, **kw: package),
+    )
+    monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
+
+    assert not check.check("dist/*", output_stream=output_stream)
+    assert (
+        output_stream.getvalue()
+        == "Checking distribution dist/dist.tar.gz: Passed\n"
+    )
+    assert renderer.render.calls == [
+        pretend.call("blah", stream=warning_stream)
+    ]
+
+
+def test_check_failing_distribution(monkeypatch):
+    renderer = pretend.stub(
+        render=pretend.call_recorder(lambda *a, **kw: None)
+    )
+    package = pretend.stub(metadata_dictionary=lambda: {"description": "blah"})
+    output_stream = check.StringIO()
+    warning_stream = "WARNING"
+
+    monkeypatch.setattr(check, "_RENDERERS", {"": renderer})
+    monkeypatch.setattr(check, "_find_dists", lambda a: ["dist/dist.tar.gz"])
+    monkeypatch.setattr(
+        check,
+        "PackageFile",
+        pretend.stub(from_filename=lambda *a, **kw: package),
+    )
+    monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
+
+    assert check.check("dist/*", output_stream=output_stream)
+    assert output_stream.getvalue() == (
+        "Checking distribution dist/dist.tar.gz: Failed\n"
+        "The project's long_description has invalid markup which will not be "
+        "rendered on PyPI. The following syntax errors were detected:\n"
+        "WARNING"
+    )
+    assert renderer.render.calls == [
+        pretend.call("blah", stream=warning_stream)
+    ]
+
+
+def test_main(monkeypatch):
+    check_result = pretend.stub()
+    check_stub = pretend.call_recorder(lambda a: check_result)
+    monkeypatch.setattr(check, "check", check_stub)
+
+    assert check.main(["dist/*"]) == check_result
+    assert check_stub.calls == [pretend.call(["dist/*"])]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+
+from twine.commands import _find_dists, _group_wheel_files_first
+
+
+def test_ensure_wheel_files_uploaded_first():
+    files = _group_wheel_files_first(
+        ["twine/foo.py", "twine/first.whl", "twine/bar.py", "twine/second.whl"]
+    )
+    expected = [
+        "twine/first.whl",
+        "twine/second.whl",
+        "twine/foo.py",
+        "twine/bar.py",
+    ]
+    assert expected == files
+
+
+def test_ensure_if_no_wheel_files():
+    files = _group_wheel_files_first(["twine/foo.py", "twine/bar.py"])
+    expected = ["twine/foo.py", "twine/bar.py"]
+    assert expected == files
+
+
+def test_find_dists_expands_globs():
+    files = sorted(_find_dists(["twine/__*.py"]))
+    expected = [
+        os.path.join("twine", "__init__.py"),
+        os.path.join("twine", "__main__.py"),
+    ]
+    assert expected == files
+
+
+def test_find_dists_errors_on_invalid_globs():
+    with pytest.raises(ValueError):
+        _find_dists(["twine/*.rb"])
+
+
+def test_find_dists_handles_real_files():
+    expected = [
+        "twine/__init__.py",
+        "twine/__main__.py",
+        "twine/cli.py",
+        "twine/utils.py",
+        "twine/wheel.py",
+    ]
+    files = _find_dists(expected)
+    assert expected == files

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -28,45 +28,6 @@ import helpers
 WHEEL_FIXTURE = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
 
 
-def test_ensure_wheel_files_uploaded_first():
-    files = upload.group_wheel_files_first(["twine/foo.py",
-                                            "twine/first.whl",
-                                            "twine/bar.py",
-                                            "twine/second.whl"])
-    expected = ["twine/first.whl",
-                "twine/second.whl",
-                "twine/foo.py",
-                "twine/bar.py"]
-    assert expected == files
-
-
-def test_ensure_if_no_wheel_files():
-    files = upload.group_wheel_files_first(["twine/foo.py",
-                                            "twine/bar.py"])
-    expected = ["twine/foo.py",
-                "twine/bar.py"]
-    assert expected == files
-
-
-def test_find_dists_expands_globs():
-    files = sorted(upload.find_dists(['twine/__*.py']))
-    expected = [os.path.join('twine', '__init__.py'),
-                os.path.join('twine', '__main__.py')]
-    assert expected == files
-
-
-def test_find_dists_errors_on_invalid_globs():
-    with pytest.raises(ValueError):
-        upload.find_dists(['twine/*.rb'])
-
-
-def test_find_dists_handles_real_files():
-    expected = ['twine/__init__.py', 'twine/__main__.py', 'twine/cli.py',
-                'twine/utils.py', 'twine/wheel.py']
-    files = upload.find_dists(expected)
-    assert expected == files
-
-
 def test_get_config_old_format(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,11 +18,6 @@ import sys
 import os.path
 import textwrap
 
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
 import pytest
 
 from twine import utils
@@ -239,13 +234,7 @@ def keyring_missing(monkeypatch):
     """
     Simulate that 'import keyring' raises an ImportError
     """
-    real_import = builtins.__import__
-
-    def my_import(name, *args, **kwargs):
-        if name == 'keyring':
-            raise ImportError
-        return real_import(name, *args, **kwargs)
-    monkeypatch.setattr(builtins, '__import__', my_import)
+    monkeypatch.delitem(sys.modules, 'keyring', raising=False)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pretend
     pytest
     py27,py34,py35: pyblake2
+    readme_renderer
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,16 @@ commands =
 
 [testenv:docs]
 basepython = python3.6
-deps = -rdocs/requirements.txt
+deps =
+    .
+    -rdocs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 docs
     sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
-    python setup.py check -r -s
+    python setup.py sdist
+    twine check dist/*
 
 [testenv:release]
 deps =
@@ -33,12 +36,13 @@ commands =
 [testenv:lint]
 basepython = python3.6
 deps =
+    .
     flake8
     check-manifest
-    readme_renderer
     mypy
 commands =
     flake8 twine/ tests/
     check-manifest -v
-    python setup.py check -r -s
+    python setup.py sdist
+    twine check dist/*
     -mypy -s twine/ tests/

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -72,4 +72,4 @@ def dispatch(argv):
 
     main = registered_commands[args.command].load()
 
-    main(args.args)
+    return main(args.args)

--- a/twine/commands/__init__.py
+++ b/twine/commands/__init__.py
@@ -13,3 +13,36 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
+
+import glob
+import os.path
+
+__all__ = []
+
+
+def _group_wheel_files_first(files):
+    if not any(fname for fname in files if fname.endswith(".whl")):
+        # Return early if there's no wheel files
+        return files
+
+    files.sort(key=lambda x: -1 if x.endswith(".whl") else 0)
+
+    return files
+
+
+def _find_dists(dists):
+    uploads = []
+    for filename in dists:
+        if os.path.exists(filename):
+            uploads.append(filename)
+            continue
+        # The filename didn't exist so it may be a glob
+        files = glob.glob(filename)
+        # If nothing matches, files is []
+        if not files:
+            raise ValueError(
+                "Cannot find file (or expand pattern): '%s'" % filename
+            )
+        # Otherwise, files will be filenames that exist
+        uploads.extend(files)
+    return _group_wheel_files_first(uploads)

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -1,0 +1,126 @@
+# Copyright 2018 Dustin Ingram
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function
+from __future__ import unicode_literals
+
+import argparse
+import cgi
+import re
+import sys
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from _io import StringIO
+
+import readme_renderer.markdown
+import readme_renderer.rst
+import readme_renderer.txt
+
+from twine.commands import _find_dists
+from twine.package import PackageFile
+
+_RENDERERS = {
+    None: readme_renderer.rst,  # Default if description_content_type is None
+    "": readme_renderer.rst,  # Default if description_content_type is None
+    "text/plain": readme_renderer.txt,
+    "text/x-rst": readme_renderer.rst,
+    "text/markdown": readme_renderer.markdown,
+}
+
+
+# Regular expression used to capture and reformat doctuils warnings into
+# something that a human can understand. This is loosely borrowed from
+# Sphinx: https://github.com/sphinx-doc/sphinx/blob
+# /c35eb6fade7a3b4a6de4183d1dd4196f04a5edaf/sphinx/util/docutils.py#L199
+_REPORT_RE = re.compile(
+    r"^<string>:(?P<line>(?:\d+)?): "
+    r"\((?P<level>DEBUG|INFO|WARNING|ERROR|SEVERE)/(\d+)?\) "
+    r"(?P<message>.*)",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+class _WarningStream(object):
+    def __init__(self):
+        self.output = StringIO()
+
+    def write(self, text):
+        matched = _REPORT_RE.search(text)
+
+        if not matched:
+            self.output.write(text)
+            return
+
+        self.output.write(
+            "line {line}: {level_text}: {message}\n".format(
+                level_text=matched.group("level").capitalize(),
+                line=matched.group("line"),
+                message=matched.group("message").rstrip("\r\n"),
+            )
+        )
+
+    def __str__(self):
+        return self.output.getvalue()
+
+
+def check(dists, output_stream=sys.stdout):
+    uploads = [i for i in _find_dists(dists) if not i.endswith(".asc")]
+    stream = _WarningStream()
+    failure = False
+
+    for filename in uploads:
+        output_stream.write("Checking distribution %s: " % filename)
+        package = PackageFile.from_filename(filename, comment=None)
+
+        metadata = package.metadata_dictionary()
+        content_type, parameters = cgi.parse_header(
+            metadata.get("description_content_type") or ""
+        )
+
+        # Get the appropriate renderer
+        renderer = _RENDERERS.get(content_type, readme_renderer.txt)
+
+        # Actually render the given value
+        rendered = renderer.render(
+            metadata.get("description"), stream=stream, **parameters
+        )
+
+        if rendered is None:
+            failure = True
+            output_stream.write("Failed\n")
+            output_stream.write(
+                "The project's long_description has invalid markup which will "
+                "not be rendered on PyPI. The following syntax errors were "
+                "detected:\n%s" % stream
+            )
+        else:
+            output_stream.write("Passed\n")
+
+    return failure
+
+
+def main(args):
+    parser = argparse.ArgumentParser(prog="twine check")
+    parser.add_argument(
+        "dists",
+        nargs="+",
+        metavar="dist",
+        help="The distribution files to check, usually dist/*",
+    )
+
+    args = parser.parse_args(args)
+
+    # Call the check function with the arguments from the command line
+    return check(args.dists)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -15,42 +15,13 @@ from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
 
 import argparse
-import glob
 import os.path
-import sys
 
 import twine.exceptions as exc
+from twine.commands import _find_dists
 from twine.package import PackageFile
 from twine import settings
 from twine import utils
-
-
-def group_wheel_files_first(files):
-    if not any(fname for fname in files if fname.endswith(".whl")):
-        # Return early if there's no wheel files
-        return files
-
-    files.sort(key=lambda x: -1 if x.endswith(".whl") else 0)
-
-    return files
-
-
-def find_dists(dists):
-    uploads = []
-    for filename in dists:
-        if os.path.exists(filename):
-            uploads.append(filename)
-            continue
-        # The filename didn't exist so it may be a glob
-        files = glob.glob(filename)
-        # If nothing matches, files is []
-        if not files:
-            raise ValueError(
-                "Cannot find file (or expand pattern): '%s'" % filename
-                )
-        # Otherwise, files will be filenames that exist
-        uploads.extend(files)
-    return group_wheel_files_first(uploads)
 
 
 def skip_upload(response, skip_existing, package):
@@ -72,7 +43,7 @@ def skip_upload(response, skip_existing, package):
 
 
 def upload(upload_settings, dists):
-    dists = find_dists(dists)
+    dists = _find_dists(dists)
 
     # Determine if the user has passed in pre-signed distributions
     signatures = dict(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -99,6 +99,8 @@ def upload(upload_settings, dists):
     # pool.
     repository.close()
 
+    return True
+
 
 def main(args):
     parser = argparse.ArgumentParser(prog="twine upload")
@@ -117,4 +119,4 @@ def main(args):
     upload_settings = settings.Settings.from_argparse(args)
 
     # Call the upload function with the arguments from the command line
-    upload(upload_settings, args.dists)
+    return upload(upload_settings, args.dists)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -118,7 +118,3 @@ def main(args):
 
     # Call the upload function with the arguments from the command line
     upload(upload_settings, args.dists)
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -207,12 +207,11 @@ def password_prompt(prompt_text):  # Always expects unicode for our own sanity
 
 
 def get_password_from_keyring(system, username):
-    try:
-        import keyring
-    except ImportError:
+    if 'keyring' not in sys.modules:
         return
 
     try:
+        import keyring
         return keyring.get_password(system, username)
     except Exception as exc:
         warnings.warn(str(exc))


### PR DESCRIPTION
The `twine check` command determines whether a given distributions `long_description` will be properly rendered on PyPI.

By checking the metadata _after_ the distribution has been built, this provides a way to check packages that have build-time dependencies that `python setup.py check` won't install (see https://github.com/pypa/readme_renderer/issues/118).

This can eventually be extended to check other metadata as well, [once this logic is moved out of Warehouse](https://github.com/pypa/warehouse/blob/55230d8ba3a4c4504bdbd7b9c562d166e703a18f/warehouse/forklift/legacy.py#L341-L343).