### PR TITLE
Add 'md' as optional feature to check Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,8 @@ setup(
         'keyring': [
             'keyring',
         ],
+        'md': [
+            'cmarkgfm>=0.2.0',
+        ],
     },
 )


### PR DESCRIPTION
Since "md" is an optional feature in `readme_renderer` (https://github.com/pypa/readme_renderer/blob/7bf7529296acfa7db0edf7914cb4571d691b63ee/setup.py#L77), it is convenient to provide this also in twine.

Without `cmarkgfm` installed, `twine check dist/*` fails when `long_description_content_type` is set to `"text/markdown"`. With this pull-request it is  possible to install twine with Markdown support analogous to readme_renderer:

    pip install twine[md]

What do you think about that?