### PR TITLE
Restore prompts while retaining support for suppressing prompts

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,6 +126,26 @@ def test_get_config_missing(tmpdir):
     }
 
 
+def test_empty_userpass(tmpdir):
+    """
+    Empty username and password may be supplied to suppress
+    prompts. See #426.
+    """
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with open(pypirc, "w") as fp:
+        fp.write(textwrap.dedent("""
+            [pypi]
+            username=
+            password=
+        """))
+
+    config = utils.get_config(pypirc)
+    pypi = config['pypi']
+
+    assert pypi['username'] == pypi['password'] == ''
+
+
 def test_get_repository_config_missing(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,6 +249,12 @@ def test_get_password_keyring_defers_to_prompt(monkeypatch):
     assert pw == 'entered pw'
 
 
+def test_no_password_defers_to_prompt(monkeypatch):
+    monkeypatch.setattr(utils, 'password_prompt', lambda prompt: 'entered pw')
+    pw = utils.get_password('system', 'user', None, {'password': None})
+    assert pw == 'entered pw'
+
+
 def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
     import collections
     Credential = collections.namedtuple('Credential', 'username password')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,6 +255,12 @@ def test_no_password_defers_to_prompt(monkeypatch):
     assert pw == 'entered pw'
 
 
+def test_empty_password_bypasses_prompt(monkeypatch):
+    monkeypatch.setattr(utils, 'password_prompt', lambda prompt: 'entered pw')
+    pw = utils.get_password('system', 'user', None, {'password': ''})
+    assert pw == ''
+
+
 def test_get_username_and_password_keyring_overrides_prompt(monkeypatch):
     import collections
     Credential = collections.namedtuple('Credential', 'username password')


### PR DESCRIPTION
As discussed in #450, the work in #426 had some unintended side-effects, namely that it unconditionally suppressed prompts for username and password (and thus also keyring resolution).

This PR goes back in time, committing tests to the code prior to #426 plus some commits on top of #426, then merges the two, fixing the failing tests.