### PR TITLE
Add helpful error message for incorrect PyPI URL

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,8 +18,10 @@ from requests.exceptions import HTTPError
 from twine.commands import upload
 from twine import package, cli, exceptions
 import twine
-from twine.exceptions import PyPIMethodNotAllowed, \
-    UploadToDeprecatedPyPIDetected
+from twine.exceptions import (
+    InvalidPyPIUploadURL,
+    UploadToDeprecatedPyPIDetected,
+)
 
 import helpers
 
@@ -300,7 +302,7 @@ def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = repo_url
 
-    with pytest.raises(PyPIMethodNotAllowed):
+    with pytest.raises(InvalidPyPIUploadURL):
         upload.upload(upload_settings, [
             WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
         ])

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,7 +18,8 @@ from requests.exceptions import HTTPError
 from twine.commands import upload
 from twine import package, cli, exceptions
 import twine
-from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
+from twine.exceptions import PyPIMethodNotAllowed, \
+    UploadToDeprecatedPyPIDetected
 
 import helpers
 
@@ -290,19 +291,31 @@ def test_values_from_env(monkeypatch):
 
 @pytest.mark.parametrize('repo_url', [
     "https://upload.pypi.org/",
-    "https://test.pypi.org/"
+    "https://test.pypi.org/",
+    "https://pypi.org/"
 ])
-def test_check_status_code_for_wrong_repo_url(repo_url, make_settings, capsys):
+def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     upload_settings = make_settings()
 
     # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = repo_url
 
-    with pytest.raises(HTTPError):
+    with pytest.raises(PyPIMethodNotAllowed):
         upload.upload(upload_settings, [
             WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
         ])
 
-    captured = capsys.readouterr()
-    assert captured.out.count(DEFAULT_REPOSITORY) == 1
-    assert captured.out.count(TEST_REPOSITORY) == 1
+
+@pytest.mark.parametrize('repo_url', [
+    "https://pypi.python.org",
+    "https://testpypi.python.org"
+])
+def test_check_status_code_for_deprecated_pypi_url(repo_url):
+    response = pretend.stub(
+        status_code=410,
+        url=repo_url
+    )
+
+    # value of Verbose doesn't matter for this check
+    with pytest.raises(UploadToDeprecatedPyPIDetected):
+        upload.check_status_code(response, False)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,6 +18,7 @@ from requests.exceptions import HTTPError
 from twine.commands import upload
 from twine import package, cli, exceptions
 import twine
+from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
 
 import helpers
 
@@ -27,8 +28,6 @@ RELEASE_URL = 'https://pypi.org/project/twine/1.5.0/'
 NEW_SDIST_FIXTURE = 'tests/fixtures/twine-1.6.5.tar.gz'
 NEW_WHEEL_FIXTURE = 'tests/fixtures/twine-1.6.5-py2.py3-none-any.whl'
 NEW_RELEASE_URL = 'https://pypi.org/project/twine/1.6.5/'
-DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
-TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 
 
 def test_successful_upload(make_settings, capsys):
@@ -289,10 +288,10 @@ def test_values_from_env(monkeypatch):
     assert "/foo/bar.crt" == upload_settings.cacert
 
 
-def test_check_status_code(make_settings, capsys):
+def test_check_status_code_for_wrong_repo_url(make_settings, capsys):
     upload_settings = make_settings()
 
-    # override default upload_settings
+    # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = \
         "https://upload.pypi.org"
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -27,6 +27,8 @@ RELEASE_URL = 'https://pypi.org/project/twine/1.5.0/'
 NEW_SDIST_FIXTURE = 'tests/fixtures/twine-1.6.5.tar.gz'
 NEW_WHEEL_FIXTURE = 'tests/fixtures/twine-1.6.5-py2.py3-none-any.whl'
 NEW_RELEASE_URL = 'https://pypi.org/project/twine/1.6.5/'
+DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
+TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 
 
 def test_successful_upload(make_settings, capsys):
@@ -285,3 +287,20 @@ def test_values_from_env(monkeypatch):
     assert "pypipassword" == upload_settings.password
     assert "pypiuser" == upload_settings.username
     assert "/foo/bar.crt" == upload_settings.cacert
