### PR TITLE
WIP: mypy support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,9 +2,11 @@ include LICENSE
 include README.rst
 include AUTHORS
 include .coveragerc
+include mypy.ini
 
 recursive-include tests *.py *.whl deprecated-pypirc
 recursive-include docs *.bat *.empty *.py *.rst Makefile *.txt
+recursive-include _stubs *.pyi
 
 prune docs/_build
 prune *.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include mypy.ini
 
 recursive-include tests *.py *.whl deprecated-pypirc
 recursive-include docs *.bat *.empty *.py *.rst Makefile *.txt
-recursive-include _stubs *.pyi
+recursive-include stubs *.pyi
 
 prune docs/_build
 prune *.yml

--- a/_stubs/twine/__main__.pyi
+++ b/_stubs/twine/__main__.pyi
@@ -1,4 +1,0 @@
-from typing import Optional
-
-
-def main() -> Optional[str]: ...

--- a/_stubs/twine/__main__.pyi
+++ b/_stubs/twine/__main__.pyi
@@ -1,0 +1,4 @@
+from typing import Optional
+
+
+def main() -> Optional[str]: ...

--- a/_stubs/twine/cli.pyi
+++ b/_stubs/twine/cli.pyi
@@ -1,0 +1,3 @@
+from typing import Optional, Sequence
+
+def dispatch(argv: Optional[Sequence[str]]) -> None: ...

--- a/_stubs/twine/cli.pyi
+++ b/_stubs/twine/cli.pyi
@@ -1,3 +1,0 @@
-from typing import Optional, Sequence
-
-def dispatch(argv: Optional[Sequence[str]]) -> None: ...

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
-; TODO: Docs seem to recommend a `stubs` directory
+; Docs seem to recommend this directory name
 ; https://mypy.readthedocs.io/en/latest/stubs.html?highlight=MYPYPATH
-; mypy_path = ./_stubs
+mypy_path = ./stubs
 check_untyped_defs = True
 ; TODO: Make this more granular; docs recommend it as a "last resort"
 ; https://mypy.readthedocs.io/en/latest/existing_code.html#start-small

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,7 @@
 [mypy]
+mypy_path = ./_stubs
 check_untyped_defs = True
-disallow_any_generics = True
-strict_optional = True
-no_implicit_optional = True
-scripts_are_modules = True
+ignore_missing_imports = True
 show_traceback = True
+strict_optional = True
 warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,8 @@
 [mypy]
-mypy_path = ./_stubs
-check_untyped_defs = True
+; mypy_path = ./_stubs
+; check_untyped_defs = True
 ignore_missing_imports = True
-follow_imports = skip
-show_traceback = True
-strict_optional = True
-warn_no_return = True
+; follow_imports = skip
+; show_traceback = True
+; strict_optional = True
+; warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 mypy_path = ./_stubs
 check_untyped_defs = True
 ignore_missing_imports = True
+follow_imports = skip
 show_traceback = True
 strict_optional = True
 warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 ; TODO: Docs seem to recommend a `stubs` directory
 ; https://mypy.readthedocs.io/en/latest/stubs.html?highlight=MYPYPATH
 ; mypy_path = ./_stubs
-; check_untyped_defs = True
+check_untyped_defs = True
 ; TODO: Make this more granular; docs recommend it as a "last resort"
 ; https://mypy.readthedocs.io/en/latest/existing_code.html#start-small
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,12 @@
 [mypy]
+; TODO: Docs seem to recommend a `stubs` directory
+; https://mypy.readthedocs.io/en/latest/stubs.html?highlight=MYPYPATH
 ; mypy_path = ./_stubs
 ; check_untyped_defs = True
+; TODO: Make this more granular; docs recommend it as a "last resort"
+; https://mypy.readthedocs.io/en/latest/existing_code.html#start-small
 ignore_missing_imports = True
+; NOTE: Docs recommend `normal` or `silent` for an existing codebase
+; https://mypy.readthedocs.io/en/latest/running_mypy.html#following-imports
 ; follow_imports = skip
