### PR TITLE
add disable_progress_bar option to disable tqdm.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ László Kiss Kollár <kiss.kollar.laszlo@gmail.com>
 Frances Hocutt <frances.hocutt@gmail.com>
 Tathagata Dasgupta <tathagatadg@gmail.com>
 Wasim Thabraze <wasim@thabraze.me>
+Varun Kamath <varunkamath18@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ Uploads one or more distributions to a repository.
                         [-s] [--sign-with SIGN_WITH] [-i IDENTITY] [-u USERNAME]
                         [-p PASSWORD] [-c COMMENT] [--config-file CONFIG_FILE]
                         [--skip-existing] [--cert path] [--client-cert path]
+                        [--verbose] [--disable-progress-bar]
                         dist [dist ...]
 
     positional arguments:
@@ -204,6 +205,9 @@ Uploads one or more distributions to a repository.
       --client-cert path    Path to SSL client certificate, a single file
                             containing the private key and the certificate in PEM
                             format.
+      --verbose             Show verbose output.
+      --disable-progress-bar
+                            Disable the progress bar.
 
 ``twine check``
 ^^^^^^^^^^^^^^^

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -155,12 +155,12 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(monkeypatch, tmpdir,
         repository
     """
     @contextmanager
-    def callable(*args, **kwargs):
+    def progressbarstub(*args, **kwargs):
         assert "disable" in kwargs
         assert kwargs["disable"] == disable_progress_bar
         yield
 
-    monkeypatch.setattr(repository, "ProgressBar", callable)
+    monkeypatch.setattr(repository, "ProgressBar", progressbarstub)
     repo = repository.Repository(
         repository_url=DEFAULT_REPOSITORY,
         username='username',
@@ -188,4 +188,3 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(monkeypatch, tmpdir,
     )
 
     repo.upload(package)
-

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -16,7 +16,11 @@ import requests
 from twine import repository
 from twine.utils import DEFAULT_REPOSITORY
 
-import unittest.mock as mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import pretend
 import pytest
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,6 +49,7 @@ def test_settings_transforms_config(tmpdir):
     assert s.password == 'password'
     assert s.cacert is None
     assert s.client_cert is None
+    assert s.disable_progress_bar is False
 
 
 def test_identity_requires_sign():

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     pytest
     py27,py34,py35: pyblake2
     readme_renderer
-    py27,pypy: mock
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     py27,py34,py35: pyblake2
     readme_renderer
+    py27,pypy: mock
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -47,7 +47,8 @@ class ProgressBar(tqdm):
 
 
 class Repository(object):
-    def __init__(self, repository_url, username, password):
+    def __init__(self, repository_url, username, password,
+                 disable_progress_bar=False):
         self.url = repository_url
         self.session = requests.session()
         self.session.auth = (username, password)
@@ -55,6 +56,7 @@ class Repository(object):
         for scheme in ('http://', 'https://'):
             self.session.mount(scheme, self._make_adapter_with_retries())
         self._releases_json_data = {}
+        self.disable_progress_bar = disable_progress_bar
 
     @staticmethod
     def _make_adapter_with_retries():
@@ -140,7 +142,8 @@ class Repository(object):
             encoder = MultipartEncoder(data_to_send)
             with ProgressBar(total=encoder.len,
                              unit='B', unit_scale=True, unit_divisor=1024,
-                             miniters=1, file=sys.stdout) as bar:
+                             miniters=1, file=sys.stdout,
+                             disable=self.disable_progress_bar) as bar:
                 monitor = MultipartEncoderMonitor(
                     encoder, lambda monitor: bar.update_to(monitor.bytes_read)
                 )

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -46,6 +46,7 @@ class Settings(object):
                  cacert=None, client_cert=None,
                  repository_name='pypi', repository_url=None,
                  verbose=False,
+                 disable_progress_bar=False,
                  **ignored_kwargs
                  ):
         """Initialize our settings instance.
@@ -95,10 +96,15 @@ class Settings(object):
             will override the settings inferred from ``repository_name``.
         :param bool verbose:
             Show verbose output.
+        :param bool disable_progress_bar:
+            Disable the progress bar.
+
+            This defaults to ``False``
         """
         self.config_file = config_file
         self.comment = comment
         self.verbose = verbose
+        self.disable_progress_bar = disable_progress_bar
         self.skip_existing = skip_existing
         self._handle_repository_options(
             repository_name=repository_name, repository_url=repository_url,
@@ -206,6 +212,13 @@ class Settings(object):
             action="store_true",
             help="Show verbose output."
         )
+        parser.add_argument(
+            "--disable-progress-bar",
+            default=False,
+            required=False,
+            action="store_true",
+            help="Disable the progress bar."
+        )
 
     @classmethod
     def from_argparse(cls, args):
@@ -276,6 +289,7 @@ class Settings(object):
             self.repository_config['repository'],
             self.username,
             self.password,
+            self.disable_progress_bar
         )
         repo.set_certificate_authority(self.cacert)
         repo.set_client_certificate(self.client_cert)


### PR DESCRIPTION
* Add a disable_progress_bar option to settings.

* Add a disable_progress_bar argument to init method of the repository.

* Forward repository's disable_progress_bar property to
tqdm ProgressBar as disable kwarg.

* update README with help options for upload command.

[x] ran tox -e lint
[x] ran tox against versions: 2.7, 3.6
[x] ran tox -e docs
[x] Added test to make sure tqdm is initialized with disable flag when repository is
initialized with disable_progress_bar parameter.

Closes #386 