### PR TITLE
Make `--skip-existing` more robust

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,8 +3,9 @@
 =========
 Changelog
 =========
+* :bug:`332` More robust handling of server response in ``--skip-existing``
 * :release:`2.0.0 <2019-09-24>`
-* :feature:`437`: Twine now requires Python 3.6 or later. Use pip
+* :feature:`437` Twine now requires Python 3.6 or later. Use pip
   9 or pin to "twine<2" to install twine on older Python versions.
 * :bug:`491` Require requests 2.20 or later to avoid reported security
   vulnerabilities in earlier releases.

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -252,6 +252,12 @@ def test_skip_existing_skips_files_already_on_artifactory(monkeypatch):
              "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
              "(user 'twine-deployer' needs DELETE permission).")
 
+    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
+    assert upload.skip_upload(response=response,
+                              skip_existing=True,
+                              package=pkg) is True
+
+
 def test_skip_existing_skips_files_already_on_new_artifactory(monkeypatch):
     # Artifactory (https://jfrog.com/artifactory/) responds with 403
     # when the file already exists.
@@ -278,6 +284,7 @@ def test_skip_upload_respects_skip_existing(monkeypatch):
                               skip_existing=False,
                               package=pkg) is False
 
+
 def test_skip_upload_requires_reason(monkeypatch):
     response = pretend.stub(
         status_code=400,
@@ -287,6 +294,7 @@ def test_skip_upload_requires_reason(monkeypatch):
     assert upload.skip_upload(response=response,
                               skip_existing=False,
                               package=pkg) is False
+
 
 def test_skip_upload_requires_code(monkeypatch):
     response = pretend.stub(status_code=404)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -263,7 +263,7 @@ def test_skip_existing_skips_files_on_repository(response_kwargs):
 def test_skip_upload_doesnt_match(response_kwargs):
     assert not upload.skip_upload(
         response=pretend.stub(**response_kwargs),
-        skip_existing=False,
+        skip_existing=True,
         package=package.PackageFile.from_filename(WHEEL_FIXTURE, None)
     )
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -203,106 +203,77 @@ def test_prints_skip_message_for_response(make_settings, capsys):
     assert RELEASE_URL not in captured.out
 
 
-def test_skip_existing_skips_files_already_on_PyPI(monkeypatch):
-    response = pretend.stub(
-        status_code=400,
-        reason='A file named "twine-1.5.0-py2.py3-none-any.whl" already '
-               'exists for twine-1.5.0.')
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=True,
-                              package=pkg) is True
-
-
-def test_skip_existing_skips_files_already_on_nexus(monkeypatch):
-    # Nexus Repository Manager (https://www.sonatype.com/nexus-repository-oss)
-    # responds with 400 when the file already exists
-    response = pretend.stub(
-        status_code=400,
-        reason="Repository does not allow updating assets: pypi for url: "
-               "http://www.foo.bar")
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=True,
-                              package=pkg) is True
-
-
-def test_skip_existing_skips_files_already_on_pypiserver(monkeypatch):
-    # pypiserver (https://pypi.org/project/pypiserver) responds with a
-    # 409 when the file already exists.
-    response = pretend.stub(
-        status_code=409,
-        reason='A file named "twine-1.5.0-py2.py3-none-any.whl" already '
-               'exists for twine-1.5.0.')
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=True,
-                              package=pkg) is True
-
-
-def test_skip_existing_skips_files_already_on_artifactory(monkeypatch):
-    # Artifactory (https://jfrog.com/artifactory/) responds with 403
-    # when the file already exists.
-    response = pretend.stub(
-        status_code=403,
-        text="Not enough permissions to overwrite artifact "
-             "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
-             "(user 'twine-deployer' needs DELETE permission).")
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=True,
-                              package=pkg) is True
+@pytest.mark.parametrize('response_kwargs', [
+    pytest.param(
+        dict(status_code=400, reason=(
+            'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
+            'exists for twine-1.5.0.'
+        )),
+        id='pypi'
+    ),
+    pytest.param(
+        dict(status_code=400, reason=(
+            'Repository does not allow updating assets: pypi for url: '
+            'http://www.foo.bar'
+        )),
+        id='nexus'
+    ),
+    pytest.param(
+        dict(status_code=409, reason=(
+            'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
+            'exists for twine-1.5.0.'
+        )),
+        id='pypiserver'
+    ),
+    pytest.param(
+        dict(status_code=403, text=(
+            "Not enough permissions to overwrite artifact "
+            "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
+            "(user 'twine-deployer' needs DELETE permission)."
+        )),
+        id='artifactory_old'
+    ),
+    pytest.param(
+        dict(status_code=403, text=(
+            "Not enough permissions to delete/overwrite artifact "
+            "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
+            "(user 'twine-deployer' needs DELETE permission)."
+        )),
+        id='artifactory_new'
+    ),
+])
+def test_skip_existing_skips_files_on_repository(response_kwargs):
+    assert upload.skip_upload(
+        response=pretend.stub(**response_kwargs),
+        skip_existing=True,
+        package=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
+    )
 
 
-def test_skip_existing_skips_files_already_on_new_artifactory(monkeypatch):
-    # Artifactory (https://jfrog.com/artifactory/) responds with 403
-    # when the file already exists.
-    response = pretend.stub(
-        status_code=403,
-        text="Not enough permissions to delete/overwrite artifact "
-             "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
-             "(user 'twine-deployer' needs DELETE permission).")
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=True,
-                              package=pkg) is True
-
-
-def test_skip_upload_respects_skip_existing(monkeypatch):
-    response = pretend.stub(
-        status_code=400,
-        reason='A file named "twine-1.5.0-py2.py3-none-any.whl" already '
-               'exists for twine-1.5.0.')
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=False,
-                              package=pkg) is False
+@pytest.mark.parametrize('response_kwargs', [
+    pytest.param(
+        dict(status_code=400, reason='Invalid credentials'),
+        id='wrong_reason'
+    ),
+    pytest.param(
+        dict(status_code=404),
+        id='wrong_code'
+    ),
+])
+def test_skip_upload_doesnt_match(response_kwargs):
+    assert not upload.skip_upload(
+        response=pretend.stub(**response_kwargs),
+        skip_existing=False,
+        package=package.PackageFile.from_filename(WHEEL_FIXTURE, None)
+    )
 
 
-def test_skip_upload_requires_reason(monkeypatch):
-    response = pretend.stub(
-        status_code=400,
-        reason='Invalid credentials')
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=False,
-                              package=pkg) is False
-
-
-def test_skip_upload_requires_code(monkeypatch):
-    response = pretend.stub(status_code=404)
-
-    pkg = package.PackageFile.from_filename(WHEEL_FIXTURE, None)
-    assert upload.skip_upload(response=response,
-                              skip_existing=False,
-                              package=pkg) is False
+def test_skip_upload_respects_skip_existing():
+    assert not upload.skip_upload(
+        response=pretend.stub(),
+        skip_existing=False,
+        package=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
+    )
 
 
 def test_values_from_env(monkeypatch):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -32,16 +32,16 @@ def skip_upload(response, skip_existing, package):
     # NOTE(sigmavirus24): PyPI presently returns a 400 status code with the
     # error message in the reason attribute. Other implementations return a
     # 403 or 409 status code.
