### PR TITLE
Prepare for 2.0 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@
 =========
 Changelog
 =========
+* :release:`2.0.0 <2019-09-23>`
 * :feature:`437`: Twine now requires Python 3.6 or later.
 * :bug:`491` Require requests 2.20 or later to avoid reported security
   vulnerabilities in earlier releases.

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -20,7 +20,7 @@ __title__ = "twine"
 __summary__ = "Collection of utilities for publishing packages on PyPI"
 __uri__ = "https://twine.readthedocs.io/"
 
-__version__ = "1.15.0"
+__version__ = "2.0.0"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"


### PR DESCRIPTION
I'd like to make the 2.0 release, dropping support for Python 3.5 and earlier including Python 2.7. Since #469 is still a WIP, it can follow in a subsequent release.