### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,7 +27,4 @@ coverage:
   fixes:
     - .tox
 
-comment:
-  layout: "header, diff, changes, sunburst, uncovered, tree"
-  branches: null
-  behavior: default
+comment: off


### PR DESCRIPTION
Codecov can be pretty noisy with its pull request comments (e.g., in #478) and the comments are redundant given that the status checks have the same information.