-    return any([
-        # PyPI / TestPyPI
-        status == 400 and 'already exist' in reason,
-        # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
-        status == 400 and 'updating asset' in reason,
-        # Artifactory (https://jfrog.com/artifactory/)
-        status == 403 and 'overwrite artifact' in text,
+    return (
         # pypiserver (https://pypi.org/project/pypiserver)
-        status == 409,
-    ])
+        status == 409
+        # PyPI / TestPyPI
+        or (status == 400 and 'already exist' in reason)
+        # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
+        or (status == 400 and 'updating asset' in reason)
+        # Artifactory (https://jfrog.com/artifactory/)
+        or (status == 403 and 'overwrite artifact' in text)
+    )
 
 
 def upload(upload_settings, dists):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import argparse
 import os.path
-import re
 
 from twine.commands import _find_dists
 from twine.package import PackageFile
@@ -27,13 +26,13 @@ from twine import utils
 # 403 or 409 status code.
 skip_responses = [
     # Warehouse and old PyPI
-    (400, lambda rsp: bool(re.search(r'file.*exist', rsp.reason))),
+    (400, lambda response: 'already exists' in response.reason),
     # Nexus Repository OSS
-    (400, lambda rsp: bool(re.search(r'updating assets', rsp.reason))),
+    (400, lambda response: 'updating assets' in response.reason),
     # Artifactory
-    (403, lambda rsp: bool(re.search(r'permissions.*overwrite', rsp.text))),
+    (403, lambda response: 'overwrite artifact' in response.text),
     # ???
-    (409, lambda rsp: True),
+    (409, lambda response: True),
 ]
 
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -27,11 +27,11 @@ from twine import utils
 skip_responses = [
     # Warehouse and old PyPI
     (400, lambda response: 'already exists' in response.reason),
-    # Nexus Repository OSS
+    # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
     (400, lambda response: 'updating assets' in response.reason),
-    # Artifactory
+    # Artifactory (https://jfrog.com/artifactory/)
     (403, lambda response: 'overwrite artifact' in response.text),
-    # ???
+    # pypiserver (https://pypi.org/project/pypiserver)
     (409, lambda response: True),
 ]
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -33,7 +33,7 @@ def skip_upload(response, skip_existing, package):
     # error message in the reason attribute. Other implementations return a
     # 403 or 409 status code.
     return any([
-        # Warehouse and old PyPI
+        # PyPI / TestPyPI
         status == 400 and 'already exist' in reason,
         # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
         status == 400 and 'updating asset' in reason,

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -26,11 +26,11 @@ from twine import utils
 # 403 or 409 status code.
 skip_responses = [
     # Warehouse and old PyPI
-    (400, lambda response: 'already exists' in response.reason),
+    (400, lambda response: 'already exist' in response.reason.lower()),
     # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
-    (400, lambda response: 'updating assets' in response.reason),
+    (400, lambda response: 'updating asset' in response.reason.lower()),
     # Artifactory (https://jfrog.com/artifactory/)
-    (403, lambda response: 'overwrite artifact' in response.text),
+    (403, lambda response: 'overwrite artifact' in response.text.lower()),
     # pypiserver (https://pypi.org/project/pypiserver)
     (409, lambda response: True),
 ]


### PR DESCRIPTION
Fixes #332.

I realize that checking for strings in the response is still brittle, but given the APIs that we support, I don't see how to avoid it. And, the issue said "less brittle". :)

I didn't spend much time on the tests; just copy-pasted from similar tests. Happy to refactor or tidy up.