### PR TITLE
Allow defining empty username and password in .pypirc

### DIFF
--- a/twine/utils.py
+++ b/twine/utils.py
@@ -57,7 +57,7 @@ TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 def get_config(path="~/.pypirc"):
     # even if the config file does not exist, set up the parser
     # variable to reduce the number of if/else statements
-    parser = configparser.RawConfigParser()
+    parser = configparser.RawConfigParser(allow_no_value=True)
 
     # this list will only be used if index-servers
     # is not defined in the config file
@@ -195,7 +195,7 @@ def get_userpass_value(cli_value, config, key, prompt_strategy=None):
     """
     if cli_value is not None:
         return cli_value
-    elif config.get(key):
+    elif key in config:
         return config[key]
     elif prompt_strategy:
         return prompt_strategy()


### PR DESCRIPTION
In the case of a private repository (Nexus in my case) without any authentication, I haven't found a way not to have a prompt asking for username and password.

This PR allows to have the following configuration:
```ini
username:
password:
```
Note that I haven't tested for side effects.