### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,27 @@
+dist: xenial
 language: python
 cache: pip
 
 matrix:
   include:
+    - python: 3.7
+      env: TOXENV=lint
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.6
-      env: TOXENV=lint
+    - python: pypy2.7-6.0
+      env: TOXENV=pypy
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.6
-      env: TOXENV=docs
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: required
-    - python: pypy
-      env: TOXENV=pypy
+    - python: pypy3.5-6.0
+      env: TOXENV=pypy3
+    - python: 3.7
+      env: TOXENV=docs
 
 install:
   - pip install tox codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27,pypy,py34,py35,py36,py37,docs
+envlist = lint,py27,pypy,py34,py35,py36,py37,pypy3,docs
 
 [testenv]
 deps =
@@ -12,7 +12,6 @@ commands =
     coverage report -m
 
 [testenv:docs]
-basepython = python3.6
 deps =
     -rdocs/requirements.txt
 commands =
@@ -31,7 +30,6 @@ commands =
     twine upload --skip-existing dist/*
 
 [testenv:lint]
-basepython = python3.6
 deps =
     flake8
     check-manifest


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

Using PyPy on xenial requires an explicit version, see:

https://travis-ci.community/t/pypy-2-7-on-xenial/889

Also reordered the environments to match the tox.ini order.