+
+
+def test_check_status_code(make_settings, capsys):
+    upload_settings = make_settings()
+
+    # override default upload_settings
+    upload_settings.repository_config['repository'] = \
+        "https://upload.pypi.org"
+
+    with pytest.raises(HTTPError):
+        upload.upload(upload_settings, [
+            WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
+        ])
+
+    captured = capsys.readouterr()
+    assert captured.out.count(DEFAULT_REPOSITORY) == 1
+    assert captured.out.count(TEST_REPOSITORY) == 1

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -18,10 +18,6 @@ from requests.exceptions import HTTPError
 from twine.commands import upload
 from twine import package, cli, exceptions
 import twine
-from twine.exceptions import (
-    InvalidPyPIUploadURL,
-    UploadToDeprecatedPyPIDetected,
-)
 
 import helpers
 
@@ -302,7 +298,7 @@ def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = repo_url
 
-    with pytest.raises(InvalidPyPIUploadURL):
+    with pytest.raises(twine.exceptions.InvalidPyPIUploadURL):
         upload.upload(upload_settings, [
             WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
         ])
@@ -319,5 +315,5 @@ def test_check_status_code_for_deprecated_pypi_url(repo_url):
     )
 
     # value of Verbose doesn't matter for this check
-    with pytest.raises(UploadToDeprecatedPyPIDetected):
+    with pytest.raises(twine.exceptions.UploadToDeprecatedPyPIDetected):
         upload.check_status_code(response, False)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -288,12 +288,15 @@ def test_values_from_env(monkeypatch):
     assert "/foo/bar.crt" == upload_settings.cacert
 
 
-def test_check_status_code_for_wrong_repo_url(make_settings, capsys):
+@pytest.mark.parametrize('repo_url', [
+    "https://upload.pypi.org/",
+    "https://test.pypi.org/"
+])
+def test_check_status_code_for_wrong_repo_url(repo_url, make_settings, capsys):
     upload_settings = make_settings()
 
     # override defaults to use incorrect URL
-    upload_settings.repository_config['repository'] = \
-        "https://upload.pypi.org"
+    upload_settings.repository_config['repository'] = repo_url
 
     with pytest.raises(HTTPError):
         upload.upload(upload_settings, [

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -298,7 +298,7 @@ def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = repo_url
 
-    with pytest.raises(twine.exceptions.InvalidPyPIUploadURL):
+    with pytest.raises(exceptions.InvalidPyPIUploadURL):
         upload.upload(upload_settings, [
             WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
         ])
@@ -315,5 +315,5 @@ def test_check_status_code_for_deprecated_pypi_url(repo_url):
     )
 
     # value of Verbose doesn't matter for this check
-    with pytest.raises(twine.exceptions.UploadToDeprecatedPyPIDetected):
+    with pytest.raises(exceptions.UploadToDeprecatedPyPIDetected):
         upload.check_status_code(response, False)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -298,22 +298,7 @@ def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     # override defaults to use incorrect URL
     upload_settings.repository_config['repository'] = repo_url
 
-    with pytest.raises(exceptions.InvalidPyPIUploadURL):
+    with pytest.raises(twine.exceptions.InvalidPyPIUploadURL):
         upload.upload(upload_settings, [
             WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
         ])
-
-
-@pytest.mark.parametrize('repo_url', [
-    "https://pypi.python.org",
-    "https://testpypi.python.org"
-])
-def test_check_status_code_for_deprecated_pypi_url(repo_url):
-    response = pretend.stub(
-        status_code=410,
-        url=repo_url
-    )
-
-    # value of Verbose doesn't matter for this check
-    with pytest.raises(exceptions.UploadToDeprecatedPyPIDetected):
-        upload.check_status_code(response, False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,8 +16,9 @@ import os.path
 import textwrap
 
 import pytest
+import pretend
 
-from twine import utils
+from twine import utils, exceptions
 
 import helpers
 
@@ -389,3 +390,18 @@ def test_no_positional_on_function():
         t(1)
 
     assert t(foo=True)
+
+
+@pytest.mark.parametrize('repo_url', [
+    "https://pypi.python.org",
+    "https://testpypi.python.org"
+])
+def test_check_status_code_for_deprecated_pypi_url(repo_url):
+    response = pretend.stub(
+        status_code=410,
+        url=repo_url
+    )
+
+    # value of Verbose doesn't matter for this check
+    with pytest.raises(exceptions.UploadToDeprecatedPyPIDetected):
+        utils.check_status_code(response, False)

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -62,16 +62,16 @@ def check_status_code(response, verbose):
             f"It appears you're uploading to pypi.python.org (or "
             f"testpypi.python.org). You've received a 410 error response. "
             f"Uploading to those sites is deprecated. The new sites are "
-            f"pypi.org and test.pypi.org. Try using {utils.DEFAULT_REPOSITORY} "
-            f"(or {utils.TEST_REPOSITORY}) to upload your packages instead. "
+            f"pypi.org and test.pypi.org. Try using {utils.DEFAULT_REPOSITORY}"
+            f" (or {utils.TEST_REPOSITORY}) to upload your packages instead. "
             f"These are the default URLs for Twine now. More at "
             f"https://packaging.python.org/guides/migrating-to-pypi-org/.")
     elif response.status_code == 405 and "pypi.org" in response.url:
         raise exceptions.InvalidPyPIUploadURL(
             f"It appears you're trying to upload to pypi.org but have an "
             f"invalid URL. You probably want one of these two URLs: "
-            f"{utils.DEFAULT_REPOSITORY} or {utils.TEST_REPOSITORY}. Check your"
-            f" --repository-url value.")
+            f"{utils.DEFAULT_REPOSITORY} or {utils.TEST_REPOSITORY}. Check "
+            f"your --repository-url value.")
     try:
         response.raise_for_status()
     except requests.HTTPError as err:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -60,25 +60,20 @@ def check_status_code(response, verbose):
     if (response.status_code == 410 and
             response.url.startswith(("https://pypi.python.org",
                                      "https://testpypi.python.org"))):
