### PR TITLE
Revert "Update changelog and bump version. Ref #408."

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,6 @@
 Changelog
 =========
 
-* :release:`1.12.2 <2018-10-14>`
-* :bug:`408` Fix regression where keyring is unconditionally disabled.
 * :release:`1.12.1 <2018-09-24>`
 * :bug:`404` Fix regression with upload exit code
 * :release:`1.12.0 <2018-09-24>`

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -22,7 +22,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for publishing packages on PyPI"
 __uri__ = "https://twine.readthedocs.io/"
 
-__version__ = "1.12.2"
+__version__ = "1.12.1"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
This reverts premature commit 191cf5c0d7a2e8df8ca889f8e64d6336352a35e3.

I've also removed the tag 1.12.2. Ref #408.