### PR TITLE
Fix changelog: mark bugs as major

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,11 +11,11 @@ Changelog
   that functionality. Instead, use ``keyring --disable`` keyring functionality
   if necessary.
 * :feature:`518` Add Python 3.8 to classifiers.
-* :bug:`332` More robust handling of server response in ``--skip-existing``
+* :bug:`332 major` More robust handling of server response in ``--skip-existing``
 * :release:`2.0.0 <2019-09-24>`
 * :feature:`437` Twine now requires Python 3.6 or later. Use pip
   9 or pin to "twine<2" to install twine on older Python versions.
-* :bug:`491` Require requests 2.20 or later to avoid reported security
+* :bug:`491 major` Require requests 2.20 or later to avoid reported security
   vulnerabilities in earlier releases.
 * :release:`1.15.0 <2019-09-17>`
 * :feature:`488` Improved output on ``check`` command:
@@ -24,7 +24,7 @@ Changelog
   messages flowing through to the next distribution's errors.
 * :release:`1.14.0 <2019-09-06>`
 * :feature:`456` Better error handling and gpg2 fallback if gpg not available.
-* :bug:`341` Fail more gracefully when encountering bad metadata
+* :bug:`341 major` Fail more gracefully when encountering bad metadata
 * :feature:`459` Show Warehouse URL after uploading a package
 * :feature:`310` Now provide a more meaningful error on redirect during upload.
 * :release:`1.13.0 <2019-02-13>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,8 @@ Changelog
   that functionality. Instead, use ``keyring --disable`` keyring functionality
   if necessary.
 * :feature:`518` Add Python 3.8 to classifiers.
-* :bug:`332 major` More robust handling of server response in ``--skip-existing``
+* :bug:`332 major` More robust handling of server response in
+  ``--skip-existing``
 * :release:`2.0.0 <2019-09-24>`
 * :feature:`437` Twine now requires Python 3.6 or later. Use pip
   9 or pin to "twine<2" to install twine on older Python versions.


### PR DESCRIPTION
When bugs are not marked as "major", they are not included in the notes for a given release:

<img width="756" alt="Screen Shot 2019-11-19 at 2 23 11 PM" src="https://user-images.githubusercontent.com/294415/69183220-349adf00-0ad8-11ea-8f63-99582f77a8da.png">
