### PR TITLE
Add a line to state register is a no op since Warehouse

### DIFF
--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -49,10 +49,7 @@ def register(register_settings, package):
 def main(args):
     parser = argparse.ArgumentParser(
         prog="twine register",
-        description=(
-            "register operation is a no op with PyPI since " +
-            "Warehouse was released in 2018"
-        )
+        description="register operation is not required with PyPI.org",
     )
     settings.Settings.register_argparse_arguments(parser)
     parser.add_argument(

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -47,7 +47,13 @@ def register(register_settings, package):
 
 
 def main(args):
-    parser = argparse.ArgumentParser(prog="twine register")
+    parser = argparse.ArgumentParser(
+        prog="twine register",
+        description=(
+            "register operation is a no op with PyPI since " +
+            "Warehouse was released in 2018"
+        )
+    )
     settings.Settings.register_argparse_arguments(parser)
     parser.add_argument(
         "package",


### PR DESCRIPTION
- I understand why it has not been removed + I feel register help should state this
- Happy to change the wording etc.
```
cooper-mbp1:twine cooper$ /tmp/tt/bin/twine register --help
usage: twine register [-h] [-r REPOSITORY] [--repository-url REPOSITORY_URL]
                      [-s] [--sign-with SIGN_WITH] [-i IDENTITY] [-u USERNAME]
                      [-p PASSWORD] [-c COMMENT] [--config-file CONFIG_FILE]
                      [--skip-existing] [--cert path] [--client-cert path]
                      [--verbose] [--disable-progress-bar]
                      package

register operation is a no op with PyPI since Warehouse was released in 2018
```

#311 