### PR TITLE
Handle missing GPG executable graciously

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -60,7 +60,7 @@ def test_sign_file_with_identity(monkeypatch):
 
 
 def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
-    replaced_check_call = pretend.raiser(FileNotFoundError('not found'))
+    replaced_check_call = pretend.raiser(package.FileNotFoundError('not found'))
     monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
     gpg_args = ('gpg', '--detach-sign', '-a', 'pypircfile')
 
@@ -73,7 +73,7 @@ def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
 def test_run_gpg_no_fallback_if_not_using_gpg(monkeypatch):
 
     def check_call(*a, **kw):
-        raise FileNotFoundError('gpg not found')
+        raise package.FileNotFoundError('gpg not found')
 
     replaced_check_call = pretend.call_recorder(check_call)
     monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
@@ -88,7 +88,7 @@ def test_run_gpg_falls_back_to_gpg2(monkeypatch):
 
     def check_call(arg_list):
         if arg_list[0] == 'gpg':
-            raise FileNotFoundError('gpg not found')
+            raise package.FileNotFoundError('gpg not found')
 
     replaced_check_call = pretend.call_recorder(check_call)
     monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -60,7 +60,9 @@ def test_sign_file_with_identity(monkeypatch):
 
 
 def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
-    replaced_check_call = pretend.raiser(package.FileNotFoundError('not found'))
+    replaced_check_call = pretend.raiser(
+        package.FileNotFoundError('not found')
+    )
     monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
     gpg_args = ('gpg', '--detach-sign', '-a', 'pypircfile')
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -72,18 +72,17 @@ def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
     assert 'executables not available' in err.value.args[0]
 
 
-def test_run_gpg_no_fallback_if_not_using_gpg(monkeypatch):
-
-    def check_call(*a, **kw):
-        raise package.FileNotFoundError('gpg not found')
-
-    replaced_check_call = pretend.call_recorder(check_call)
+def test_run_gpg_raises_exception_if_not_using_gpg(monkeypatch):
+    replaced_check_call = pretend.raiser(
+        package.FileNotFoundError('not found')
+    )
     monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
     gpg_args = ('not_gpg', '--detach-sign', '-a', 'pypircfile')
 
-    package.PackageFile.run_gpg(gpg_args)
+    with pytest.raises(exceptions.InvalidSigningExecutable) as err:
+        package.PackageFile.run_gpg(gpg_args)
 
-    assert replaced_check_call.calls == [pretend.call(gpg_args)]
+    assert 'not_gpg executable not available' in err.value.args[0]
 
 
 def test_run_gpg_falls_back_to_gpg2(monkeypatch):

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -85,6 +85,12 @@ class InvalidSigningConfiguration(TwineException):
     pass
 
 
+class InvalidSigningExecutable(TwineException):
+    """Signing executable must be installed on system."""
+
+    pass
+
+
 class InvalidConfiguration(TwineException):
     """Raised when configuration is invalid."""
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -190,12 +190,11 @@ class PackageFile(object):
             subprocess.check_call(gpg_args)
             return
         except FileNotFoundError:
-            print("{} executable not available.".format(gpg_args[0]))
+            if gpg_args[0] != "gpg":
+                raise exceptions.InvalidSigningExecutable(
+                    "{} executable not available.".format(gpg_args[0]))
 
-        if not gpg_args[0] == "gpg":
-            return
-
-        print("Attempting fallback to gpg2.")
+        print("gpg executable not available. Attempting fallback to gpg2.")
         try:
             subprocess.check_call(("gpg2",) + gpg_args[1:])
         except FileNotFoundError:

--- a/twine/package.py
+++ b/twine/package.py
@@ -33,6 +33,12 @@ from twine.wheel import Wheel
 from twine.wininst import WinInst
 from twine import exceptions
 
+try:
+    FileNotFoundError = FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError  # Py2
+
+
 DIST_TYPES = {
     "bdist_wheel": Wheel,
     "bdist_wininst": WinInst,


### PR DESCRIPTION
If GPG not installed, handle the FileNotFound exception.
Fall back to trying with gpg2 if the original call was to gpg.

Closes #456 