### PR TITLE
Add env var for --non-interactive flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,9 @@ Uploads one or more distributions to a repository.
                             (package index) with. (Can also be set via
                             TWINE_PASSWORD environment variable.)
       --non-interactive     Do not interactively prompt for username/password
-                            if the required credentials are missing.
+                            if the required credentials are missing. (Can also
+                            be set via TWINE_NON_INTERACTIVE environment
+                            variable.)
       -c COMMENT, --comment COMMENT
                             The comment to include with the distribution file.
       --config-file CONFIG_FILE
@@ -288,7 +290,9 @@ For completeness, its usage:
                             (package index) with. (Can also be set via
                             TWINE_PASSWORD environment variable.)
       --non-interactive     Do not interactively prompt for username/password
-                            if the required credentials are missing.
+                            if the required credentials are missing. (Can also
+                            be set via TWINE_NON_INTERACTIVE environment
+                            variable.)
       -c COMMENT, --comment COMMENT
                             The comment to include with the distribution file.
       --config-file CONFIG_FILE
@@ -315,6 +319,8 @@ example.
 * ``TWINE_REPOSITORY_URL`` - the repository URL to use.
 * ``TWINE_CERT`` - custom CA certificate to use for repositories with
   self-signed or untrusted certificates.
+* ``TWINE_NON_INTERACTIVE`` - Do not interactively prompt for username/password
+  if the required credentials are missing.
 
 Resources
 ---------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,10 +3,14 @@
 =========
 Changelog
 =========
+* :feature:`547` Add support for specifying ``--non-interactive`` as an
+  environment variable.
 * :release:`3.0.0 <2019-11-18>`
-* :feature:`336`: When a client certificate is indicated, all password
+* :feature:`336` When a client certificate is indicated, all password
   processing is disabled.
-* :feature:`524`: Twine now unconditionally requires the keyring library
+* :feature:`489` Add ``--non-interactive`` flag to abort upload rather than
+  interactively prompt if credentials are missing.
+* :feature:`524` Twine now unconditionally requires the keyring library
   and no longer supports uninstalling ``keyring`` as a means to disable
   that functionality. Instead, use ``keyring --disable`` keyring functionality
   if necessary.

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -201,11 +201,13 @@ class Settings:
         )
         parser.add_argument(
             "--non-interactive",
-            action="store_true",
+            action=utils.EnvironmentDefault,
+            env="TWINE_NON_INTERACTIVE",
             default=False,
             required=False,
             help="Do not interactively prompt for username/password if the "
-                 "required credentials are missing."
+                 "required credentials are missing. (Can also be set via "
+                 "%(env)s environment variable.)"
         )
         parser.add_argument(
             "-c", "--comment",


### PR DESCRIPTION
Per [review comments](https://github.com/pypa/twine/pull/489#pullrequestreview-291524973) in #489, this PR adds support for specifying the `--non-interactive` flag via a `TWINE_NON_INTERACTIVE` environment variable.

Opening this up as a draft for comments & also to ask a question on testing: Is it overkill to add testing for `argparse`'s parsing of the env var as part of Twine?