-        raise exceptions.\
-            UploadToDeprecatedPyPIDetected(f"It appears you're uploading to "
-                                           f"pypi.python.org (or "
-                                           f"testpypi.python.org). You've "
-                                           f"received a 410 error response. "
-                                           f"Uploading to those sites is "
-                                           f"deprecated. The new sites are "
-                                           f"pypi.org and test.pypi.org. Try "
-                                           f"using {DEFAULT_REPOSITORY} (or "
-                                           f"{TEST_REPOSITORY}) to upload your"
-                                           f" packages instead. These are the "
-                                           f"default URLs for Twine now. More "
-                                           f"at https://packaging.python.org/"
-                                           f"guides/migrating-to-pypi-org/.")
+        raise exceptions.UploadToDeprecatedPyPIDetected(
+            f"It appears you're uploading to pypi.python.org (or "
+            f"testpypi.python.org). You've received a 410 error response. "
+            f"Uploading to those sites is deprecated. The new sites are "
+            f"pypi.org and test.pypi.org. Try using {DEFAULT_REPOSITORY} (or "
+            f"{TEST_REPOSITORY}) to upload your packages instead. These are "
+            f"the default URLs for Twine now. More at "
+            f"https://packaging.python.org/guides/migrating-to-pypi-org/.")
     elif response.status_code == 405 and "pypi.org" in response.url:
-        raise exceptions.PyPIMethodNotAllowed(f"You probably want one of these"
-                                              f"two URLs: {DEFAULT_REPOSITORY}"
-                                              f"or {TEST_REPOSITORY}. Check "
-                                              f"your --repository-url value.")
+        raise exceptions.InvalidPyPIUploadURL(
+            f"It appears you're trying to upload to pypi.org but have an "
+            f"invalid URL. You probably want one of these two URLs: "
+            f"{DEFAULT_REPOSITORY} or {TEST_REPOSITORY}. Check your "
+            f"--repository-url value.")
     try:
         response.raise_for_status()
     except HTTPError as err:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -18,9 +18,9 @@ from twine.commands import _find_dists
 from twine.package import PackageFile
 from twine import exceptions
 from twine import settings
-from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
+from twine import utils
 
-from requests.exceptions import HTTPError
+import requests
 
 
 def skip_upload(response, skip_existing, package):
@@ -62,19 +62,19 @@ def check_status_code(response, verbose):
             f"It appears you're uploading to pypi.python.org (or "
             f"testpypi.python.org). You've received a 410 error response. "
             f"Uploading to those sites is deprecated. The new sites are "
