### PR TITLE
Workaround mypy issues with importlib.metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires=
 	requests-toolbelt >= 0.8.0, != 0.9.0
 	setuptools >= 0.7.0
 	tqdm >= 4.14
-	importlib_metadata
+      importlib_metadata; python_version < "3.8"
 	keyring >= 15.1
 setup_requires =
     setuptools_scm >= 1.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires=
 	requests-toolbelt >= 0.8.0, != 0.9.0
 	setuptools >= 0.7.0
 	tqdm >= 4.14
-      importlib_metadata; python_version < "3.8"
+	importlib_metadata
 	keyring >= 15.1
 setup_requires =
     setuptools_scm >= 1.15

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,7 @@ commands =
 
 [testenv:lint-mypy]
 deps =
-    # pin to workaround #550
-    mypy<0.750
+    mypy
     lxml
 commands =
     # TODO: Consider checking the tests after the source is fully typed

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,8 @@ commands =
 
 [testenv:lint-mypy]
 deps =
-    mypy
+    # pin to workaround #550
+    mypy<0.750
     lxml
 commands =
     # TODO: Consider checking the tests after the source is fully typed

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -18,10 +18,10 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-
-# This should be importlib.metadata in Python 3.8, but a conditional import
-# with try/except was causing confusing mypy errors
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 
 metadata = importlib_metadata.metadata('twine')

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -18,13 +18,12 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-
 try:
-    # https://github.com/python/mypy/issues/1393
     from importlib.metadata import metadata  # type: ignore
+    # https://github.com/python/mypy/issues/1393
 except ImportError:
-    # https://github.com/python/mypy/issues/1153
     from importlib_metadata import metadata  # type: ignore
+    # https://github.com/python/mypy/issues/1153
 
 
 twine_metadata = metadata('twine')

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -18,19 +18,22 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
+
 try:
-    import importlib.metadata as importlib_metadata
+    # https://github.com/python/mypy/issues/1393
+    from importlib.metadata import metadata  # type: ignore
 except ImportError:
-    import importlib_metadata
+    # https://github.com/python/mypy/issues/1153
+    from importlib_metadata import metadata  # type: ignore
 
 
-metadata = importlib_metadata.metadata('twine')
+twine_metadata = metadata('twine')
 
 
-__title__ = metadata['name']
-__summary__ = metadata['summary']
-__uri__ = metadata['home-page']
-__version__ = metadata['version']
-__author__ = metadata['author']
-__email__ = metadata['author-email']
-__license__ = metadata['license']
+__title__ = twine_metadata['name']
+__summary__ = twine_metadata['summary']
+__uri__ = twine_metadata['home-page']
+__version__ = twine_metadata['version']
+__author__ = twine_metadata['author']
+__email__ = twine_metadata['author-email']
+__license__ = twine_metadata['license']

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -18,21 +18,21 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-try:
-    from importlib.metadata import metadata  # type: ignore
-    # https://github.com/python/mypy/issues/1393
-except ImportError:
-    from importlib_metadata import metadata  # type: ignore
-    # https://github.com/python/mypy/issues/1153
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 
-twine_metadata = metadata('twine')
+metadata = importlib_metadata.metadata('twine')
 
 
-__title__ = twine_metadata['name']
-__summary__ = twine_metadata['summary']
-__uri__ = twine_metadata['home-page']
-__version__ = twine_metadata['version']
-__author__ = twine_metadata['author']
-__email__ = twine_metadata['author-email']
-__license__ = twine_metadata['license']
+__title__ = metadata['name']
+__summary__ = metadata['summary']
+__uri__ = metadata['home-page']
+__version__ = metadata['version']
+__author__ = metadata['author']
+__email__ = metadata['author-email']
+__license__ = metadata['license']

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -18,10 +18,10 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    import importlib_metadata
+
+# This should be importlib.metadata in Python 3.8, but a conditional import
+# with try/except was causing confusing mypy errors
+import importlib_metadata
 
 
 metadata = importlib_metadata.metadata('twine')


### PR DESCRIPTION
Closes #550 

There were two errors on the [failed build](https://travis-ci.org/pypa/twine/jobs/618755208):

```
twine/__init__.py:24: error: Name 'importlib_metadata' already defined (by an import)
twine/__init__.py:27: error: Module has no attribute "metadata"
```

The first is an open issue on mypy: https://github.com/python/mypy/issues/1153, and easily resolved with a `# type: ignore` on the `except` import. I don't know why we weren't getting that error before.

The second only happens in Python <3.8. I don't know why, since `metadata` does seem to be an attribute of both modules. Weirdly, removing the conditional import cleared the error.

I opted for the expedient solution of always using `importlib_metadata`, even though it's redundant in Python 3.8. If folks feel strongly, I can investigate further.