### PR TITLE
Fix keyring support

### DIFF
--- a/twine/utils.py
+++ b/twine/utils.py
@@ -35,6 +35,11 @@ try:
 except ImportError:
     from urllib.parse import urlparse, urlunparse
 
+try:
+    import keyring  # noqa
+except ImportError:
+    pass
+
 from twine import exceptions
 
 # Shim for raw_input in python3
@@ -211,8 +216,7 @@ def get_password_from_keyring(system, username):
         return
 
     try:
-        import keyring
-        return keyring.get_password(system, username)
+        return sys.modules['keyring'].get_password(system, username)
     except Exception as exc:
         warnings.warn(str(exc))
 


### PR DESCRIPTION
Per [this comment](https://github.com/pypa/twine/pull/395/files#r221757965), fix a regression from #395 that would never successfully import `keyring`. A full explanation as to why this needed changed is in https://github.com/pypa/twine/pull/395/commits/3ae98ed4bf6c0208cc275891407c968d7c4a0383.

Thanks to @adamtheturtle for catching it.