### PR TITLE
Pin against semantic-version 2.7 or later

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,6 @@ Sphinx>=1.7.0
 sphinx_rtd_theme>=0.2.4
 tox>=2.9.1
 twine>=1.10.0
+
+# workaround for #492
+semantic-version<2.7


### PR DESCRIPTION
Workaround for #492 