### PR TITLE
Use environment markers to define pyblake2 dependency in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,3 @@ ignore =
 
 [metadata]
 license_file = LICENSE
-requires-dist =
-    tqdm >= 4.14
-    requests >= 2.5.0, != 2.15, != 2.16
-    requests-toolbelt >= 0.8.0
-    pkginfo >= 1.4.2
-    setuptools >= 0.7.0
-    pyblake2; extra == 'with-blake2' and python_version < '3.6'
-    keyring; extra == 'keyring'

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,7 @@
 # limitations under the License.
 from setuptools import setup
 
-import sys
-
 import twine
-
-
-blake2_requires = []
-
-if sys.version_info[:2] < (3, 6):
-    blake2_requires += [
-        "pyblake2",
-    ]
 
 
 setup(
@@ -88,7 +78,9 @@ setup(
         "tqdm >= 4.14",
     ],
     extras_require={
-        'with-blake2': blake2_requires,
+        'with-blake2': [
+            'pyblake2; python_version<"3.6" and platform_python_implementation=="CPython"',
+        ],
         'keyring': [
             'keyring',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 2.4
 envlist = lint,docs,py37,py27,pypy3,py36,py35,py34,pypy
 
 [testenv]
@@ -6,7 +7,8 @@ deps =
     coverage
     pretend
     pytest
-    pyblake2; python_version<"3.6" and platform_python_implementation=="CPython"
+extras =
+    with-blake2
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m


### PR DESCRIPTION
Allows removing logic from setup.py, resulting in a more consistent
package definition across Python versions.

Can remove duplicate information from both setup.cfg and tox.ini to use
setup.py as a single source of dependency truth. To remove from tox.ini,
use the "extras" feature, which bumps the tox min version to 2.4.

https://tox.readthedocs.io/en/latest/config.html#conf-extras

> A list of “extras” to be installed with the sdist or develop install.
> For example, extras = testing is equivalent to [testing] in a pip
> install command.