### PR TITLE
Fix codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 codecov:
   branch: master
-  bot: null
 
 coverage:
   precision: 2
@@ -11,20 +10,11 @@ coverage:
     project:
       default:
         target: auto
-        threshold: null
-        branches: null
 
     patch:
       default:
         target: auto
-        branches: null
 
-    changes:
-      default:
-        branches: null
-
-  ignore: null
-  fixes:
-    - .tox
+    changes: no
 
 comment: off


### PR DESCRIPTION
Turns out the existing configuration was invalid:

```
$ cat codecov.yml | curl --data-binary @- https://codecov.io/validate

Invalid value '.tox' (str): must match pattern ^[^\:]*::[^\:]*$ (at fixes[0])
```