### PR TITLE
Fixes #418 Support keyring.get_credential

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -284,8 +284,8 @@ def entered_password(monkeypatch):
 
 
 def test_get_password_keyring_missing_get_credentials_prompts(
-        entered_password, keyring_missing_get_credentials):
-    assert utils.get_password('system', 'user', None, {}) == 'entered pw'
+        entered_username, keyring_missing_get_credentials):
+    assert utils.get_username('system', None, {}) == 'entered user'
 
 
 def test_get_password_keyring_missing_prompts(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -242,9 +242,9 @@ def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
 
     monkeypatch.setitem(sys.modules, 'keyring', MockKeyring)
 
-    user = utils.get_username('system', 'user', {})
+    user = utils.get_username('system', None, {})
     assert user == 'real_user'
-    pw = utils.get_password('system', 'user', None, {})
+    pw = utils.get_password('system', user, None, {})
     assert pw == 'real_user@system sekure pa55word'
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -283,7 +283,7 @@ def entered_password(monkeypatch):
     monkeypatch.setattr(utils, 'password_prompt', lambda prompt: 'entered pw')
 
 
-def test_get_password_keyring_missing_get_credentials_prompts(
+def test_get_username_keyring_missing_get_credentials_prompts(
         entered_username, keyring_missing_get_credentials):
     assert utils.get_username('system', None, {}) == 'entered user'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -237,7 +237,7 @@ def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
 
     monkeypatch.setitem(sys.modules, 'keyring', MockKeyring)
 
-    user = utils.get_username('system', 'user', None, {})
+    user = utils.get_username('system', 'user', {})
     assert user == 'real_user'
     pw = utils.get_password('system', 'user', None, {})
     assert pw == 'real_user@system sekure pa55word'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -267,10 +267,11 @@ def keyring_missing(monkeypatch):
 @pytest.fixture
 def keyring_missing_get_credentials(monkeypatch):
     """
-    Simulate that 'import keyring' raises an ImportError
+    Simulate older versions of keyring that do not have the
+    'get_credentials' API.
     """
     monkeypatch.delattr('keyring.backends.KeyringBackend',
-                        'get_credentials', raising=False)
+                        'get_credential', raising=False)
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,6 +229,20 @@ def test_get_password_keyring_defers_to_prompt(monkeypatch):
     assert pw == 'entered pw'
 
 
+def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
+    class MockKeyring:
+        @staticmethod
+        def get_username_and_password(system, user):
+            return 'real_user', 'real_user@{system} sekure pa55word'.format(**locals())
+
+    monkeypatch.setitem(sys.modules, 'keyring', MockKeyring)
+
+    user = utils.get_username('system', 'user', None, {})
+    assert user == 'real_user'
+    pw = utils.get_password('system', 'user', None, {})
+    assert pw == 'real_user@system sekure pa55word'
+
+
 @pytest.fixture
 def keyring_missing(monkeypatch):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,10 +230,15 @@ def test_get_password_keyring_defers_to_prompt(monkeypatch):
 
 
 def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
+    import collections
+    Credential = collections.namedtuple('Credential', 'username password')
     class MockKeyring:
         @staticmethod
-        def get_username_and_password(system, user):
-            return 'real_user', 'real_user@{system} sekure pa55word'.format(**locals())
+        def get_credential(system, user):
+            return Credential(
+                'real_user',
+                'real_user@{system} sekure pa55word'.format(**locals())
+            )
 
     monkeypatch.setitem(sys.modules, 'keyring', MockKeyring)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -232,6 +232,7 @@ def test_get_password_keyring_defers_to_prompt(monkeypatch):
 def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
     import collections
     Credential = collections.namedtuple('Credential', 'username password')
+
     class MockKeyring:
         @staticmethod
         def get_credential(system, user):
@@ -239,6 +240,13 @@ def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
                 'real_user',
                 'real_user@{system} sekure pa55word'.format(**locals())
             )
+
+        @staticmethod
+        def get_password(system, user):
+            cred = MockKeyring.get_credential(system, user)
+            if user != cred.username:
+                raise RuntimeError("unexpected username")
+            return cred.password
 
     monkeypatch.setitem(sys.modules, 'keyring', MockKeyring)
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -235,7 +235,11 @@ class Settings(object):
         )
 
     def _handle_authentication(self, username, password):
-        self.username = utils.get_username(username, self.repository_config)
+        self.username = utils.get_username(
+            self.repository_config['repository'],
+            username,
+            self.repository_config
+        )
         self.password = utils.get_password(
             self.repository_config['repository'],
             self.username,

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -219,6 +219,7 @@ def get_username_from_keyring(system):
     except Exception as exc:
         warnings.warn(str(exc))
 
+
 def password_prompt(prompt_text):  # Always expects unicode for our own sanity
     prompt = prompt_text
     # Workaround for https://github.com/pypa/twine/issues/116
@@ -242,6 +243,7 @@ def username_from_keyring_or_prompt(system):
         get_username_from_keyring(system)
         or input_func('Enter your username: ')
     )
+
 
 def password_from_keyring_or_prompt(system, username):
     return (

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -208,12 +208,14 @@ def get_username_from_keyring(system):
         return
 
     try:
-        getter = sys.modules['keyring'].get_username_and_password
+        getter = sys.modules['keyring'].get_credential
     except AttributeError:
         return None
 
     try:
-        return getter(system, None)[0]
+        creds = getter(system, None)
+        if creds:
+            return creds.username
     except Exception as exc:
         warnings.warn(str(exc))
 


### PR DESCRIPTION
Fixes #418 Support keyring.get_credential
This requires keyring 15.2 or later.