-; show_traceback = True
-; strict_optional = True
-; warn_no_return = True
+show_traceback = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+check_untyped_defs = True
+disallow_any_generics = True
+strict_optional = True
+no_implicit_optional = True
+scripts_are_modules = True
+show_traceback = True
+warn_no_return = True

--- a/stubs/twine/__main__.pyi
+++ b/stubs/twine/__main__.pyi
@@ -1,0 +1,4 @@
+from typing import Optional
+
+
+def main() -> Optional[str]: ...

--- a/stubs/twine/cli.pyi
+++ b/stubs/twine/cli.pyi
@@ -1,0 +1,4 @@
+from typing import Optional, Sequence
+
+
+def dispatch(argv: Optional[Sequence[str]]) -> None: ...

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
 deps =
     mypy
 commands =
-    mypy --ignore-missing-imports --follow-imports=skip twine/ tests/
+    mypy twine tests
 
 [testenv:lint]
 deps =

--- a/twine/commands/__init__.py
+++ b/twine/commands/__init__.py
@@ -19,7 +19,7 @@ import os.path
 
 from twine import exceptions
 
-__all__ = []
+__all__ = []  # type: ignore # TODO: List[str] in stub file
 
 
 def _group_wheel_files_first(files):

--- a/twine/commands/__init__.py
+++ b/twine/commands/__init__.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
+from typing import List
 
 import glob
 import os.path
 
 from twine import exceptions
 
-__all__ = []  # type: ignore # TODO: List[str] in stub file
+__all__: List[str] = []
 
 
 def _group_wheel_files_first(files):

--- a/twine/package.py
+++ b/twine/package.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, unicode_literals, print_function
+from typing import Optional, Tuple
+
 import collections
 import hashlib
 import io
@@ -87,7 +89,7 @@ class PackageFile(object):
 
         if dtype == "bdist_egg":
             pkgd = pkg_resources.Distribution.from_filename(filename)
-            py_version = pkgd.py_version
+            py_version = pkgd.py_version  # type: Optional[str]
         elif dtype == "bdist_wheel":
             py_version = meta.py_version
         elif dtype == "bdist_wininst":
@@ -162,7 +164,7 @@ class PackageFile(object):
 
     def sign(self, sign_with, identity):
         print("Signing {}".format(self.basefilename))
-        gpg_args = (sign_with, "--detach-sign")
+        gpg_args = (sign_with, "--detach-sign")  # type: Tuple[str, ...]
         if identity:
             gpg_args += ("--local-user", identity)
         gpg_args += ("-a", self.filename)

--- a/twine/package.py
+++ b/twine/package.py
@@ -25,9 +25,10 @@ try:
     from hashlib import blake2b
 except ImportError:
     try:
-        from pyblake2 import blake2b
+        # https://github.com/python/mypy/issues/1153
+        from pyblake2 import blake2b  # type: ignore
     except ImportError:
-        blake2b = None
+        blake2b = None  # type: ignore
 
 from twine.wheel import Wheel
 from twine.wininst import WinInst

--- a/twine/package.py
+++ b/twine/package.py
@@ -89,7 +89,7 @@ class PackageFile(object):
 
         if dtype == "bdist_egg":
             pkgd = pkg_resources.Distribution.from_filename(filename)
-            py_version = pkgd.py_version  # type: Optional[str]
+            py_version: Optional[str] = pkgd.py_version
         elif dtype == "bdist_wheel":
             py_version = meta.py_version
         elif dtype == "bdist_wininst":
@@ -164,7 +164,7 @@ class PackageFile(object):
 
     def sign(self, sign_with, identity):
         print("Signing {}".format(self.basefilename))
-        gpg_args = (sign_with, "--detach-sign")  # type: Tuple[str, ...]
+        gpg_args: Tuple[str, ...] = (sign_with, "--detach-sign")
         if identity:
             gpg_args += ("--local-user", identity)
         gpg_args += ("-a", self.filename)

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, unicode_literals, print_function
+from typing import Dict
 
 import sys
 
