### PR TITLE
Replace all StringIO uses with io.StringIO

### DIFF
--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -18,11 +18,7 @@ import argparse
 import cgi
 import re
 import sys
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from _io import StringIO
+from io import StringIO
 
 import readme_renderer.rst
 

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -17,11 +17,7 @@ from __future__ import unicode_literals
 import os
 import re
 import zipfile
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from _io import StringIO
+from io import StringIO
 
 from pkginfo import distribution
 from pkginfo.distribution import Distribution


### PR DESCRIPTION
`io.StringIO` is available on all supported Pythons (2.7 & 3.4+). Can replace unnecessary compatibility shim with a direct import.

https://docs.python.org/3/library/io.html#io.StringIO
https://docs.python.org/2/library/io.html#io.StringIO