### PR TITLE
Added twine entry point for command prompt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ from setuptools import setup
 
 setup(
     use_scm_version=True,
+    entry_points={"console_scripts": ["twine=twine.__main__:main",]}
 )


### PR DESCRIPTION
On windows twine is invoked as
```bash
py -m twine upload
```
After this commit the following command will work in command prompt.
```bash
twine upload
```