@@ -55,7 +56,7 @@ class Repository(object):
         self.session.headers['User-Agent'] = self._make_user_agent_string()
         for scheme in ('http://', 'https://'):
             self.session.mount(scheme, self._make_adapter_with_retries())
-        self._releases_json_data = {}
+        self._releases_json_data = {}  # type: Dict[str, Dict]
         self.disable_progress_bar = disable_progress_bar
 
     @staticmethod

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -56,7 +56,7 @@ class Repository(object):
         self.session.headers['User-Agent'] = self._make_user_agent_string()
         for scheme in ('http://', 'https://'):
             self.session.mount(scheme, self._make_adapter_with_retries())
-        self._releases_json_data = {}  # type: Dict[str, Dict]
+        self._releases_json_data: Dict[str, Dict] = {}
         self.disable_progress_bar = disable_progress_bar
 
     @staticmethod

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -28,8 +28,8 @@ from requests.exceptions import HTTPError
 try:
     import configparser
 except ImportError:  # pragma: no cover
-    import ConfigParser as configparser
-
+    import ConfigParser as configparser  # type: ignore
+    # https://github.com/python/mypy/issues/1153
 try:
     from urlparse import urlparse, urlunparse
 except ImportError:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function
 from __future__ import unicode_literals
+from typing import DefaultDict, Dict, Optional
 
 import os
 import os.path
@@ -64,7 +65,10 @@ def get_config(path="~/.pypirc"):
     index_servers = ["pypi", "testpypi"]
 
     # default configuration for each repository
-    defaults = {"username": None, "password": None}
+    defaults = {
+        "username": None,
+        "password": None
+    }  # type: Dict[str, Optional[str]]
 
     # Expand user strings in the path
     path = os.path.expanduser(path)
@@ -82,7 +86,8 @@ def get_config(path="~/.pypirc"):
             if parser.has_option("server-login", key):
                 defaults[key] = parser.get("server-login", key)
 
-    config = collections.defaultdict(lambda: defaults.copy())
+    config = collections.defaultdict(lambda: defaults.copy()) \
+        # type: DefaultDict[str, Dict]
 
     # don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -65,10 +65,10 @@ def get_config(path="~/.pypirc"):
     index_servers = ["pypi", "testpypi"]
 
     # default configuration for each repository
-    defaults = {
+    defaults: Dict[str, Optional[str]] = {
         "username": None,
         "password": None
-    }  # type: Dict[str, Optional[str]]
+    }
 
     # Expand user strings in the path
     path = os.path.expanduser(path)
@@ -86,8 +86,8 @@ def get_config(path="~/.pypirc"):
             if parser.has_option("server-login", key):
                 defaults[key] = parser.get("server-login", key)
 
-    config = collections.defaultdict(lambda: defaults.copy()) \
-        # type: DefaultDict[str, Dict]
+    config: DefaultDict[str, Dict] = \
+        collections.defaultdict(lambda: defaults.copy())
 
     # don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY


### PR DESCRIPTION
Related to #231, building on #344.

I'm a newbie to mypy, but at @brainwane's suggestion, I decided to dive in as an exercise. I've skimmed the [Zulip blog](https://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/) (which is somewhat outdated, e.g. CLI options and broken links), read mypy's [getting started](https://mypy.readthedocs.io/en/latest/getting_started.html) and [existing codebase](https://mypy.readthedocs.io/en/latest/existing_code.html) docs, and reviewed the existing PR's.

I got `lint-mypy` to pass in 8f569a5 (covering some of the ground from #359), then added `check_untyped_defs` as suggested by Zulip. I know the preference is to use stub files, but the [initial batch of errors](https://github.com/pypa/twine/files/3268924/check_untyped_def_errors.txt) seemed to require local variable annotations. I'd love some feedback on this direction.

Current errors:

```
twine/wheel.py:56: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
twine/utils.py:216: error: Module has no attribute "get_credential"
twine/utils.py:241: error: Module has no attribute "get_password"
tests/test_check.py:27: error: "Callable[[str], int]" has no attribute "calls"
tests/test_check.py:38: error: "Callable[[str], int]" has no attribute "calls"
```