### PR TITLE
Fix OpenSSL issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "pkginfo >= 1.4.2",
         "readme_renderer >= 21.0",
         "requests >= 2.5.0, != 2.15, != 2.16",
-        "requests-toolbelt == 0.8.0",
+        "requests-toolbelt >= 0.8.0, != 0.9.0",
         "setuptools >= 0.7.0",
         "tqdm >= 4.14",
     ],

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "pkginfo >= 1.4.2",
         "readme_renderer >= 21.0",
         "requests >= 2.5.0, != 2.15, != 2.16",
-        "requests-toolbelt >= 0.8.0",
+        "requests-toolbelt == 0.8.0",
         "setuptools >= 0.7.0",
         "tqdm >= 4.14",
     ],


### PR DESCRIPTION
Fixes #446 

Using `twine` to push a package to a repository over HTTPS recently began resulting in the following stack trace:

```
Traceback (most recent call last):
  File "/usr/local/bin/twine", line 6, in <module>
    from twine.__main__ import main
  File "/usr/local/lib/python3.6/site-packages/twine/__main__.py", line 23, in <module>
    from twine.cli import dispatch
  File "/usr/local/lib/python3.6/site-packages/twine/cli.py", line 23, in <module>
    import requests_toolbelt
  File "/usr/local/lib/python3.6/site-packages/requests_toolbelt/__init__.py", line 12, in <module>
    from .adapters import SSLAdapter, SourceAddressAdapter
  File "/usr/local/lib/python3.6/site-packages/requests_toolbelt/adapters/__init__.py", line 12, in <module>
    from .ssl import SSLAdapter
  File "/usr/local/lib/python3.6/site-packages/requests_toolbelt/adapters/ssl.py", line 16, in <module>
    from .._compat import poolmanager
  File "/usr/local/lib/python3.6/site-packages/requests_toolbelt/_compat.py", line 59, in <module>
    from urllib3.contrib.pyopenssl import PyOpenSSLContext
  File "/usr/local/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
ModuleNotFoundError: No module named 'OpenSSL'
```

A [recent change](https://github.com/requests/toolbelt/compare/0.8.0..0.9.0) to `requests-toolbelt` results in twine attempting to reference the `pyopenssl` library when it is not a requirement.

While this is being addressed (https://github.com/requests/toolbelt/issues/241) in `requests-toolbelt`, we should pin twine to the last working version.