### PR TITLE
Suppress warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings=
+	# workaround for https://github.com/mozilla/bleach/issues/425
+	ignore:Using or importing the ABCs:DeprecationWarning:bleach
+	# workaround for https://github.com/pypa/setuptools/issues/479
+	ignore:the imp module is deprecated::setuptools


### PR DESCRIPTION
The test suite emits warnings for which this code base has no control. Let's suppress those while the upstream packages work out their issues.

Ref mozilla/bleach#425 and pypa/setuptools#479.