### PR TITLE
Testing env tox/TravisCI refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 cache: pip
 
 matrix:
+  fast_finish: true
+
   include:
     - python: 3.7
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ matrix:
     - python: 3.7
       env:
         TOXENV: lint
-    - python: 2.7
-    - python: pypy2.7-6.0
-    - python: 3.4
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-    - python: pypy3.5-6.0
     - python: 3.7
       env:
         TOXENV: docs
+    - python: 3.7
+    - python: 2.7
+    - python: pypy3.5-6.0
+    - python: 3.6
+    - python: 3.5
+    - python: 3.4
+    - python: pypy2.7-6.0
 
 install:
   - pip install tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ matrix:
 
   include:
     - python: 3.7
+      name: Linting code smells and metadata
       env:
         TOXENV: lint
     - python: 3.7
+      name: Making sure that docs build is healthy
       env:
         TOXENV: docs
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: xenial
 language: python
 cache: pip
 
+env:
+  global:
+    TOXENV: python
+
 matrix:
   fast_finish: true
 
@@ -10,26 +14,12 @@ matrix:
       env:
         TOXENV: lint
     - python: 2.7
-      env:
-        TOXENV: py27
     - python: pypy2.7-6.0
-      env:
-        TOXENV: pypy
     - python: 3.4
-      env:
-        TOXENV: py34
     - python: 3.5
-      env:
-        TOXENV: py35
     - python: 3.6
-      env:
-        TOXENV: py36
     - python: 3.7
-      env:
-        TOXENV: py37
     - python: pypy3.5-6.0
-      env:
-        TOXENV: pypy3
     - python: 3.7
       env:
         TOXENV: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   - tox
 
-after_success:
+after_script:
   - codecov --env TRAVIS_OS_NAME,TOXENV
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,32 @@ cache: pip
 matrix:
   include:
     - python: 3.7
-      env: TOXENV=lint
+      env:
+        TOXENV: lint
     - python: 2.7
-      env: TOXENV=py27
+      env:
+        TOXENV: py27
     - python: pypy2.7-6.0
-      env: TOXENV=pypy
+      env:
+        TOXENV: pypy
     - python: 3.4
-      env: TOXENV=py34
+      env:
+        TOXENV: py34
     - python: 3.5
-      env: TOXENV=py35
+      env:
+        TOXENV: py35
     - python: 3.6
-      env: TOXENV=py36
+      env:
+        TOXENV: py36
     - python: 3.7
-      env: TOXENV=py37
+      env:
+        TOXENV: py37
     - python: pypy3.5-6.0
-      env: TOXENV=pypy3
+      env:
+        TOXENV: pypy3
     - python: 3.7
-      env: TOXENV=docs
+      env:
+        TOXENV: docs
 
 install:
   - pip install tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ matrix:
 
   include:
     - python: 3.7
-      name: Linting code smells and metadata
+      name: Linting code smells
       env:
-        TOXENV: lint
+        TOXENV: lint-code-style
+    - python: 3.7
+      name: Linting distribution metadata
+      env:
+        TOXENV: lint-dist-meta
     - python: 3.7
       name: Linting type matching
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,19 @@ env:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env:
+        TOXENV: lint-mypy
 
   include:
     - python: 3.7
       name: Linting code smells and metadata
       env:
         TOXENV: lint
+    - python: 3.7
+      name: Linting type matching
+      env:
+        TOXENV: lint-mypy
     - python: 3.7
       name: Making sure that docs build is healthy
       env:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/travis/pypa/twine/master.svg?label=travis-ci
+   :target: https://travis-ci.org/pypa/twine
+
 twine
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     url=twine.__uri__,
     project_urls={
         'Packaging tutorial': 'https://packaging.python.org/tutorials/distributing-packages/',
+        'Travis CI': 'https://travis-ci.org/pypa/twine',
         'Twine documentation': 'https://twine.readthedocs.io/en/latest/',
         'Twine source': 'https://github.com/pypa/twine/',
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint{,-{code-style,dist-meta,mypy}},docs,py37,py27,pypy3,py36,py35,py34,pypy
+envlist = lint-{code-style,dist-meta,mypy},docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     coverage
     pretend
     pytest
-    pyblake2; python_version<"3.6"
+    pyblake2; python_version<"3.6" and platform_python_implementation=="CPython"
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,13 @@ deps =
     mypy
 commands =
     mypy --ignore-missing-imports --follow-imports=skip twine/ tests/
+
+[testenv:lint]
+deps =
+    {[testenv:lint-code-style]deps}
+    {[testenv:lint-dist-meta]deps}
+    {[testenv:lint-mypy]deps}
+commands =
+    {[testenv:lint-code-style]commands}
+    {[testenv:lint-dist-meta]commands}
+    -{[testenv:lint-mypy]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint{,-mypy},docs,py37,py27,pypy3,py36,py35,py34,pypy
+envlist = lint{,-{code-style,dist-meta,mypy}},docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
 deps =
@@ -29,18 +29,22 @@ commands =
     python setup.py -q bdist_wheel sdist
     twine upload --skip-existing dist/*
 
+[testenv:lint-code-style]
+deps =
+    flake8
+commands =
+    flake8 twine/ tests/
+
+[testenv:lint-dist-meta]
+deps =
+    check-manifest
+commands =
+    check-manifest -v
+    python setup.py sdist
+    twine check dist/*
+
 [testenv:lint-mypy]
 deps =
     mypy
 commands =
     mypy --ignore-missing-imports --follow-imports=skip twine/ tests/
-
-[testenv:lint]
-deps =
-    flake8
-    check-manifest
-commands =
-    flake8 twine/ tests/
-    check-manifest -v
-    python setup.py sdist
-    twine check dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-{code-style,dist-meta,mypy},docs,py37,py27,pypy3,py36,py35,py34,pypy
+envlist = lint,docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ commands =
     check-manifest -v
     python setup.py sdist
     twine check dist/*
-    -mypy -s twine/ tests/
+    -mypy --ignore-missing-imports --follow-imports=skip twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     coverage
     pretend
     pytest
-    py27,py34,py35: pyblake2
+    pyblake2; python_version<"3.6"
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,docs,py37,py27,pypy3,py36,py35,py34,pypy
+envlist = lint{,-mypy},docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
 deps =
@@ -29,14 +29,18 @@ commands =
     python setup.py -q bdist_wheel sdist
     twine upload --skip-existing dist/*
 
+[testenv:lint-mypy]
+deps =
+    mypy
+commands =
+    mypy --ignore-missing-imports --follow-imports=skip twine/ tests/
+
 [testenv:lint]
 deps =
     flake8
     check-manifest
-    mypy
 commands =
     flake8 twine/ tests/
     check-manifest -v
     python setup.py sdist
     twine check dist/*
-    -mypy --ignore-missing-imports --follow-imports=skip twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27,pypy,py34,py35,py36,py37,pypy3,docs
+envlist = lint,docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Demo: https://travis-ci.org/pypa/twine/builds/466680913.
`mypy` job fails (as it should) but doesn't affect the overall build status (by design).
Links/buttons to Travis help people to easily find out where the CI page is actually located.
I assumed that it's probably more important to see certain jobs passing faster so I've done some reordering.
Changing pyblake2 conditionals to env markers help tox support "check with current python" mode.
Smaller linting jobs help visually identifying what went wrong faster.