### PR TITLE
Simplify tox deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps =
     pretend
     pytest
     py27,py34,py35: pyblake2
-    readme_renderer
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m
@@ -15,7 +14,6 @@ commands =
 [testenv:docs]
 basepython = python3.6
 deps =
-    .
     -rdocs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
@@ -27,7 +25,6 @@ commands =
 
 [testenv:release]
 deps =
-    .
     wheel
 commands =
     python setup.py -q bdist_wheel sdist
@@ -36,7 +33,6 @@ commands =
 [testenv:lint]
 basepython = python3.6
 deps =
-    .
     flake8
     check-manifest
     mypy


### PR DESCRIPTION
- Can remove '.'. Tox installs the package automatically as the first step. No need to do so a second time.
- Remove readme_renderer. It is already a dependency of twine in setup.py.