-            f"pypi.org and test.pypi.org. Try using {DEFAULT_REPOSITORY} (or "
-            f"{TEST_REPOSITORY}) to upload your packages instead. These are "
-            f"the default URLs for Twine now. More at "
+            f"pypi.org and test.pypi.org. Try using {utils.DEFAULT_REPOSITORY} "
+            f"(or {utils.TEST_REPOSITORY}) to upload your packages instead. "
+            f"These are the default URLs for Twine now. More at "
             f"https://packaging.python.org/guides/migrating-to-pypi-org/.")
     elif response.status_code == 405 and "pypi.org" in response.url:
         raise exceptions.InvalidPyPIUploadURL(
             f"It appears you're trying to upload to pypi.org but have an "
             f"invalid URL. You probably want one of these two URLs: "
-            f"{DEFAULT_REPOSITORY} or {TEST_REPOSITORY}. Check your "
-            f"--repository-url value.")
+            f"{utils.DEFAULT_REPOSITORY} or {utils.TEST_REPOSITORY}. Check your"
+            f" --repository-url value.")
     try:
         response.raise_for_status()
-    except HTTPError as err:
+    except requests.HTTPError as err:
         if response.text:
             if verbose:
                 print('Content received from server:\n{}'.format(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -18,12 +18,9 @@ from twine.commands import _find_dists
 from twine.package import PackageFile
 from twine import exceptions
 from twine import settings
+from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
 
 from requests.exceptions import HTTPError
-
-
-DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
-TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 
 
 def skip_upload(response, skip_existing, package):
@@ -67,8 +64,8 @@ def check_status_code(response, verbose):
               "testpypi.python.org). You've received a 410 error response. "
               "Uploading to those sites is deprecated. The new sites are "
               "pypi.org and test.pypi.org. Try using "
-              "https://upload.pypi.org/legacy/ "
-              "(or https://test.pypi.org/legacy/) to upload your packages "
+              f"{DEFAULT_REPOSITORY} "
+              f"(or {TEST_REPOSITORY}) to upload your packages "
               "instead. These are the default URLs for Twine now. More at "
               "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
     elif response.status_code == 405 and "pypi.org" in response.url:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -57,9 +57,7 @@ def check_status_code(response, verbose):
     Also includes a check for response code 405 and prints helpful error
     message guiding users to the right repository endpoints.
     """
-    if (response.status_code == 410 and
-            response.url.startswith(("https://pypi.python.org",
-                                     "https://testpypi.python.org"))):
+    if response.status_code == 410 and "pypi.python.org" in response.url:
         raise exceptions.UploadToDeprecatedPyPIDetected(
             f"It appears you're uploading to pypi.python.org (or "
             f"testpypi.python.org). You've received a 410 error response. "

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -51,11 +51,11 @@ def skip_upload(response, skip_existing, package):
 
 
 def check_status_code(response, verbose):
-    """Additional safety net to catch response code 410 in case the
-    UploadToDeprecatedPyPIDetected exception breaks.
+    """Generate a helpful message based on the response from the repository.
 
-    Also includes a check for response code 405 and prints helpful error
-    message guiding users to the right repository endpoints.
+    Raise a custom exception for recognized errors. Otherwise, print the
+    response content (based on the verbose option) before re-raising the
+    HTTPError.
     """
     if response.status_code == 410 and "pypi.python.org" in response.url:
         raise exceptions.UploadToDeprecatedPyPIDetected(
@@ -72,6 +72,7 @@ def check_status_code(response, verbose):
             f"invalid URL. You probably want one of these two URLs: "
             f"{utils.DEFAULT_REPOSITORY} or {utils.TEST_REPOSITORY}. Check "
             f"your --repository-url value.")
+
     try:
         response.raise_for_status()
     except requests.HTTPError as err:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -20,8 +20,6 @@ from twine import exceptions
 from twine import settings
 from twine import utils
 
-import requests
-
 
 def skip_upload(response, skip_existing, package):
     filename = package.basefilename
@@ -48,41 +46,6 @@ def skip_upload(response, skip_existing, package):
             (response.status_code == 400 and
              response.reason.startswith(msg_400)) or
             (response.status_code == 403 and msg_403 in response.text)))
