### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [check-manifest]
@@ -9,6 +9,7 @@ ignore =
     .github/*
 
 [metadata]
+license_file = LICENSE
 requires-dist =
     tqdm >= 4.14
     requests >= 2.5.0, != 2.15, != 2.16


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> You must give any other recipients of the Work or Derivative Works a copy of this License ...

Additionally, rename `[wheel]` section to `[bdist_wheel]` as the former is legacy. For additional details, see:

https://github.com/pypa/wheel/blob/3dc261abc98a5e43bc7fcf5783d080aaf8f9f0cf/wheel/bdist_wheel.py#L127-L133

http://pythonwheels.com/