### PR TITLE
Remove Python 2.6 argparse workarounds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,5 @@ requires-dist =
     requests-toolbelt >= 0.8.0
     pkginfo >= 1.4.2
     setuptools >= 0.7.0
-    argparse; python_version == '2.6'
     pyblake2; extra == 'with-blake2' and python_version < '3.6'
     keyring; extra == 'keyring'

--- a/setup.py
+++ b/setup.py
@@ -18,21 +18,6 @@ import sys
 import twine
 
 
-install_requires = [
-    "tqdm >= 4.14",
-    "pkginfo >= 1.4.2",
-    "readme_renderer >= 21.0",
-    "requests >= 2.5.0, != 2.15, != 2.16",
-    "requests-toolbelt >= 0.8.0",
-    "setuptools >= 0.7.0",
-]
-
-if sys.version_info[:2] < (2, 7):
-    install_requires += [
-        "argparse",
-    ]
-
-
 blake2_requires = []
 
 if sys.version_info[:2] < (3, 6):
@@ -91,7 +76,14 @@ setup(
         ],
     },
 
-    install_requires=install_requires,
+    install_requires=[
+        "pkginfo >= 1.4.2",
+        "readme_renderer >= 21.0",
+        "requests >= 2.5.0, != 2.15, != 2.16",
+        "requests-toolbelt >= 0.8.0",
+        "setuptools >= 0.7.0",
+        "tqdm >= 4.14",
+    ],
     extras_require={
         'with-blake2': blake2_requires,
         'keyring': [


### PR DESCRIPTION
Python 2.6 support was dropped in a935951825ee3b405238cd18f9ec845e74bb7e8c.