-
-
-def check_status_code(response, verbose):
-    """Generate a helpful message based on the response from the repository.
-
-    Raise a custom exception for recognized errors. Otherwise, print the
-    response content (based on the verbose option) before re-raising the
-    HTTPError.
-    """
-    if response.status_code == 410 and "pypi.python.org" in response.url:
-        raise exceptions.UploadToDeprecatedPyPIDetected(
-            f"It appears you're uploading to pypi.python.org (or "
-            f"testpypi.python.org). You've received a 410 error response. "
-            f"Uploading to those sites is deprecated. The new sites are "
-            f"pypi.org and test.pypi.org. Try using {utils.DEFAULT_REPOSITORY}"
-            f" (or {utils.TEST_REPOSITORY}) to upload your packages instead. "
-            f"These are the default URLs for Twine now. More at "
-            f"https://packaging.python.org/guides/migrating-to-pypi-org/.")
-    elif response.status_code == 405 and "pypi.org" in response.url:
-        raise exceptions.InvalidPyPIUploadURL(
-            f"It appears you're trying to upload to pypi.org but have an "
-            f"invalid URL. You probably want one of these two URLs: "
-            f"{utils.DEFAULT_REPOSITORY} or {utils.TEST_REPOSITORY}. Check "
-            f"your --repository-url value.")
-
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as err:
-        if response.text:
-            if verbose:
-                print('Content received from server:\n{}'.format(
-                    response.text))
-            else:
-                print('NOTE: Try --verbose to see response content.')
-        raise err
 
 
 def upload(upload_settings, dists):
@@ -136,7 +99,7 @@ def upload(upload_settings, dists):
             print(skip_message)
             continue
 
-        check_status_code(resp, upload_settings.verbose)
+        utils.check_status_code(resp, upload_settings.verbose)
 
         uploaded_packages.append(package)
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -70,7 +70,7 @@ def check_status_code(response, verbose):
               "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
     elif response.status_code == 405 and "pypi.org" in response.url:
         print(f"You probably want one of these two URLs: {DEFAULT_REPOSITORY} "
-              f"or {TEST_REPOSITORY}.")
+              f"or {TEST_REPOSITORY}. Check your --repository-url value.")
     try:
         response.raise_for_status()
     except HTTPError as err:

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -51,9 +51,9 @@ def skip_upload(response, skip_existing, package):
 
 
 def check_status_code(response, verbose):
-    """
-    Additional safety net to catch response code 410 in case the
+    """Additional safety net to catch response code 410 in case the
     UploadToDeprecatedPyPIDetected exception breaks.
+
     Also includes a check for response code 405 and prints helpful error
     message guiding users to the right repository endpoints.
     """

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -60,17 +60,25 @@ def check_status_code(response, verbose):
     if (response.status_code == 410 and
             response.url.startswith(("https://pypi.python.org",
                                      "https://testpypi.python.org"))):
-        print("It appears you're uploading to pypi.python.org (or "
-              "testpypi.python.org). You've received a 410 error response. "
-              "Uploading to those sites is deprecated. The new sites are "
-              "pypi.org and test.pypi.org. Try using "
-              f"{DEFAULT_REPOSITORY} "
-              f"(or {TEST_REPOSITORY}) to upload your packages "
-              "instead. These are the default URLs for Twine now. More at "
-              "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
+        raise exceptions.\
+            UploadToDeprecatedPyPIDetected(f"It appears you're uploading to "
+                                           f"pypi.python.org (or "
+                                           f"testpypi.python.org). You've "
+                                           f"received a 410 error response. "
+                                           f"Uploading to those sites is "
+                                           f"deprecated. The new sites are "
+                                           f"pypi.org and test.pypi.org. Try "
+                                           f"using {DEFAULT_REPOSITORY} (or "
+                                           f"{TEST_REPOSITORY}) to upload your"
+                                           f" packages instead. These are the "
+                                           f"default URLs for Twine now. More "
+                                           f"at https://packaging.python.org/"
+                                           f"guides/migrating-to-pypi-org/.")
     elif response.status_code == 405 and "pypi.org" in response.url:
-        print(f"You probably want one of these two URLs: {DEFAULT_REPOSITORY} "
-              f"or {TEST_REPOSITORY}. Check your --repository-url value.")
+        raise exceptions.PyPIMethodNotAllowed(f"You probably want one of these"
+                                              f"two URLs: {DEFAULT_REPOSITORY}"
+                                              f"or {TEST_REPOSITORY}. Check "
+                                              f"your --repository-url value.")
     try:
         response.raise_for_status()
     except HTTPError as err:

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -101,3 +101,11 @@ class InvalidDistribution(TwineException):
     """Raised when a distribution is invalid."""
 
     pass
+
+
+class PyPIMethodNotAllowed(TwineException):
+    """Raised when --repository-url contains pypi.org but the upload
+    method is not supported.
+    """
+
+    pass

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -103,9 +103,10 @@ class InvalidDistribution(TwineException):
     pass
 
 
-class PyPIMethodNotAllowed(TwineException):
-    """Raised when --repository-url contains pypi.org but the upload
-    method is not supported.
+class InvalidPyPIUploadURL(TwineException):
+    """Repository configuration tries to use PyPI with an incorrect URL.
+
+    For example, https://pypi.org instead of https://upload.pypi.org/legacy.
     """
 
     pass

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -22,7 +22,6 @@ import collections
 import configparser
 from urllib.parse import urlparse, urlunparse
 
