### PR TITLE
Replaced requests.packages.urllib3.util with ullib3.util.

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -14,13 +14,13 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import sys
+from urllib3 import util
 
 from tqdm import tqdm
 
 import requests
 from requests import adapters
 from requests import codes
-from requests.packages.urllib3 import util
 from requests_toolbelt.multipart import (
     MultipartEncoder, MultipartEncoderMonitor
 )


### PR DESCRIPTION
Replaced requests.packages.urllib3.util with ullib3.util as the former isn't found in some versions of requests.

Here's a similar issue I found on Stackoverflow: https://stackoverflow.com/questions/28904607/cannot-import-requests-packages-urllib3-util-retry 