-from requests.exceptions import HTTPError
 
 try:
     import keyring  # noqa
@@ -127,37 +126,6 @@ def normalize_repository_url(url):
     if parsed.netloc in _HOSTNAMES:
         return urlunparse(("https",) + parsed[1:])
     return urlunparse(parsed)
-
-
-def check_status_code(response, verbose):
-    """
-    Shouldn't happen, thanks to the UploadToDeprecatedPyPIDetected
-    exception, but this is in case that breaks and it does.
-    """
-    if (response.status_code == 410 and
-            response.url.startswith(("https://pypi.python.org",
-                                     "https://testpypi.python.org"))):
-        print("It appears you're uploading to pypi.python.org (or "
-              "testpypi.python.org). You've received a 410 error response. "
-              "Uploading to those sites is deprecated. The new sites are "
-              "pypi.org and test.pypi.org. Try using "
-              "https://upload.pypi.org/legacy/ "
-              "(or https://test.pypi.org/legacy/) to upload your packages "
-              "instead. These are the default URLs for Twine now. More at "
-              "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
-    elif response.status_code == 405 and "pypi.org" in response.url:
-        print(f"You probably want one of these two URLs: {DEFAULT_REPOSITORY} "
-              f"or {TEST_REPOSITORY}.")
-    try:
-        response.raise_for_status()
-    except HTTPError as err:
-        if response.text:
-            if verbose:
-                print('Content received from server:\n{}'.format(
-                    response.text))
-            else:
-                print('NOTE: Try --verbose to see response content.')
-        raise err
 
 
 def get_userpass_value(cli_value, config, key, prompt_strategy=None):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -145,6 +145,15 @@ def check_status_code(response, verbose):
               "(or https://test.pypi.org/legacy/) to upload your packages "
               "instead. These are the default URLs for Twine now. More at "
               "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
+    if (response.status_code == 405 and
+            response.url.startswith(("https://pypi.org",
+                                     "https://test.pypi.org"))):
+        print("You probably want one of these two URLs: {} or {}. Check {} for"
+              " more information.".format(
+                  "https://pypi.org/legacy/",
+                  "https://test.pypi.org/legacy/",
+                  "https://warehouse.readthedocs.io/api-reference/legacy/"
+                  "#upload-api"))
     try:
         response.raise_for_status()
     except HTTPError as err:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -145,15 +145,9 @@ def check_status_code(response, verbose):
               "(or https://test.pypi.org/legacy/) to upload your packages "
               "instead. These are the default URLs for Twine now. More at "
               "https://packaging.python.org/guides/migrating-to-pypi-org/ ")
-    if (response.status_code == 405 and
-            response.url.startswith(("https://pypi.org",
-                                     "https://test.pypi.org"))):
-        print("You probably want one of these two URLs: {} or {}. Check {} for"
-              " more information.".format(
-                  "https://pypi.org/legacy/",
-                  "https://test.pypi.org/legacy/",
-                  "https://warehouse.readthedocs.io/api-reference/legacy/"
-                  "#upload-api"))
+    elif response.status_code == 405 and "pypi.org" in response.url:
+        print(f"You probably want one of these two URLs: {DEFAULT_REPOSITORY} "
+              f"or {TEST_REPOSITORY}.")
     try:
         response.raise_for_status()
     except HTTPError as err:


### PR DESCRIPTION
Closes #499.  