### PR TITLE
Format twine and tests with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+# Matching black's default
+max-line-length = 88

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ def make_settings(pypirc):
     def _settings(pypirc_text=default_pypirc, **settings_kwargs):
         pypirc.write(textwrap.dedent(pypirc_text))
 
-        settings_kwargs.setdefault('sign_with', None)
-        settings_kwargs.setdefault('config_file', str(pypirc))
+        settings_kwargs.setdefault("sign_with", None)
+        settings_kwargs.setdefault("config_file", str(pypirc))
 
         return settings.Settings(**settings_kwargs)
 
@@ -47,8 +47,9 @@ class DevPiEnv(jaraco.envs.ToxEnv):
     """
     Run devpi using tox:testenv:devpi.
     """
-    name = 'devpi'
-    username = 'foober'
+
+    name = "devpi"
+    username = "foober"
 
     def create(self, root, password):
         super().create()
@@ -56,19 +57,21 @@ class DevPiEnv(jaraco.envs.ToxEnv):
         self.password = password
         self.port = portend.find_available_local_port()
         cmd = [
-            self.exe('devpi-init'),
-            '--serverdir', str(root),
-            '--root-passwd', password,
+            self.exe("devpi-init"),
+            "--serverdir",
+            str(root),
+            "--root-passwd",
+            password,
         ]
         subprocess.run(cmd, check=True)
 
     @property
     def url(self):
-        return f'http://localhost:{self.port}/'
+        return f"http://localhost:{self.port}/"
 
     @property
     def repo(self):
-        return f'{self.url}/{self.username}/dev/'
+        return f"{self.url}/{self.username}/dev/"
 
     def ready(self):
         with contextlib.suppress(Exception):
@@ -76,28 +79,30 @@ class DevPiEnv(jaraco.envs.ToxEnv):
 
     def init(self):
         run = functools.partial(subprocess.run, check=True)
-        client_dir = self.base / 'client'
+        client_dir = self.base / "client"
         devpi_client = [
-            self.exe('devpi'),
-            '--clientdir', str(client_dir),
+            self.exe("devpi"),
+            "--clientdir",
+            str(client_dir),
         ]
-        run(devpi_client + ['use', self.url + 'root/pypi/'])
-        run(devpi_client + [
-            'user', '--create', self.username, f'password={self.password}'])
-        run(devpi_client + [
-            'login', self.username, '--password', self.password])
-        run(devpi_client + ['index', '-c', 'dev'])
+        run(devpi_client + ["use", self.url + "root/pypi/"])
+        run(
+            devpi_client
+            + ["user", "--create", self.username, f"password={self.password}"]
+        )
+        run(devpi_client + ["login", self.username, "--password", self.password])
+        run(devpi_client + ["index", "-c", "dev"])
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def devpi_server(request, watcher_getter, tmp_path_factory):
     env = DevPiEnv()
     password = secrets.token_urlsafe()
-    root = tmp_path_factory.mktemp('devpi')
+    root = tmp_path_factory.mktemp("devpi")
     env.create(root, password)
     proc = watcher_getter(
-        name=str(env.exe('devpi-server')),
-        arguments=['--port', str(env.port), '--serverdir', str(root)],
+        name=str(env.exe("devpi-server")),
+        arguments=["--port", str(env.port), "--serverdir", str(root)],
         checker=env.ready,
         # Needed for the correct execution order of finalizers
         request=request,
@@ -109,48 +114,41 @@ def devpi_server(request, watcher_getter, tmp_path_factory):
 
 
 dist_names = [
-    'twine-1.5.0.tar.gz',
-    'twine-1.5.0-py2.py3-none-any.whl',
-    'twine-1.6.5.tar.gz',
-    'twine-1.6.5-py2.py3-none-any.whl',
+    "twine-1.5.0.tar.gz",
+    "twine-1.5.0-py2.py3-none-any.whl",
+    "twine-1.6.5.tar.gz",
+    "twine-1.6.5-py2.py3-none-any.whl",
 ]
 
 
 @pytest.fixture(params=dist_names)
 def uploadable_dist(request):
-    return pathlib.Path(__file__).parent / 'fixtures' / request.param
+    return pathlib.Path(__file__).parent / "fixtures" / request.param
 
 
 @pytest.fixture
 def entered_password(monkeypatch):
-    monkeypatch.setattr(getpass, 'getpass', lambda prompt: 'entered pw')
+    monkeypatch.setattr(getpass, "getpass", lambda prompt: "entered pw")
 
 
 @pytest.fixture
 def sampleproject_dist(tmp_path_factory):
-    checkout = tmp_path_factory.mktemp('sampleproject', numbered=False)
-    subprocess.run([
-        'git',
-        'clone', 'https://github.com/pypa/sampleproject',
-        str(checkout),
-    ])
-    with (checkout / 'setup.py').open('r+') as setup:
+    checkout = tmp_path_factory.mktemp("sampleproject", numbered=False)
+    subprocess.run(
+        ["git", "clone", "https://github.com/pypa/sampleproject", str(checkout)]
+    )
+    with (checkout / "setup.py").open("r+") as setup:
         orig = setup.read()
-        sub = orig.replace(
-            "name='sampleproject'", "name='twine-sampleproject'")
+        sub = orig.replace("name='sampleproject'", "name='twine-sampleproject'")
         assert orig != sub
         setup.seek(0)
         setup.write(sub)
-    tag = datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')
-    subprocess.run([
-        sys.executable,
-        'setup.py',
-        'egg_info', '--tag-build', f'post{tag}',
-        'sdist',
-    ],
+    tag = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
+    subprocess.run(
+        [sys.executable, "setup.py", "egg_info", "--tag-build", f"post{tag}", "sdist"],
         cwd=str(checkout),
     )
-    dist, = checkout.joinpath('dist').glob('*')
+    (dist,) = checkout.joinpath("dist").glob("*")
     return dist
 
 
@@ -158,7 +156,8 @@ class PypiserverEnv(jaraco.envs.ToxEnv):
     """
     Run pypiserver using tox:testenv:pypiserver.
     """
-    name = 'pypiserver'
+
+    name = "pypiserver"
 
     @property
     @functools.lru_cache()
@@ -167,24 +166,28 @@ class PypiserverEnv(jaraco.envs.ToxEnv):
 
     @property
     def url(self):
-        return f'http://localhost:{self.port}/'
+        return f"http://localhost:{self.port}/"
 
     def ready(self):
         with contextlib.suppress(Exception):
             return requests.get(self.url)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def pypiserver_instance(request, watcher_getter, tmp_path_factory):
     env = PypiserverEnv()
     env.create()
     proc = watcher_getter(
-        name=str(env.exe('pypi-server')),
+        name=str(env.exe("pypi-server")),
         arguments=[
-            '--port', str(env.port),
+            "--port",
+            str(env.port),
             # allow anonymous uploads
-            '-P', '.', '-a', '.',
-            tmp_path_factory.mktemp('packages'),
+            "-P",
+            ".",
+            "-a",
+            ".",
+            tmp_path_factory.mktemp("packages"),
         ],
         checker=env.ready,
         # Needed for the correct execution order of finalizers

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,66 +12,61 @@ cred = auth.CredentialInput
 
 @pytest.fixture
 def config() -> utils.RepositoryConfig:
-    return dict(repository='system')
+    return dict(repository="system")
 
 
 def test_get_password_keyring_overrides_prompt(monkeypatch, config):
     class MockKeyring:
         @staticmethod
         def get_password(system, user):
-            return '{user}@{system} sekure pa55word'.format(**locals())
+            return "{user}@{system} sekure pa55word".format(**locals())
 
-    monkeypatch.setattr(auth, 'keyring', MockKeyring)
+    monkeypatch.setattr(auth, "keyring", MockKeyring)
 
-    pw = auth.Resolver(config, cred('user')).password
-    assert pw == 'user@system sekure pa55word'
+    pw = auth.Resolver(config, cred("user")).password
+    assert pw == "user@system sekure pa55word"
 
 
-def test_get_password_keyring_defers_to_prompt(
-        monkeypatch, entered_password, config):
+def test_get_password_keyring_defers_to_prompt(monkeypatch, entered_password, config):
     class MockKeyring:
         @staticmethod
         def get_password(system, user):
             return
 
-    monkeypatch.setattr(auth, 'keyring', MockKeyring)
+    monkeypatch.setattr(auth, "keyring", MockKeyring)
 
-    pw = auth.Resolver(config, cred('user')).password
-    assert pw == 'entered pw'
+    pw = auth.Resolver(config, cred("user")).password
+    assert pw == "entered pw"
 
 
 def test_no_password_defers_to_prompt(monkeypatch, entered_password, config):
     config.update(password=None)
-    pw = auth.Resolver(config, cred('user')).password
-    assert pw == 'entered pw'
+    pw = auth.Resolver(config, cred("user")).password
+    assert pw == "entered pw"
 
 
-def test_empty_password_bypasses_prompt(
-        monkeypatch, entered_password, config):
-    config.update(password='')
-    pw = auth.Resolver(config, cred('user')).password
-    assert pw == ''
+def test_empty_password_bypasses_prompt(monkeypatch, entered_password, config):
+    config.update(password="")
+    pw = auth.Resolver(config, cred("user")).password
+    assert pw == ""
 
 
 def test_no_username_non_interactive_aborts(config):
     with pytest.raises(exceptions.NonInteractive):
-        auth.Private(config, cred('user')).password
+        auth.Private(config, cred("user")).password
 
 
 def test_no_password_non_interactive_aborts(config):
     with pytest.raises(exceptions.NonInteractive):
-        auth.Private(config, cred('user')).password
+        auth.Private(config, cred("user")).password
 
 
-def test_get_username_and_password_keyring_overrides_prompt(
-        monkeypatch, config):
-
+def test_get_username_and_password_keyring_overrides_prompt(monkeypatch, config):
     class MockKeyring:
         @staticmethod
         def get_credential(system, user):
             return cred(
-                'real_user',
-                'real_user@{system} sekure pa55word'.format(**locals())
+                "real_user", "real_user@{system} sekure pa55word".format(**locals())
             )
 
         @staticmethod
@@ -81,11 +76,11 @@ def test_get_username_and_password_keyring_overrides_prompt(
                 raise RuntimeError("unexpected username")
             return cred.password
 
-    monkeypatch.setattr(auth, 'keyring', MockKeyring)
+    monkeypatch.setattr(auth, "keyring", MockKeyring)
 
     res = auth.Resolver(config, cred())
-    assert res.username == 'real_user'
-    assert res.password == 'real_user@system sekure pa55word'
+    assert res.username == "real_user"
+    assert res.password == "real_user@system sekure pa55word"
 
 
 @pytest.fixture
@@ -94,30 +89,32 @@ def keyring_missing_get_credentials(monkeypatch):
     Simulate keyring prior to 15.2 that does not have the
     'get_credential' API.
     """
-    monkeypatch.delattr(auth.keyring, 'get_credential')
+    monkeypatch.delattr(auth.keyring, "get_credential")
 
 
 @pytest.fixture
 def entered_username(monkeypatch):
-    monkeypatch.setattr(
-        auth, 'input', lambda prompt: 'entered user', raising=False)
+    monkeypatch.setattr(auth, "input", lambda prompt: "entered user", raising=False)
 
 
 def test_get_username_keyring_missing_get_credentials_prompts(
-        entered_username, keyring_missing_get_credentials, config):
-    assert auth.Resolver(config, cred()).username == 'entered user'
+    entered_username, keyring_missing_get_credentials, config
+):
+    assert auth.Resolver(config, cred()).username == "entered user"
 
 
 def test_get_username_keyring_missing_non_interactive_aborts(
-        entered_username, keyring_missing_get_credentials, config):
+    entered_username, keyring_missing_get_credentials, config
+):
     with pytest.raises(exceptions.NonInteractive):
         auth.Private(config, cred()).username
 
 
 def test_get_password_keyring_missing_non_interactive_aborts(
-        entered_username, keyring_missing_get_credentials, config):
+    entered_username, keyring_missing_get_credentials, config
+):
     with pytest.raises(exceptions.NonInteractive):
-        auth.Private(config, cred('user')).password
+        auth.Private(config, cred("user")).password
 
 
 @pytest.fixture
@@ -127,11 +124,13 @@ def keyring_no_backends(monkeypatch):
     has no backends for the system, the backend will be a
     fail.Keyring, which raises RuntimeError on get_password.
     """
+
     class FailKeyring:
         @staticmethod
         def get_password(system, username):
             raise RuntimeError("fail!")
-    monkeypatch.setattr(auth, 'keyring', FailKeyring())
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring())
 
 
 @pytest.fixture
@@ -141,25 +140,28 @@ def keyring_no_backends_get_credential(monkeypatch):
     has no backends for the system, the backend will be a
     fail.Keyring, which raises RuntimeError on get_credential.
     """
+
     class FailKeyring:
         @staticmethod
         def get_credential(system, username):
             raise RuntimeError("fail!")
-    monkeypatch.setattr(auth, 'keyring', FailKeyring())
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring())
 
 
 def test_get_username_runtime_error_suppressed(
-        entered_username, keyring_no_backends_get_credential, recwarn,
-        config):
-    assert auth.Resolver(config, cred()).username == 'entered user'
+    entered_username, keyring_no_backends_get_credential, recwarn, config
+):
+    assert auth.Resolver(config, cred()).username == "entered user"
     assert len(recwarn) == 1
     warning = recwarn.pop(UserWarning)
-    assert 'fail!' in str(warning)
+    assert "fail!" in str(warning)
 
 
 def test_get_password_runtime_error_suppressed(
-        entered_password, keyring_no_backends, recwarn, config):
-    assert auth.Resolver(config, cred('user')).password == 'entered pw'
+    entered_password, keyring_no_backends, recwarn, config
+):
+    assert auth.Resolver(config, cred("user")).password == "entered pw"
     assert len(recwarn) == 1
     warning = recwarn.pop(UserWarning)
-    assert 'fail!' in str(warning)
+    assert "fail!" in str(warning)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -17,12 +17,10 @@ from twine.commands import check
 
 
 class TestWarningStream:
-
     def setup(self):
         self.stream = check._WarningStream()
         self.stream.output = pretend.stub(
-            write=pretend.call_recorder(lambda a: None),
-            getvalue=lambda: "result",
+            write=pretend.call_recorder(lambda a: None), getvalue=lambda: "result",
         )
 
     def test_write_match(self):
@@ -35,9 +33,7 @@ class TestWarningStream:
     def test_write_nomatch(self):
         self.stream.write("this does not match")
 
-        assert self.stream.output.write.calls == [
-            pretend.call("this does not match")
-        ]
+        assert self.stream.output.write.calls == [pretend.call("this does not match")]
 
     def test_str_representation(self):
         assert str(self.stream) == "result"
@@ -53,70 +49,67 @@ def test_check_no_distributions(monkeypatch):
 
 
 def test_check_passing_distribution(monkeypatch):
-    renderer = pretend.stub(
-        render=pretend.call_recorder(lambda *a, **kw: "valid")
+    renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: "valid"))
+    package = pretend.stub(
+        metadata_dictionary=lambda: {
+            "description": "blah",
+            "description_content_type": "text/markdown",
+        }
     )
-    package = pretend.stub(metadata_dictionary=lambda: {
-        "description": "blah", 'description_content_type': 'text/markdown',
-    })
     output_stream = check.StringIO()
     warning_stream = ""
 
     monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
     monkeypatch.setattr(check, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        check,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
+        check, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: package),
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 
     assert not check.check("dist/*", output_stream=output_stream)
     assert output_stream.getvalue() == "Checking dist/dist.tar.gz: PASSED\n"
-    assert renderer.render.calls == [
-        pretend.call("blah", stream=warning_stream)
-    ]
+    assert renderer.render.calls == [pretend.call("blah", stream=warning_stream)]
 
 
 def test_check_no_description(monkeypatch, capsys):
-    package = pretend.stub(metadata_dictionary=lambda: {
-        'description': None, 'description_content_type': None,
-    })
+    package = pretend.stub(
+        metadata_dictionary=lambda: {
+            "description": None,
+            "description_content_type": None,
+        }
+    )
 
     monkeypatch.setattr(check, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        check,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
+        check, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: package),
     )
 
     # used to crash with `AttributeError`
     output_stream = check.StringIO()
     check.check("dist/*", output_stream=output_stream)
     assert output_stream.getvalue() == (
-        'Checking dist/dist.tar.gz: PASSED, with warnings\n'
-        '  warning: `long_description_content_type` missing.  '
-        'defaulting to `text/x-rst`.\n'
-        '  warning: `long_description` missing.\n'
+        "Checking dist/dist.tar.gz: PASSED, with warnings\n"
+        "  warning: `long_description_content_type` missing. "
+        "defaulting to `text/x-rst`.\n"
+        "  warning: `long_description` missing.\n"
     )
 
 
 def test_check_failing_distribution(monkeypatch):
-    renderer = pretend.stub(
-        render=pretend.call_recorder(lambda *a, **kw: None)
+    renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: None))
+    package = pretend.stub(
+        metadata_dictionary=lambda: {
+            "description": "blah",
+            "description_content_type": "text/markdown",
+        }
     )
-    package = pretend.stub(metadata_dictionary=lambda: {
-        "description": "blah", "description_content_type": 'text/markdown',
-    })
     output_stream = check.StringIO()
     warning_stream = "WARNING"
 
     monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
     monkeypatch.setattr(check, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        check,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
+        check, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: package),
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 
@@ -127,9 +120,7 @@ def test_check_failing_distribution(monkeypatch):
         "rendered on PyPI.\n"
         "    WARNING"
     )
-    assert renderer.render.calls == [
-        pretend.call("blah", stream=warning_stream)
-    ]
+    assert renderer.render.calls == [pretend.call("blah", stream=warning_stream)]
 
 
 def test_main(monkeypatch):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,10 +3,13 @@ from twine.cli import dispatch
 
 def test_devpi_upload(devpi_server, uploadable_dist):
     command = [
-        'upload',
-        '--repository-url', devpi_server.url,
-        '--username', devpi_server.username,
-        '--password', devpi_server.password,
+        "upload",
+        "--repository-url",
+        devpi_server.url,
+        "--username",
+        devpi_server.username,
+        "--password",
+        devpi_server.password,
         str(uploadable_dist),
     ]
     dispatch(command)
@@ -23,10 +26,13 @@ twine_sampleproject_token = (
 
 def test_pypi_upload(sampleproject_dist):
     command = [
-        'upload',
-        '--repository-url', 'https://test.pypi.org/legacy/',
-        '--username', '__token__',
-        '--password', twine_sampleproject_token,
+        "upload",
+        "--repository-url",
+        "https://test.pypi.org/legacy/",
+        "--username",
+        "__token__",
+        "--password",
+        twine_sampleproject_token,
         str(sampleproject_dist),
     ]
     dispatch(command)
@@ -34,10 +40,13 @@ def test_pypi_upload(sampleproject_dist):
 
 def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
     command = [
-        'upload',
-        '--repository-url', pypiserver_instance.url,
-        '--username', 'any',
-        '--password', 'any',
+        "upload",
+        "--repository-url",
+        pypiserver_instance.url,
+        "--username",
+        "any",
+        "--password",
+        "any",
         str(uploadable_dist),
     ]
     dispatch(command)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,8 +17,6 @@ import pretend
 
 
 def test_exception_handling(monkeypatch):
-    replaced_dispatch = pretend.raiser(
-        exceptions.InvalidConfiguration('foo')
-    )
-    monkeypatch.setattr(dunder_main, 'dispatch', replaced_dispatch)
-    assert dunder_main.main() == 'InvalidConfiguration: foo'
+    replaced_dispatch = pretend.raiser(exceptions.InvalidConfiguration("foo"))
+    monkeypatch.setattr(dunder_main, "dispatch", replaced_dispatch)
+    assert dunder_main.main() == "InvalidConfiguration: foo"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -19,104 +19,100 @@ import pytest
 
 def test_sign_file(monkeypatch):
     replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
-    filename = 'tests/fixtures/deprecated-pypirc'
+    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    filename = "tests/fixtures/deprecated-pypirc"
 
     pkg = package.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
         python_version=None,
-        filetype=None
+        filetype=None,
     )
     try:
-        pkg.sign('gpg2', None)
+        pkg.sign("gpg2", None)
     except IOError:
         pass
-    args = ('gpg2', '--detach-sign', '-a', filename)
+    args = ("gpg2", "--detach-sign", "-a", filename)
     assert replaced_check_call.calls == [pretend.call(args)]
 
 
 def test_sign_file_with_identity(monkeypatch):
     replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
-    filename = 'tests/fixtures/deprecated-pypirc'
+    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    filename = "tests/fixtures/deprecated-pypirc"
 
     pkg = package.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
         python_version=None,
-        filetype=None
+        filetype=None,
     )
     try:
-        pkg.sign('gpg', 'identity')
+        pkg.sign("gpg", "identity")
     except IOError:
         pass
-    args = ('gpg', '--detach-sign', '--local-user', 'identity', '-a', filename)
+    args = ("gpg", "--detach-sign", "--local-user", "identity", "-a", filename)
     assert replaced_check_call.calls == [pretend.call(args)]
 
 
 def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
-    replaced_check_call = pretend.raiser(FileNotFoundError('not found'))
-    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
-    gpg_args = ('gpg', '--detach-sign', '-a', 'pypircfile')
+    replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
+    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
         package.PackageFile.run_gpg(gpg_args)
 
-    assert 'executables not available' in err.value.args[0]
+    assert "executables not available" in err.value.args[0]
 
 
 def test_run_gpg_raises_exception_if_not_using_gpg(monkeypatch):
-    replaced_check_call = pretend.raiser(FileNotFoundError('not found'))
-    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
-    gpg_args = ('not_gpg', '--detach-sign', '-a', 'pypircfile')
+    replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
+    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    gpg_args = ("not_gpg", "--detach-sign", "-a", "pypircfile")
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
         package.PackageFile.run_gpg(gpg_args)
 
-    assert 'not_gpg executable not available' in err.value.args[0]
+    assert "not_gpg executable not available" in err.value.args[0]
 
 
 def test_run_gpg_falls_back_to_gpg2(monkeypatch):
-
     def check_call(arg_list):
-        if arg_list[0] == 'gpg':
-            raise FileNotFoundError('gpg not found')
+        if arg_list[0] == "gpg":
+            raise FileNotFoundError("gpg not found")
 
     replaced_check_call = pretend.call_recorder(check_call)
-    monkeypatch.setattr(package.subprocess, 'check_call', replaced_check_call)
-    gpg_args = ('gpg', '--detach-sign', '-a', 'pypircfile')
+    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
 
     package.PackageFile.run_gpg(gpg_args)
 
     gpg2_args = replaced_check_call.calls[1].args
-    assert gpg2_args[0][0] == 'gpg2'
+    assert gpg2_args[0][0] == "gpg2"
 
 
 def test_package_signed_name_is_correct():
-    filename = 'tests/fixtures/deprecated-pypirc'
+    filename = "tests/fixtures/deprecated-pypirc"
 
     pkg = package.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
         python_version=None,
-        filetype=None
+        filetype=None,
     )
 
     assert pkg.signed_basefilename == "deprecated-pypirc.asc"
-    assert pkg.signed_filename == (filename + '.asc')
+    assert pkg.signed_filename == (filename + ".asc")
 
 
-@pytest.mark.parametrize('gpg_signature', [
-    (None),
-    (pretend.stub()),
-])
+@pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])
 def test_metadata_dictionary(gpg_signature):
     meta = pretend.stub(
-        name='whatever',
+        name="whatever",
         version=pretend.stub(),
         metadata_version=pretend.stub(),
         summary=pretend.stub(),
@@ -146,7 +142,7 @@ def test_metadata_dictionary(gpg_signature):
     )
 
     pkg = package.PackageFile(
-        filename='tests/fixtures/twine-1.5.0-py2.py3-none-any.whl',
+        filename="tests/fixtures/twine-1.5.0-py2.py3-none-any.whl",
         comment=pretend.stub(),
         metadata=meta,
         python_version=pretend.stub(),
@@ -157,61 +153,61 @@ def test_metadata_dictionary(gpg_signature):
     result = pkg.metadata_dictionary()
 
     # identify release
-    assert result['name'] == pkg.safe_name
-    assert result['version'] == meta.version
+    assert result["name"] == pkg.safe_name
+    assert result["version"] == meta.version
 
     # file content
-    assert result['filetype'] == pkg.filetype
-    assert result['pyversion'] == pkg.python_version
+    assert result["filetype"] == pkg.filetype
+    assert result["pyversion"] == pkg.python_version
 
     # additional meta-data
-    assert result['metadata_version'] == meta.metadata_version
-    assert result['summary'] == meta.summary
-    assert result['home_page'] == meta.home_page
-    assert result['author'] == meta.author
-    assert result['author_email'] == meta.author_email
-    assert result['maintainer'] == meta.maintainer
-    assert result['maintainer_email'] == meta.maintainer_email
-    assert result['license'] == meta.license
-    assert result['description'] == meta.description
-    assert result['keywords'] == meta.keywords
-    assert result['platform'] == meta.platforms
-    assert result['classifiers'] == meta.classifiers
-    assert result['download_url'] == meta.download_url
-    assert result['supported_platform'] == meta.supported_platforms
-    assert result['comment'] == pkg.comment
+    assert result["metadata_version"] == meta.metadata_version
+    assert result["summary"] == meta.summary
+    assert result["home_page"] == meta.home_page
+    assert result["author"] == meta.author
+    assert result["author_email"] == meta.author_email
+    assert result["maintainer"] == meta.maintainer
+    assert result["maintainer_email"] == meta.maintainer_email
+    assert result["license"] == meta.license
+    assert result["description"] == meta.description
+    assert result["keywords"] == meta.keywords
+    assert result["platform"] == meta.platforms
+    assert result["classifiers"] == meta.classifiers
+    assert result["download_url"] == meta.download_url
+    assert result["supported_platform"] == meta.supported_platforms
+    assert result["comment"] == pkg.comment
 
     # PEP 314
-    assert result['provides'] == meta.provides
-    assert result['requires'] == meta.requires
-    assert result['obsoletes'] == meta.obsoletes
+    assert result["provides"] == meta.provides
+    assert result["requires"] == meta.requires
+    assert result["obsoletes"] == meta.obsoletes
 
     # Metadata 1.2
-    assert result['project_urls'] == meta.project_urls
-    assert result['provides_dist'] == meta.provides_dist
-    assert result['obsoletes_dist'] == meta.obsoletes_dist
-    assert result['requires_dist'] == meta.requires_dist
-    assert result['requires_external'] == meta.requires_external
-    assert result['requires_python'] == meta.requires_python
+    assert result["project_urls"] == meta.project_urls
+    assert result["provides_dist"] == meta.provides_dist
+    assert result["obsoletes_dist"] == meta.obsoletes_dist
+    assert result["requires_dist"] == meta.requires_dist
+    assert result["requires_external"] == meta.requires_external
+    assert result["requires_python"] == meta.requires_python
 
     # Metadata 2.1
-    assert result['provides_extras'] == meta.provides_extras
-    assert result['description_content_type'] == meta.description_content_type
+    assert result["provides_extras"] == meta.provides_extras
+    assert result["description_content_type"] == meta.description_content_type
 
     # GPG signature
-    assert result.get('gpg_signature') == gpg_signature
+    assert result.get("gpg_signature") == gpg_signature
 
 
 TWINE_1_5_0_WHEEL_HEXDIGEST = package.Hexdigest(
-    '1919f967e990bee7413e2a4bc35fd5d1',
-    'd86b0f33f0c7df49e888b11c43b417da5520cbdbce9f20618b1494b600061e67',
-    'b657a4148d05bd0098c1d6d8cc4e14e766dbe93c3a5ab6723b969da27a87bac0',
+    "1919f967e990bee7413e2a4bc35fd5d1",
+    "d86b0f33f0c7df49e888b11c43b417da5520cbdbce9f20618b1494b600061e67",
+    "b657a4148d05bd0098c1d6d8cc4e14e766dbe93c3a5ab6723b969da27a87bac0",
 )
 
 
 def test_hash_manager():
     """Verify our HashManager works."""
-    filename = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
+    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
     hasher = package.HashManager(filename)
     hasher.hash()
     assert hasher.hexdigest() == TWINE_1_5_0_WHEEL_HEXDIGEST
@@ -219,10 +215,10 @@ def test_hash_manager():
 
 def test_fips_hash_manager(monkeypatch):
     """Verify the behaviour if hashlib is using FIPS mode."""
-    replaced_md5 = pretend.raiser(ValueError('fipsmode'))
-    monkeypatch.setattr(package.hashlib, 'md5', replaced_md5)
+    replaced_md5 = pretend.raiser(ValueError("fipsmode"))
+    monkeypatch.setattr(package.hashlib, "md5", replaced_md5)
 
-    filename = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
+    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
     hasher = package.HashManager(filename)
     hasher.hash()
     hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(md5=None)
@@ -231,9 +227,9 @@ def test_fips_hash_manager(monkeypatch):
 
 def test_no_blake2_hash_manager(monkeypatch):
     """Verify the behaviour with missing blake2."""
-    monkeypatch.setattr(package, 'blake2b', None)
+    monkeypatch.setattr(package, "blake2b", None)
 
-    filename = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
+    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
     hasher = package.HashManager(filename)
     hasher.hash()
     hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(blake2=None)
@@ -251,9 +247,9 @@ def test_pkginfo_returns_no_metadata(monkeypatch):
         return pretend.stub(name=None, version=None)
 
     monkeypatch.setattr(package, "DIST_TYPES", {"bdist_wheel": EmptyDist})
-    filename = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
+    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
 
     with pytest.raises(exceptions.InvalidDistribution) as err:
         package.PackageFile.from_filename(filename, comment=None)
 
-    assert 'Invalid distribution metadata' in err.value.args[0]
+    assert "Invalid distribution metadata" in err.value.args[0]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -9,26 +9,27 @@ from twine import exceptions
 
 # TODO: Copied from test_upload.py. Extract to helpers?
 
-WHEEL_FIXTURE = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
+WHEEL_FIXTURE = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
 
 
 def test_exception_for_redirect(make_settings):
-    register_settings = make_settings("""
+    register_settings = make_settings(
+        """
         [pypi]
         repository: https://test.pypi.org/legacy
         username:foo
         password:bar
-    """)
+    """
+    )
 
     stub_response = pretend.stub(
         is_redirect=True,
         status_code=301,
-        headers={'location': 'https://test.pypi.org/legacy/'}
+        headers={"location": "https://test.pypi.org/legacy/"},
     )
 
     stub_repository = pretend.stub(
-        register=lambda package: stub_response,
-        close=lambda: None
+        register=lambda package: stub_response, close=lambda: None
     )
 
     register_settings.create_repository = lambda: stub_repository

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -23,80 +23,73 @@ from contextlib import contextmanager
 
 def test_gpg_signature_structure_is_preserved():
     data = {
-        'gpg_signature': ('filename.asc', 'filecontent'),
+        "gpg_signature": ("filename.asc", "filecontent"),
     }
 
     tuples = repository.Repository._convert_data_to_list_of_tuples(data)
-    assert tuples == [('gpg_signature', ('filename.asc', 'filecontent'))]
+    assert tuples == [("gpg_signature", ("filename.asc", "filecontent"))]
 
 
 def test_content_structure_is_preserved():
     data = {
-        'content': ('filename', 'filecontent'),
+        "content": ("filename", "filecontent"),
     }
 
     tuples = repository.Repository._convert_data_to_list_of_tuples(data)
-    assert tuples == [('content', ('filename', 'filecontent'))]
+    assert tuples == [("content", ("filename", "filecontent"))]
 
 
 def test_iterables_are_flattened():
     data = {
-        'platform': ['UNKNOWN'],
+        "platform": ["UNKNOWN"],
     }
 
     tuples = repository.Repository._convert_data_to_list_of_tuples(data)
-    assert tuples == [('platform', 'UNKNOWN')]
+    assert tuples == [("platform", "UNKNOWN")]
 
     data = {
-        'platform': ['UNKNOWN', 'ANOTHERPLATFORM'],
+        "platform": ["UNKNOWN", "ANOTHERPLATFORM"],
     }
 
     tuples = repository.Repository._convert_data_to_list_of_tuples(data)
-    assert tuples == [('platform', 'UNKNOWN'),
-                      ('platform', 'ANOTHERPLATFORM')]
+    assert tuples == [("platform", "UNKNOWN"), ("platform", "ANOTHERPLATFORM")]
 
 
 def test_set_client_certificate():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
     )
 
     assert repo.session.cert is None
 
-    repo.set_client_certificate(('/path/to/cert', '/path/to/key'))
-    assert repo.session.cert == ('/path/to/cert', '/path/to/key')
+    repo.set_client_certificate(("/path/to/cert", "/path/to/key"))
+    assert repo.session.cert == ("/path/to/cert", "/path/to/key")
 
 
 def test_set_certificate_authority():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
     )
 
     assert repo.session.verify is True
 
-    repo.set_certificate_authority('/path/to/cert')
-    assert repo.session.verify == '/path/to/cert'
+    repo.set_certificate_authority("/path/to/cert")
+    assert repo.session.verify == "/path/to/cert"
 
 
 def test_make_user_agent_string():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
     )
 
-    assert 'User-Agent' in repo.session.headers
+    assert "User-Agent" in repo.session.headers
 
-    user_agent = repo.session.headers['User-Agent']
-    assert 'twine/' in user_agent
-    assert 'requests/' in user_agent
-    assert 'requests-toolbelt/' in user_agent
-    assert 'pkginfo/' in user_agent
-    assert 'setuptools/' in user_agent
+    user_agent = repo.session.headers["User-Agent"]
+    assert "twine/" in user_agent
+    assert "requests/" in user_agent
+    assert "requests-toolbelt/" in user_agent
+    assert "pkginfo/" in user_agent
+    assert "setuptools/" in user_agent
 
 
 def response_with(**kwattrs):
@@ -110,50 +103,37 @@ def response_with(**kwattrs):
 
 def test_package_is_uploaded_404s():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
     )
-    repo.session = pretend.stub(
-        get=lambda url, headers: response_with(status_code=404)
-    )
-    package = pretend.stub(
-        safe_name='fake',
-        metadata=pretend.stub(version='2.12.0'),
-    )
+    repo.session = pretend.stub(get=lambda url, headers: response_with(status_code=404))
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
     assert repo.package_is_uploaded(package) is False
 
 
 def test_package_is_uploaded_200s_with_no_releases():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
     )
     repo.session = pretend.stub(
-        get=lambda url, headers: response_with(status_code=200,
-                                               _content=b'{"releases": {}}',
-                                               _content_consumed=True),
+        get=lambda url, headers: response_with(
+            status_code=200, _content=b'{"releases": {}}', _content_consumed=True
+        ),
     )
-    package = pretend.stub(
-        safe_name='fake',
-        metadata=pretend.stub(version='2.12.0'),
-    )
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
     assert repo.package_is_uploaded(package) is False
 
 
-@pytest.mark.parametrize('disable_progress_bar', [
-    True,
-    False
-])
-def test_disable_progress_bar_is_forwarded_to_tqdm(monkeypatch, tmpdir,
-                                                   disable_progress_bar):
+@pytest.mark.parametrize("disable_progress_bar", [True, False])
+def test_disable_progress_bar_is_forwarded_to_tqdm(
+    monkeypatch, tmpdir, disable_progress_bar
+):
     """Test whether the disable flag is passed to tqdm
         when the disable_progress_bar option is passed to the
         repository
     """
+
     @contextmanager
     def progressbarstub(*args, **kwargs):
         assert "disable" in kwargs
@@ -163,87 +143,76 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(monkeypatch, tmpdir,
     monkeypatch.setattr(repository, "ProgressBar", progressbarstub)
     repo = repository.Repository(
         repository_url=DEFAULT_REPOSITORY,
-        username='username',
-        password='password',
+        username="username",
+        password="password",
         disable_progress_bar=disable_progress_bar,
     )
 
     repo.session = pretend.stub(
-        post=lambda url, data, allow_redirects, headers: response_with(
-            status_code=200)
+        post=lambda url, data, allow_redirects, headers: response_with(status_code=200)
     )
 
-    fakefile = tmpdir.join('fake.whl')
-    fakefile.write('.')
+    fakefile = tmpdir.join("fake.whl")
+    fakefile.write(".")
 
     def dictfunc():
         return {"name": "fake"}
 
     package = pretend.stub(
-        safe_name='fake',
-        metadata=pretend.stub(version='2.12.0'),
+        safe_name="fake",
+        metadata=pretend.stub(version="2.12.0"),
         basefilename="fake.whl",
         filename=str(fakefile),
-        metadata_dictionary=dictfunc
+        metadata_dictionary=dictfunc,
     )
 
     repo.upload(package)
 
 
-@pytest.mark.parametrize('package_meta,repository_url,release_urls', [
-    # Single package
-    (
-        [('fake', '2.12.0')],
-        DEFAULT_REPOSITORY,
-        {'https://pypi.org/project/fake/2.12.0/'},
-    ),
-    # Single package to testpypi
-    (
-        [('fake', '2.12.0')],
-        TEST_REPOSITORY,
-        {'https://test.pypi.org/project/fake/2.12.0/'},
-    ),
-    # Multiple packages (faking a wheel and an sdist)
-    (
-        [('fake', '2.12.0'), ('fake', '2.12.0')],
-        DEFAULT_REPOSITORY,
-        {'https://pypi.org/project/fake/2.12.0/'},
-    ),
-    # Multiple releases
-    (
-        [('fake', '2.12.0'), ('fake', '2.12.1')],
-        DEFAULT_REPOSITORY,
-        {
-            'https://pypi.org/project/fake/2.12.0/',
-            'https://pypi.org/project/fake/2.12.1/',
-        },
-    ),
-    # Not pypi
-    (
-        [('fake', '2.12.0')],
-        'http://devpi.example.com',
-        set(),
-    ),
-    # No packages
-    (
-        [],
-        DEFAULT_REPOSITORY,
-        set(),
-    ),
-])
+@pytest.mark.parametrize(
+    "package_meta,repository_url,release_urls",
+    [
+        # Single package
+        (
+            [("fake", "2.12.0")],
+            DEFAULT_REPOSITORY,
+            {"https://pypi.org/project/fake/2.12.0/"},
+        ),
+        # Single package to testpypi
+        (
+            [("fake", "2.12.0")],
+            TEST_REPOSITORY,
+            {"https://test.pypi.org/project/fake/2.12.0/"},
+        ),
+        # Multiple packages (faking a wheel and an sdist)
+        (
+            [("fake", "2.12.0"), ("fake", "2.12.0")],
+            DEFAULT_REPOSITORY,
+            {"https://pypi.org/project/fake/2.12.0/"},
+        ),
+        # Multiple releases
+        (
+            [("fake", "2.12.0"), ("fake", "2.12.1")],
+            DEFAULT_REPOSITORY,
+            {
+                "https://pypi.org/project/fake/2.12.0/",
+                "https://pypi.org/project/fake/2.12.1/",
+            },
+        ),
+        # Not pypi
+        ([("fake", "2.12.0")], "http://devpi.example.com", set(),),
+        # No packages
+        ([], DEFAULT_REPOSITORY, set(),),
+    ],
+)
 def test_release_urls(package_meta, repository_url, release_urls):
     packages = [
-        pretend.stub(
-            safe_name=name,
-            metadata=pretend.stub(version=version),
-        )
+        pretend.stub(safe_name=name, metadata=pretend.stub(version=version),)
         for name, version in package_meta
     ]
 
     repo = repository.Repository(
-        repository_url=repository_url,
-        username='username',
-        password='password',
+        repository_url=repository_url, username="username", password="password",
     )
 
     assert repo.release_urls(packages) == release_urls

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ import pytest
 def test_settings_takes_no_positional_arguments():
     """Verify that the Settings initialization is kw-only."""
     with pytest.raises(TypeError):
-        settings.Settings('a', 'b', 'c')
+        settings.Settings("a", "b", "c")
 
 
 def test_settings_transforms_config(tmpdir):
@@ -33,20 +33,23 @@ def test_settings_transforms_config(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [pypi]
             repository: https://upload.pypi.org/legacy/
             username:username
             password:password
-        """))
+        """
+            )
+        )
     s = settings.Settings(config_file=pypirc)
-    assert (s.repository_config['repository'] ==
-            'https://upload.pypi.org/legacy/')
+    assert s.repository_config["repository"] == "https://upload.pypi.org/legacy/"
     assert s.sign is False
-    assert s.sign_with == 'gpg'
+    assert s.sign_with == "gpg"
     assert s.identity is None
-    assert s.username == 'username'
-    assert s.password == 'password'
+    assert s.username == "username"
+    assert s.password == "password"
     assert s.cacert is None
     assert s.client_cert is None
     assert s.disable_progress_bar is False
@@ -55,37 +58,35 @@ def test_settings_transforms_config(tmpdir):
 def test_identity_requires_sign():
     """Verify that if a user passes identity, we require sign=True."""
     with pytest.raises(exceptions.InvalidSigningConfiguration):
-        settings.Settings(sign=False, identity='fakeid')
+        settings.Settings(sign=False, identity="fakeid")
 
 
 def test_password_not_required_if_client_cert(entered_password):
     """Verify that if client_cert is provided then a password is not."""
-    test_client_cert = '/random/path'
-    settings_obj = settings.Settings(
-        username='fakeuser', client_cert=test_client_cert)
+    test_client_cert = "/random/path"
+    settings_obj = settings.Settings(username="fakeuser", client_cert=test_client_cert)
     assert not settings_obj.password
     assert settings_obj.client_cert == test_client_cert
 
 
-@pytest.mark.parametrize('client_cert', [None, ""])
+@pytest.mark.parametrize("client_cert", [None, ""])
 def test_password_is_required_if_no_client_cert(client_cert, entered_password):
     """Verify that if client_cert is not provided then a password must be."""
-    settings_obj = settings.Settings(
-        username='fakeuser', client_cert=client_cert)
-    assert settings_obj.password == 'entered pw'
+    settings_obj = settings.Settings(username="fakeuser", client_cert=client_cert)
+    assert settings_obj.password == "entered pw"
 
 
 def test_client_cert_is_set_and_password_not_if_both_given(entered_password):
     """Verify that if both password and client_cert are given they are set"""
-    client_cert = '/random/path'
+    client_cert = "/random/path"
     settings_obj = settings.Settings(
-        username='fakeuser', password='anything', client_cert=client_cert)
+        username="fakeuser", password="anything", client_cert=client_cert
+    )
     assert not settings_obj.password
     assert settings_obj.client_cert == client_cert
 
 
 class TestArgumentParsing:
-
     @staticmethod
     def parse_args(args):
         parser = argparse.ArgumentParser()
@@ -93,7 +94,7 @@ class TestArgumentParsing:
         return parser.parse_args(args)
 
     def test_non_interactive_flag(self):
-        args = self.parse_args(['--non-interactive'])
+        args = self.parse_args(["--non-interactive"])
         assert args.non_interactive
 
     def test_non_interactive_environment(self, monkeypatch):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -21,34 +21,33 @@ import twine
 
 import helpers
 
-SDIST_FIXTURE = 'tests/fixtures/twine-1.5.0.tar.gz'
-WHEEL_FIXTURE = 'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl'
-RELEASE_URL = 'https://pypi.org/project/twine/1.5.0/'
-NEW_SDIST_FIXTURE = 'tests/fixtures/twine-1.6.5.tar.gz'
-NEW_WHEEL_FIXTURE = 'tests/fixtures/twine-1.6.5-py2.py3-none-any.whl'
-NEW_RELEASE_URL = 'https://pypi.org/project/twine/1.6.5/'
+SDIST_FIXTURE = "tests/fixtures/twine-1.5.0.tar.gz"
+WHEEL_FIXTURE = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
+RELEASE_URL = "https://pypi.org/project/twine/1.5.0/"
+NEW_SDIST_FIXTURE = "tests/fixtures/twine-1.6.5.tar.gz"
+NEW_WHEEL_FIXTURE = "tests/fixtures/twine-1.6.5-py2.py3-none-any.whl"
+NEW_RELEASE_URL = "https://pypi.org/project/twine/1.6.5/"
 
 
 def test_successful_upload(make_settings, capsys):
     upload_settings = make_settings()
 
     stub_response = pretend.stub(
-        is_redirect=False,
-        status_code=201,
-        raise_for_status=lambda: None
+        is_redirect=False, status_code=201, raise_for_status=lambda: None
     )
 
     stub_repository = pretend.stub(
         upload=lambda package: stub_response,
         close=lambda: None,
-        release_urls=lambda packages: {RELEASE_URL, NEW_RELEASE_URL}
+        release_urls=lambda packages: {RELEASE_URL, NEW_RELEASE_URL},
     )
 
     upload_settings.create_repository = lambda: stub_repository
 
-    result = upload.upload(upload_settings, [
-        WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
-    ])
+    result = upload.upload(
+        upload_settings,
+        [WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE],
+    )
 
     # A truthy result means the upload failed
     assert result is None
@@ -58,7 +57,7 @@ def test_successful_upload(make_settings, capsys):
     assert captured.out.count(NEW_RELEASE_URL) == 1
 
 
-@pytest.mark.parametrize('verbose', [False, True])
+@pytest.mark.parametrize("verbose", [False, True])
 def test_exception_for_http_status(verbose, make_settings, capsys):
     upload_settings = make_settings()
     upload_settings.verbose = verbose
@@ -67,12 +66,11 @@ def test_exception_for_http_status(verbose, make_settings, capsys):
         is_redirect=False,
         status_code=403,
         text="Invalid or non-existent authentication information",
-        raise_for_status=pretend.raiser(HTTPError)
+        raise_for_status=pretend.raiser(HTTPError),
     )
 
     stub_repository = pretend.stub(
-        upload=lambda package: stub_response,
-        close=lambda: None,
+        upload=lambda package: stub_response, close=lambda: None,
     )
 
     upload_settings.create_repository = lambda: stub_repository
@@ -85,64 +83,75 @@ def test_exception_for_http_status(verbose, make_settings, capsys):
 
     if verbose:
         assert stub_response.text in captured.out
-        assert '--verbose' not in captured.out
+        assert "--verbose" not in captured.out
     else:
         assert stub_response.text not in captured.out
-        assert '--verbose' in captured.out
+        assert "--verbose" in captured.out
 
 
 def test_get_config_old_format(make_settings, pypirc):
     try:
-        make_settings("""
+        make_settings(
+            """
             [server-login]
             username:foo
             password:bar
-        """)
+        """
+        )
     except KeyError as err:
-        assert all(text in err.args[0] for text in [
-            "'pypi'",
-            "--repository-url",
-            pypirc,
-            "https://docs.python.org/",
-        ])
+        assert all(
+            text in err.args[0]
+            for text in [
+                "'pypi'",
+                "--repository-url",
+                pypirc,
+                "https://docs.python.org/",
+            ]
+        )
 
 
 def test_deprecated_repo(make_settings):
     with pytest.raises(exceptions.UploadToDeprecatedPyPIDetected) as err:
-        upload_settings = make_settings("""
+        upload_settings = make_settings(
+            """
             [pypi]
             repository: https://pypi.python.org/pypi/
             username:foo
             password:bar
-        """)
+        """
+        )
 
         upload.upload(upload_settings, [WHEEL_FIXTURE])
 
-    assert all(text in err.value.args[0] for text in [
-        "https://pypi.python.org/pypi/",
-        "https://upload.pypi.org/legacy/",
-        "https://test.pypi.org/legacy/",
-        "https://packaging.python.org/",
-    ])
+    assert all(
+        text in err.value.args[0]
+        for text in [
+            "https://pypi.python.org/pypi/",
+            "https://upload.pypi.org/legacy/",
+            "https://test.pypi.org/legacy/",
+            "https://packaging.python.org/",
+        ]
+    )
 
 
 def test_exception_for_redirect(make_settings):
-    upload_settings = make_settings("""
+    upload_settings = make_settings(
+        """
         [pypi]
         repository: https://test.pypi.org/legacy
         username:foo
         password:bar
-    """)
+    """
+    )
 
     stub_response = pretend.stub(
         is_redirect=True,
         status_code=301,
-        headers={'location': 'https://test.pypi.org/legacy/'}
+        headers={"location": "https://test.pypi.org/legacy/"},
     )
 
     stub_repository = pretend.stub(
-        upload=lambda package: stub_response,
-        close=lambda: None
+        upload=lambda package: stub_response, close=lambda: None
     )
 
     upload_settings.create_repository = lambda: stub_repository
@@ -160,7 +169,7 @@ def test_prints_skip_message_for_uploaded_package(make_settings, capsys):
         # Short-circuit the upload, so no need for a stub response
         package_is_uploaded=lambda package: True,
         release_urls=lambda packages: {},
-        close=lambda: None
+        close=lambda: None,
     )
 
     upload_settings.create_repository = lambda: stub_repository
@@ -178,17 +187,14 @@ def test_prints_skip_message_for_uploaded_package(make_settings, capsys):
 def test_prints_skip_message_for_response(make_settings, capsys):
     upload_settings = make_settings(skip_existing=True)
 
-    stub_response = pretend.stub(
-        is_redirect=False,
-        status_code=409,
-    )
+    stub_response = pretend.stub(is_redirect=False, status_code=409,)
 
     stub_repository = pretend.stub(
         # Do the upload, triggering the error response
         package_is_uploaded=lambda package: False,
         release_urls=lambda packages: {},
         upload=lambda package: stub_response,
-        close=lambda: None
+        close=lambda: None,
     )
 
     upload_settings.create_repository = lambda: stub_repository
@@ -203,45 +209,63 @@ def test_prints_skip_message_for_response(make_settings, capsys):
     assert RELEASE_URL not in captured.out
 
 
-@pytest.mark.parametrize('response_kwargs', [
-    pytest.param(
-        dict(status_code=400, reason=(
-            'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
-            'exists for twine-1.5.0.'
-        )),
-        id='pypi'
-    ),
-    pytest.param(
-        dict(status_code=400, reason=(
-            'Repository does not allow updating assets: pypi for url: '
-            'http://www.foo.bar'
-        )),
-        id='nexus'
-    ),
-    pytest.param(
-        dict(status_code=409, reason=(
-            'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
-            'exists for twine-1.5.0.'
-        )),
-        id='pypiserver'
-    ),
-    pytest.param(
-        dict(status_code=403, text=(
-            "Not enough permissions to overwrite artifact "
-            "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
-            "(user 'twine-deployer' needs DELETE permission)."
-        )),
-        id='artifactory_old'
-    ),
-    pytest.param(
-        dict(status_code=403, text=(
-            "Not enough permissions to delete/overwrite artifact "
-            "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
-            "(user 'twine-deployer' needs DELETE permission)."
-        )),
-        id='artifactory_new'
-    ),
-])
+@pytest.mark.parametrize(
+    "response_kwargs",
+    [
+        pytest.param(
+            dict(
+                status_code=400,
+                reason=(
+                    'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
+                    "exists for twine-1.5.0."
+                ),
+            ),
+            id="pypi",
+        ),
+        pytest.param(
+            dict(
+                status_code=400,
+                reason=(
+                    "Repository does not allow updating assets: pypi for url: "
+                    "http://www.foo.bar"
+                ),
+            ),
+            id="nexus",
+        ),
+        pytest.param(
+            dict(
+                status_code=409,
+                reason=(
+                    'A file named "twine-1.5.0-py2.py3-none-any.whl" already '
+                    "exists for twine-1.5.0."
+                ),
+            ),
+            id="pypiserver",
+        ),
+        pytest.param(
+            dict(
+                status_code=403,
+                text=(
+                    "Not enough permissions to overwrite artifact "
+                    "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
+                    "(user 'twine-deployer' needs DELETE permission)."
+                ),
+            ),
+            id="artifactory_old",
+        ),
+        pytest.param(
+            dict(
+                status_code=403,
+                text=(
+                    "Not enough permissions to delete/overwrite artifact "
+                    "'pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl'"
+                    "(user 'twine-deployer' needs DELETE permission)."
+                ),
+            ),
+            id="artifactory_new",
+        ),
+    ],
+)
 def test_skip_existing_skips_files_on_repository(response_kwargs):
     assert upload.skip_upload(
         response=pretend.stub(**response_kwargs),
@@ -250,21 +274,20 @@ def test_skip_existing_skips_files_on_repository(response_kwargs):
     )
 
 
-@pytest.mark.parametrize('response_kwargs', [
-    pytest.param(
-        dict(status_code=400, reason='Invalid credentials'),
-        id='wrong_reason'
-    ),
-    pytest.param(
-        dict(status_code=404),
-        id='wrong_code'
-    ),
-])
+@pytest.mark.parametrize(
+    "response_kwargs",
+    [
+        pytest.param(
+            dict(status_code=400, reason="Invalid credentials"), id="wrong_reason"
+        ),
+        pytest.param(dict(status_code=404), id="wrong_code"),
+    ],
+)
 def test_skip_upload_doesnt_match(response_kwargs):
     assert not upload.skip_upload(
         response=pretend.stub(**response_kwargs),
         skip_existing=True,
-        package=package.PackageFile.from_filename(WHEEL_FIXTURE, None)
+        package=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
     )
 
 
@@ -282,9 +305,11 @@ def test_values_from_env(monkeypatch):
 
     replaced_upload = pretend.call_recorder(none_upload)
     monkeypatch.setattr(twine.commands.upload, "upload", replaced_upload)
-    testenv = {"TWINE_USERNAME": "pypiuser",
-               "TWINE_PASSWORD": "pypipassword",
-               "TWINE_CERT": "/foo/bar.crt"}
+    testenv = {
+        "TWINE_USERNAME": "pypiuser",
+        "TWINE_PASSWORD": "pypipassword",
+        "TWINE_CERT": "/foo/bar.crt",
+    }
     with helpers.set_env(**testenv):
         cli.dispatch(["upload", "path/to/file"])
     upload_settings = replaced_upload.calls[0].args[0]
@@ -293,18 +318,18 @@ def test_values_from_env(monkeypatch):
     assert "/foo/bar.crt" == upload_settings.cacert
 
 
-@pytest.mark.parametrize('repo_url', [
-    "https://upload.pypi.org/",
-    "https://test.pypi.org/",
-    "https://pypi.org/"
-])
+@pytest.mark.parametrize(
+    "repo_url",
+    ["https://upload.pypi.org/", "https://test.pypi.org/", "https://pypi.org/"],
+)
 def test_check_status_code_for_wrong_repo_url(repo_url, make_settings):
     upload_settings = make_settings()
 
     # override defaults to use incorrect URL
-    upload_settings.repository_config['repository'] = repo_url
+    upload_settings.repository_config["repository"] = repo_url
 
     with pytest.raises(twine.exceptions.InvalidPyPIUploadURL):
-        upload.upload(upload_settings, [
-            WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE
-        ])
+        upload.upload(
+            upload_settings,
+            [WHEEL_FIXTURE, SDIST_FIXTURE, NEW_SDIST_FIXTURE, NEW_WHEEL_FIXTURE],
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,14 +27,18 @@ def test_get_config(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [distutils]
             index-servers = pypi
 
             [pypi]
             username = testuser
             password = testpassword
-        """))
+        """
+            )
+        )
 
     assert utils.get_config(pypirc) == {
         "pypi": {
@@ -53,11 +57,15 @@ def test_get_config_no_distutils(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [pypi]
             username = testuser
             password = testpassword
-        """))
+        """
+            )
+        )
 
     assert utils.get_config(pypirc) == {
         "pypi": {
@@ -77,14 +85,18 @@ def test_get_config_no_section(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [distutils]
             index-servers = pypi foo
 
             [pypi]
             username = testuser
             password = testpassword
-        """))
+        """
+            )
+        )
 
     assert utils.get_config(pypirc) == {
         "pypi": {
@@ -99,12 +111,16 @@ def test_get_config_override_pypi_url(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [pypi]
             repository = http://pypiproxy
-        """))
+        """
+            )
+        )
 
-    assert utils.get_config(pypirc)['pypi']['repository'] == 'http://pypiproxy'
+    assert utils.get_config(pypirc)["pypi"]["repository"] == "http://pypiproxy"
 
 
 def test_get_config_missing(tmpdir):
@@ -119,7 +135,7 @@ def test_get_config_missing(tmpdir):
         "testpypi": {
             "repository": utils.TEST_REPOSITORY,
             "username": None,
-            "password": None
+            "password": None,
         },
     }
 
@@ -132,16 +148,20 @@ def test_empty_userpass(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
-        fp.write(textwrap.dedent("""
+        fp.write(
+            textwrap.dedent(
+                """
             [pypi]
             username=
             password=
-        """))
+        """
+            )
+        )
 
     config = utils.get_config(pypirc)
-    pypi = config['pypi']
+    pypi = config["pypi"]
 
-    assert pypi['username'] == pypi['password'] == ''
+    assert pypi["username"] == pypi["password"] == ""
 
 
 def test_get_repository_config_missing(tmpdir):
@@ -153,22 +173,19 @@ def test_get_repository_config_missing(tmpdir):
         "username": None,
         "password": None,
     }
-    assert (utils.get_repository_from_config(pypirc, 'foo', repository_url) ==
-            exp)
-    assert (utils.get_repository_from_config(pypirc, 'pypi', repository_url) ==
-            exp)
+    assert utils.get_repository_from_config(pypirc, "foo", repository_url) == exp
+    assert utils.get_repository_from_config(pypirc, "pypi", repository_url) == exp
     exp = {
-            "repository": utils.DEFAULT_REPOSITORY,
-            "username": None,
-            "password": None,
-        }
+        "repository": utils.DEFAULT_REPOSITORY,
+        "username": None,
+        "password": None,
+    }
     assert utils.get_repository_from_config(pypirc, "pypi") == exp
 
 
 def test_get_config_deprecated_pypirc():
     tests_dir = os.path.dirname(os.path.abspath(__file__))
-    deprecated_pypirc_path = os.path.join(tests_dir, 'fixtures',
-                                          'deprecated-pypirc')
+    deprecated_pypirc_path = os.path.join(tests_dir, "fixtures", "deprecated-pypirc")
 
     assert utils.get_config(deprecated_pypirc_path) == {
         "pypi": {
@@ -185,11 +202,11 @@ def test_get_config_deprecated_pypirc():
 
 
 @pytest.mark.parametrize(
-    ('cli_value', 'config', 'key', 'strategy', 'expected'),
+    ("cli_value", "config", "key", "strategy", "expected"),
     (
-        ('cli', {}, 'key', lambda: 'fallback', 'cli'),
-        (None, {'key': 'value'}, 'key', lambda: 'fallback', 'value'),
-        (None, {}, 'key', lambda: 'fallback', 'fallback'),
+        ("cli", {}, "key", lambda: "fallback", "cli"),
+        (None, {"key": "value"}, "key", lambda: "fallback", "value"),
+        (None, {}, "key", lambda: "fallback", "fallback"),
     ),
 )
 def test_get_userpass_value(cli_value, config, key, strategy, expected):
@@ -198,38 +215,30 @@ def test_get_userpass_value(cli_value, config, key, strategy, expected):
 
 
 @pytest.mark.parametrize(
-    ('env_name', 'default', 'environ', 'expected'),
+    ("env_name", "default", "environ", "expected"),
     [
-        ('MY_PASSWORD', None, {}, None),
-        ('MY_PASSWORD', None, {'MY_PASSWORD': 'foo'}, 'foo'),
-        ('URL', 'https://example.org', {}, 'https://example.org'),
-        ('URL', 'https://example.org', {'URL': 'https://pypi.org'},
-            'https://pypi.org'),
+        ("MY_PASSWORD", None, {}, None),
+        ("MY_PASSWORD", None, {"MY_PASSWORD": "foo"}, "foo"),
+        ("URL", "https://example.org", {}, "https://example.org"),
+        ("URL", "https://example.org", {"URL": "https://pypi.org"}, "https://pypi.org"),
     ],
 )
 def test_default_to_environment_action(env_name, default, environ, expected):
-    option_strings = ('-x', '--example')
-    dest = 'example'
+    option_strings = ("-x", "--example")
+    dest = "example"
     with helpers.set_env(**environ):
         action = utils.EnvironmentDefault(
-            env=env_name,
-            default=default,
-            option_strings=option_strings,
-            dest=dest,
+            env=env_name, default=default, option_strings=option_strings, dest=dest,
         )
     assert action.env == env_name
     assert action.default == expected
 
 
-@pytest.mark.parametrize('repo_url', [
-    "https://pypi.python.org",
-    "https://testpypi.python.org"
-])
+@pytest.mark.parametrize(
+    "repo_url", ["https://pypi.python.org", "https://testpypi.python.org"]
+)
 def test_check_status_code_for_deprecated_pypi_url(repo_url):
-    response = pretend.stub(
-        status_code=410,
-        url=repo_url
-    )
+    response = pretend.stub(status_code=410, url=repo_url)
 
     # value of Verbose doesn't matter for this check
     with pytest.raises(exceptions.UploadToDeprecatedPyPIDetected):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -16,30 +16,32 @@ from twine import wheel
 import pytest
 
 
-@pytest.fixture(params=[
-    'tests/fixtures/twine-1.5.0-py2.py3-none-any.whl',
-    'tests/alt-fixtures/twine-1.5.0-py2.py3-none-any.whl'
-])
+@pytest.fixture(
+    params=[
+        "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl",
+        "tests/alt-fixtures/twine-1.5.0-py2.py3-none-any.whl",
+    ]
+)
 def example_wheel(request):
     return wheel.Wheel(request.param)
 
 
 def test_version_parsing(example_wheel):
-    assert example_wheel.py_version == 'py2.py3'
+    assert example_wheel.py_version == "py2.py3"
 
 
 def test_find_metadata_files():
     names = [
-        'package/lib/__init__.py',
-        'package/lib/version.py',
-        'package/METADATA.txt',
-        'package/METADATA.json',
-        'package/METADATA',
+        "package/lib/__init__.py",
+        "package/lib/version.py",
+        "package/METADATA.txt",
+        "package/METADATA.json",
+        "package/METADATA",
     ]
     expected = [
-        ['package', 'METADATA'],
-        ['package', 'METADATA.json'],
-        ['package', 'METADATA.txt'],
+        ["package", "METADATA"],
+        ["package", "METADATA.json"],
+        ["package", "METADATA.txt"],
     ]
     candidates = wheel.Wheel.find_candidate_metadata_files(names)
     assert expected == candidates

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __all__ = (
-    "__title__", "__summary__", "__uri__", "__version__", "__author__",
-    "__email__", "__license__", "__copyright__",
+    "__title__",
+    "__summary__",
+    "__uri__",
+    "__version__",
+    "__author__",
+    "__email__",
+    "__license__",
+    "__copyright__",
 )
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
@@ -26,13 +32,13 @@ else:
     import importlib_metadata
 
 
-metadata = importlib_metadata.metadata('twine')
+metadata = importlib_metadata.metadata("twine")
 
 
-__title__ = metadata['name']
-__summary__ = metadata['summary']
-__uri__ = metadata['home-page']
-__version__ = metadata['version']
-__author__ = metadata['author']
-__email__ = metadata['author-email']
-__license__ = metadata['license']
+__title__ = metadata["name"]
+__summary__ = metadata["summary"]
+__uri__ = metadata["home-page"]
+__version__ = metadata["version"]
+__author__ = metadata["author"]
+__email__ = metadata["author-email"]
+__license__ = metadata["license"]

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -24,7 +24,7 @@ def main():
     try:
         return dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.exceptions.HTTPError) as exc:
-        return '{}: {}'.format(exc.__class__.__name__, exc.args[0])
+        return "{}: {}".format(exc.__class__.__name__, exc.args[0])
 
 
 if __name__ == "__main__":

--- a/twine/_installed.py
+++ b/twine/_installed.py
@@ -14,16 +14,15 @@ import pkginfo
 
 
 class Installed(pkginfo.Installed):
-
     def read(self):
         opj = os.path.join
         if self.package is not None:
             package = self.package.__package__
             if package is None:
                 package = self.package.__name__
-            egg_pattern = '%s*.egg-info' % package
-            dist_pattern = '%s*.dist-info' % package
-            file = getattr(self.package, '__file__', None)
+            egg_pattern = "%s*.egg-info" % package
+            dist_pattern = "%s*.dist-info" % package
+            file = getattr(self.package, "__file__", None)
             if file is not None:
                 candidates = []
 
@@ -32,27 +31,28 @@ class Installed(pkginfo.Installed):
 
                 for entry in sys.path:
                     if file.startswith(entry):
-                        _add_candidate(opj(entry, 'METADATA'))  # egg?
-                        _add_candidate(opj(entry, 'EGG-INFO'))  # egg?
+                        _add_candidate(opj(entry, "METADATA"))  # egg?
+                        _add_candidate(opj(entry, "EGG-INFO"))  # egg?
                         # dist-installed?
                         _add_candidate(opj(entry, egg_pattern))
                         _add_candidate(opj(entry, dist_pattern))
                 dir, name = os.path.split(self.package.__file__)
                 _add_candidate(opj(dir, egg_pattern))
                 _add_candidate(opj(dir, dist_pattern))
-                _add_candidate(opj(dir, '..', egg_pattern))
-                _add_candidate(opj(dir, '..', dist_pattern))
+                _add_candidate(opj(dir, "..", egg_pattern))
+                _add_candidate(opj(dir, "..", dist_pattern))
 
                 for candidate in candidates:
                     if os.path.isdir(candidate):
-                        path = opj(candidate, 'PKG-INFO')
+                        path = opj(candidate, "PKG-INFO")
                         if not os.path.exists(path):
-                            path = opj(candidate, 'METADATA')
+                            path = opj(candidate, "METADATA")
                     else:
                         path = candidate
                     if os.path.exists(path):
                         with open(path) as f:
                             return f.read()
 
-        warnings.warn('No PKG-INFO or METADATA found for package: %s' %
-                      self.package_name)
+        warnings.warn(
+            "No PKG-INFO or METADATA found for package: %s" % self.package_name
+        )

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -10,7 +10,6 @@ from . import exceptions
 
 
 class CredentialInput:
-
     def __init__(self, username: str = None, password: str = None):
         self.username = username
         self.password = password
@@ -31,7 +30,7 @@ class Resolver:
         return utils.get_userpass_value(
             self.input.username,
             self.config,
-            key='username',
+            key="username",
             prompt_strategy=self.username_from_keyring_or_prompt,
         )
 
@@ -41,13 +40,13 @@ class Resolver:
         return utils.get_userpass_value(
             self.input.password,
             self.config,
-            key='password',
+            key="password",
             prompt_strategy=self.password_from_keyring_or_prompt,
         )
 
     @property
     def system(self) -> Optional[str]:
-        return self.config['repository']
+        return self.config["repository"]
 
     def get_username_from_keyring(self) -> Optional[str]:
         try:
@@ -69,15 +68,11 @@ class Resolver:
         return None
 
     def username_from_keyring_or_prompt(self) -> str:
-        return (
-            self.get_username_from_keyring()
-            or self.prompt('username', input)
-        )
+        return self.get_username_from_keyring() or self.prompt("username", input)
 
     def password_from_keyring_or_prompt(self) -> str:
-        return (
-            self.get_password_from_keyring()
-            or self.prompt('password', getpass.getpass)
+        return self.get_password_from_keyring() or self.prompt(
+            "password", getpass.getpass
         )
 
     def prompt(self, what: str, how: Callable) -> str:

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -24,25 +24,24 @@ import twine
 from twine._installed import Installed
 
 
-def _registered_commands(group='twine.registered_commands'):
+def _registered_commands(group="twine.registered_commands"):
     registered_commands = pkg_resources.iter_entry_points(group=group)
     return {c.name: c for c in registered_commands}
 
 
 def list_dependencies_and_versions():
     return [
-        ('pkginfo', Installed(pkginfo).version),
-        ('requests', requests.__version__),
-        ('setuptools', setuptools.__version__),
-        ('requests-toolbelt', requests_toolbelt.__version__),
-        ('tqdm', tqdm.__version__),
+        ("pkginfo", Installed(pkginfo).version),
+        ("requests", requests.__version__),
+        ("setuptools", setuptools.__version__),
+        ("requests-toolbelt", requests_toolbelt.__version__),
+        ("tqdm", tqdm.__version__),
     ]
 
 
 def dep_versions():
-    return ', '.join(
-        '{}: {}'.format(*dependency)
-        for dependency in list_dependencies_and_versions()
+    return ", ".join(
+        "{}: {}".format(*dependency) for dependency in list_dependencies_and_versions()
     )
 
 
@@ -52,19 +51,13 @@ def dispatch(argv):
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s version {} ({})".format(
-            twine.__version__,
-            dep_versions(),
-        ),
+        version="%(prog)s version {} ({})".format(twine.__version__, dep_versions(),),
     )
     parser.add_argument(
-        "command",
-        choices=registered_commands.keys(),
+        "command", choices=registered_commands.keys(),
     )
     parser.add_argument(
-        "args",
-        help=argparse.SUPPRESS,
-        nargs=argparse.REMAINDER,
+        "args", help=argparse.SUPPRESS, nargs=argparse.REMAINDER,
     )
 
     args = parser.parse_args(argv)

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -78,16 +78,15 @@ def _check_file(filename, render_warning_stream):
 
     if description_content_type is None:
         warnings.append(
-            '`long_description_content_type` missing.  '
-            'defaulting to `text/x-rst`.'
+            "`long_description_content_type` missing. defaulting to `text/x-rst`."
         )
-        description_content_type = 'text/x-rst'
+        description_content_type = "text/x-rst"
 
     content_type, params = cgi.parse_header(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
-    if description in {None, 'UNKNOWN\n\n\n'}:
-        warnings.append('`long_description` missing.')
+    if description in {None, "UNKNOWN\n\n\n"}:
+        warnings.append("`long_description` missing.")
     elif renderer:
         rendering_result = renderer.render(
             description, stream=render_warning_stream, **params
@@ -101,10 +100,12 @@ def _check_file(filename, render_warning_stream):
 # TODO: Replace with textwrap.indent when Python 2 support is dropped
 def _indented(text, prefix):
     """Adds 'prefix' to all non-empty lines on 'text'."""
+
     def prefixed_lines():
         for line in text.splitlines(True):
             yield (prefix + line if line.strip() else line)
-    return ''.join(prefixed_lines())
+
+    return "".join(prefixed_lines())
 
 
 def check(dists, output_stream=sys.stdout):
@@ -138,7 +139,7 @@ def check(dists, output_stream=sys.stdout):
 
         # Print warnings after the status and/or error
         for message in warnings:
-            output_stream.write('  warning: ' + message + '\n')
+            output_stream.write("  warning: " + message + "\n")
 
     return failure
 

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -20,7 +20,7 @@ from twine import settings
 
 
 def register(register_settings, package):
-    repository_url = register_settings.repository_config['repository']
+    repository_url = register_settings.repository_config["repository"]
 
     print(f"Registering package to {repository_url}")
     repository = register_settings.create_repository()
@@ -37,8 +37,7 @@ def register(register_settings, package):
 
     if resp.is_redirect:
         raise exceptions.RedirectDetected.from_args(
-            repository_url,
-            resp.headers["location"],
+            repository_url, resp.headers["location"],
         )
 
     resp.raise_for_status()

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -26,8 +26,8 @@ def skip_upload(response, skip_existing, package):
         return False
 
     status = response.status_code
-    reason = getattr(response, 'reason', '').lower()
-    text = getattr(response, 'text', '').lower()
+    reason = getattr(response, "reason", "").lower()
+    text = getattr(response, "text", "").lower()
 
     # NOTE(sigmavirus24): PyPI presently returns a 400 status code with the
     # error message in the reason attribute. Other implementations return a
@@ -36,11 +36,11 @@ def skip_upload(response, skip_existing, package):
         # pypiserver (https://pypi.org/project/pypiserver)
         status == 409
         # PyPI / TestPyPI
-        or (status == 400 and 'already exist' in reason)
+        or (status == 400 and "already exist" in reason)
         # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
-        or (status == 400 and 'updating asset' in reason)
+        or (status == 400 and "updating asset" in reason)
         # Artifactory (https://jfrog.com/artifactory/)
-        or (status == 403 and 'overwrite artifact' in text)
+        or (status == 403 and "overwrite artifact" in text)
     )
 
 
@@ -51,7 +51,7 @@ def upload(upload_settings, dists):
     signatures = {os.path.basename(d): d for d in dists if d.endswith(".asc")}
     uploads = [i for i in dists if not i.endswith(".asc")]
     upload_settings.check_repository_url()
-    repository_url = upload_settings.repository_config['repository']
+    repository_url = upload_settings.repository_config["repository"]
 
     print(f"Uploading distributions to {repository_url}")
 
@@ -60,16 +60,14 @@ def upload(upload_settings, dists):
 
     for filename in uploads:
         package = PackageFile.from_filename(filename, upload_settings.comment)
-        skip_message = (
-            "  Skipping {} because it appears to already exist".format(
-                package.basefilename)
+        skip_message = "  Skipping {} because it appears to already exist".format(
+            package.basefilename
         )
 
         # Note: The skip_existing check *needs* to be first, because otherwise
         #       we're going to generate extra HTTP requests against a hardcoded
         #       URL for no reason.
-        if (upload_settings.skip_existing and
-                repository.package_is_uploaded(package)):
+        if upload_settings.skip_existing and repository.package_is_uploaded(package):
             print(skip_message)
             continue
 
@@ -87,8 +85,7 @@ def upload(upload_settings, dists):
         # redirects as well.
         if resp.is_redirect:
             raise exceptions.RedirectDetected.from_args(
-                repository_url,
-                resp.headers["location"],
+                repository_url, resp.headers["location"],
             )
 
         if skip_upload(resp, upload_settings.skip_existing, package):
@@ -101,7 +98,7 @@ def upload(upload_settings, dists):
 
     release_urls = repository.release_urls(uploaded_packages)
     if release_urls:
-        print('\nView at:')
+        print("\nView at:")
         for url in release_urls:
             print(url)
 
@@ -118,9 +115,9 @@ def main(args):
         nargs="+",
         metavar="dist",
         help="The distribution files to upload to the repository "
-             "(package index). Usually dist/* . May additionally contain "
-             "a .asc file to include an existing signature with the "
-             "file upload.",
+        "(package index). Usually dist/* . May additionally contain "
+        "a .asc file to include an existing signature with the "
+        "file upload.",
     )
 
     args = parser.parse_args(args)

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -31,13 +31,15 @@ class RedirectDetected(TwineException):
 
     @classmethod
     def from_args(cls, repository_url, redirect_url):
-        msg = "\n".join([
-            "{} attempted to redirect to {}."
-            .format(repository_url, redirect_url),
-            "If you trust these URLs, set {} as your repository URL."
-            .format(redirect_url),
-            "Aborting."
-        ])
+        msg = "\n".join(
+            [
+                "{} attempted to redirect to {}.".format(repository_url, redirect_url),
+                "If you trust these URLs, set {} as your repository URL.".format(
+                    redirect_url
+                ),
+                "Aborting.",
+            ]
+        )
 
         return cls(msg)
 
@@ -60,14 +62,15 @@ class UploadToDeprecatedPyPIDetected(TwineException):
     @classmethod
     def from_args(cls, target_url, default_url, test_url):
         """Return an UploadToDeprecatedPyPIDetected instance."""
-        return cls("You're trying to upload to the legacy PyPI site '{}'. "
-                   "Uploading to those sites is deprecated. \n "
-                   "The new sites are pypi.org and test.pypi.org. Try using "
-                   "{} (or {}) to upload your packages instead. "
-                   "These are the default URLs for Twine now. \n More at "
-                   "https://packaging.python.org/guides/migrating-to-pypi-org/"
-                   " .".format(target_url, default_url, test_url)
-                   )
+        return cls(
+            "You're trying to upload to the legacy PyPI site '{}'. "
+            "Uploading to those sites is deprecated. \n "
+            "The new sites are pypi.org and test.pypi.org. Try using "
+            "{} (or {}) to upload your packages instead. "
+            "These are the default URLs for Twine now. \n More at "
+            "https://packaging.python.org/guides/migrating-to-pypi-org/"
+            " .".format(target_url, default_url, test_url)
+        )
 
 
 class UnreachableRepositoryURLDetected(TwineException):

--- a/twine/package.py
+++ b/twine/package.py
@@ -62,8 +62,8 @@ class PackageFile:
         self.python_version = python_version
         self.filetype = filetype
         self.safe_name = pkg_resources.safe_name(metadata.name)
-        self.signed_filename = self.filename + '.asc'
-        self.signed_basefilename = self.basefilename + '.asc'
+        self.signed_filename = self.filename + ".asc"
+        self.signed_basefilename = self.basefilename + ".asc"
         self.gpg_signature: Optional[Tuple[str, bytes]] = None
 
         hasher = HashManager(filename)
@@ -75,7 +75,7 @@ class PackageFile:
         self.blake2_256_digest = hexdigest.blake2
 
     @classmethod
-    def from_filename(cls, filename: str, comment: None) -> 'PackageFile':
+    def from_filename(cls, filename: str, comment: None) -> "PackageFile":
         # Extract the metadata from the package
         for ext, dtype in DIST_EXTENSIONS.items():
             if filename.endswith(ext):
@@ -83,8 +83,7 @@ class PackageFile:
                 break
         else:
             raise exceptions.InvalidDistribution(
-                "Unknown distribution format: '%s'" %
-                os.path.basename(filename)
+                "Unknown distribution format: '%s'" % os.path.basename(filename)
             )
 
         # If pkginfo encounters a metadata version it doesn't support, it may
@@ -92,8 +91,7 @@ class PackageFile:
         # and version
         if not (meta.name and meta.version):
             raise exceptions.InvalidDistribution(
-                "Invalid distribution metadata. Try upgrading twine if "
-                "possible."
+                "Invalid distribution metadata. Try upgrading twine if possible."
             )
 
         py_version: Optional[str]
@@ -115,11 +113,9 @@ class PackageFile:
             # identify release
             "name": self.safe_name,
             "version": meta.version,
-
             # file content
             "filetype": self.filetype,
             "pyversion": self.python_version,
-
             # additional meta-data
             "metadata_version": meta.metadata_version,
             "summary": meta.summary,
@@ -139,12 +135,10 @@ class PackageFile:
             "md5_digest": self.md5_digest,
             "sha256_digest": self.sha2_digest,
             "blake2_256_digest": self.blake2_256_digest,
-
             # PEP 314
             "provides": meta.provides,
             "requires": meta.requires,
             "obsoletes": meta.obsoletes,
-
             # Metadata 1.2
             "project_urls": meta.project_urls,
             "provides_dist": meta.provides_dist,
@@ -152,26 +146,19 @@ class PackageFile:
             "requires_dist": meta.requires_dist,
             "requires_external": meta.requires_external,
             "requires_python": meta.requires_python,
-
             # Metadata 2.1
             "provides_extras": meta.provides_extras,
             "description_content_type": meta.description_content_type,
         }
 
         if self.gpg_signature is not None:
-            data['gpg_signature'] = self.gpg_signature
+            data["gpg_signature"] = self.gpg_signature
 
         return data
 
-    def add_gpg_signature(
-        self,
-        signature_filepath: str,
-        signature_filename: str
-    ):
+    def add_gpg_signature(self, signature_filepath: str, signature_filename: str):
         if self.gpg_signature is not None:
-            raise exceptions.InvalidDistribution(
-                'GPG Signature can only be added once'
-            )
+            raise exceptions.InvalidDistribution("GPG Signature can only be added once")
 
         with open(signature_filepath, "rb") as gpg:
             self.gpg_signature = (signature_filename, gpg.read())
@@ -194,7 +181,8 @@ class PackageFile:
         except FileNotFoundError:
             if gpg_args[0] != "gpg":
                 raise exceptions.InvalidSigningExecutable(
-                    "{} executable not available.".format(gpg_args[0]))
+                    "{} executable not available.".format(gpg_args[0])
+                )
 
         print("gpg executable not available. Attempting fallback to gpg2.")
         try:
@@ -208,7 +196,7 @@ class PackageFile:
             )
 
 
-Hexdigest = collections.namedtuple('Hexdigest', ['md5', 'sha2', 'blake2'])
+Hexdigest = collections.namedtuple("Hexdigest", ["md5", "sha2", "blake2"])
 
 
 class HashManager:
@@ -264,7 +252,7 @@ class HashManager:
     def hash(self) -> None:
         """Hash the file contents."""
         with open(self.filename, "rb") as fp:
-            for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b''):
+            for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):
                 self._md5_update(content)
                 self._sha2_update(content)
                 self._blake_update(content)
@@ -272,7 +260,5 @@ class HashManager:
     def hexdigest(self) -> Hexdigest:
         """Return the hexdigest for the file."""
         return Hexdigest(
-            self._md5_hexdigest(),
-            self._sha2_hexdigest(),
-            self._blake_hexdigest(),
+            self._md5_hexdigest(), self._sha2_hexdigest(), self._blake_hexdigest(),
         )

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -21,9 +21,7 @@ from requests import codes
 from requests.adapters import HTTPAdapter
 from requests.models import Response
 from requests.packages.urllib3 import util
-from requests_toolbelt.multipart import (
-    MultipartEncoder, MultipartEncoderMonitor
-)
+from requests_toolbelt.multipart import MultipartEncoder, MultipartEncoderMonitor
 from requests_toolbelt.utils import user_agent
 
 from twine.package import PackageFile, MetadataValue
@@ -31,12 +29,12 @@ import twine
 
 KEYWORDS_TO_NOT_FLATTEN = {"gpg_signature", "content"}
 
-LEGACY_PYPI = 'https://pypi.python.org/'
-LEGACY_TEST_PYPI = 'https://testpypi.python.org/'
-WAREHOUSE = 'https://upload.pypi.org/'
-OLD_WAREHOUSE = 'https://upload.pypi.io/'
-TEST_WAREHOUSE = 'https://test.pypi.org/'
-WAREHOUSE_WEB = 'https://pypi.org/'
+LEGACY_PYPI = "https://pypi.python.org/"
+LEGACY_TEST_PYPI = "https://testpypi.python.org/"
+WAREHOUSE = "https://upload.pypi.org/"
+OLD_WAREHOUSE = "https://upload.pypi.io/"
+TEST_WAREHOUSE = "https://test.pypi.org/"
+WAREHOUSE_WEB = "https://pypi.org/"
 
 
 class ProgressBar(tqdm):
@@ -64,12 +62,10 @@ class Repository:
         # But username or password could be None
         # See TODO for utils.RepositoryConfig
         self.session.auth = (
-            (username or '', password or '')
-            if username or password
-            else None
+            (username or "", password or "") if username or password else None
         )
-        self.session.headers['User-Agent'] = self._make_user_agent_string()
-        for scheme in ('http://', 'https://'):
+        self.session.headers["User-Agent"] = self._make_user_agent_string()
+        for scheme in ("http://", "https://"):
             self.session.mount(scheme, self._make_adapter_with_retries())
 
         self._releases_json_data: Dict[str, Dict] = {}
@@ -80,7 +76,7 @@ class Repository:
         retry = util.Retry(
             connect=5,
             total=10,
-            method_whitelist=['GET'],
+            method_whitelist=["GET"],
             status_forcelist=[500, 501, 502, 503],
         )
         return HTTPAdapter(max_retries=retry)
@@ -88,12 +84,14 @@ class Repository:
     @staticmethod
     def _make_user_agent_string() -> str:
         from twine import cli
+
         dependencies = cli.list_dependencies_and_versions()
-        return user_agent.UserAgentBuilder(
-                'twine', twine.__version__,
-            ).include_extras(
-                dependencies
-            ).include_implementation().build()
+        return (
+            user_agent.UserAgentBuilder("twine", twine.__version__,)
+            .include_extras(dependencies)
+            .include_implementation()
+            .build()
+        )
 
     def close(self):
         self.session.close()
@@ -104,8 +102,7 @@ class Repository:
     ) -> List[Tuple[str, MetadataValue]]:
         data_to_send = []
         for key, value in data.items():
-            if (key in KEYWORDS_TO_NOT_FLATTEN or
-                    not isinstance(value, (list, tuple))):
+            if key in KEYWORDS_TO_NOT_FLATTEN or not isinstance(value, (list, tuple)):
                 data_to_send.append((key, value))
             else:
                 for item in value:
@@ -122,10 +119,7 @@ class Repository:
 
     def register(self, package):
         data = package.metadata_dictionary()
-        data.update({
-            ":action": "submit",
-            "protocol_version": "1",
-        })
+        data.update({":action": "submit", "protocol_version": "1"})
 
         print(f"Registering {package.basefilename}")
 
@@ -135,7 +129,7 @@ class Repository:
             self.url,
             data=encoder,
             allow_redirects=False,
-            headers={'Content-Type': encoder.content_type},
+            headers={"Content-Type": encoder.content_type},
         )
         # Bug 28. Try to silence a ResourceWarning by releasing the socket.
         resp.close()
@@ -143,26 +137,32 @@ class Repository:
 
     def _upload(self, package: PackageFile) -> Response:
         data = package.metadata_dictionary()
-        data.update({
-            # action
-            ":action": "file_upload",
-            "protocol_version": "1",
-        })
+        data.update(
+            {
+                # action
+                ":action": "file_upload",
+                "protocol_version": "1",
+            }
+        )
 
         data_to_send = self._convert_data_to_list_of_tuples(data)
 
         print(f"Uploading {package.basefilename}")
 
         with open(package.filename, "rb") as fp:
-            data_to_send.append((
-                "content",
-                (package.basefilename, fp, "application/octet-stream"),
-            ))
+            data_to_send.append(
+                ("content", (package.basefilename, fp, "application/octet-stream"),)
+            )
             encoder = MultipartEncoder(data_to_send)
-            with ProgressBar(total=encoder.len,
-                             unit='B', unit_scale=True, unit_divisor=1024,
-                             miniters=1, file=sys.stdout,
-                             disable=self.disable_progress_bar) as bar:
+            with ProgressBar(
+                total=encoder.len,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                miniters=1,
+                file=sys.stdout,
+                disable=self.disable_progress_bar,
+            ) as bar:
                 monitor = MultipartEncoderMonitor(
                     encoder, lambda monitor: bar.update_to(monitor.bytes_read)
                 )
@@ -171,16 +171,12 @@ class Repository:
                     self.url,
                     data=monitor,
                     allow_redirects=False,
-                    headers={'Content-Type': monitor.content_type},
+                    headers={"Content-Type": monitor.content_type},
                 )
 
         return resp
 
-    def upload(
-        self,
-        package: PackageFile,
-        max_redirects: int = 5
-    ) -> Response:
+    def upload(self, package: PackageFile, max_redirects: int = 5) -> Response:
         number_of_redirects = 0
         while number_of_redirects < max_redirects:
             resp = self._upload(package)
@@ -189,21 +185,21 @@ class Repository:
                 return resp
             if 500 <= resp.status_code < 600:
                 number_of_redirects += 1
-                print('Received "{status_code}: {reason}" Package upload '
-                      'appears to have failed.  Retry {retry} of 5'.format(
-                          status_code=resp.status_code,
-                          reason=resp.reason,
-                          retry=number_of_redirects,
-                      ))
+                print(
+                    'Received "{status_code}: {reason}" Package upload '
+                    "appears to have failed.  Retry {retry} of 5".format(
+                        status_code=resp.status_code,
+                        reason=resp.reason,
+                        retry=number_of_redirects,
+                    )
+                )
             else:
                 return resp
 
         return resp
 
     def package_is_uploaded(
-        self,
-        package: PackageFile,
-        bypass_cache: bool = False
+        self, package: PackageFile, bypass_cache: bool = False
     ) -> bool:
         # NOTE(sigmavirus24): Not all indices are PyPI and pypi.io doesn't
         # have a similar interface for finding the package versions.
@@ -217,12 +213,11 @@ class Repository:
             releases = self._releases_json_data.get(safe_name)
 
         if releases is None:
-            url = '{url}pypi/{package}/json'.format(package=safe_name,
-                                                    url=LEGACY_PYPI)
-            headers = {'Accept': 'application/json'}
+            url = "{url}pypi/{package}/json".format(package=safe_name, url=LEGACY_PYPI)
+            headers = {"Accept": "application/json"}
             response = self.session.get(url, headers=headers)
             if response.status_code == 200:
-                releases = response.json()['releases']
+                releases = response.json()["releases"]
             else:
                 releases = {}
             self._releases_json_data[safe_name] = releases
@@ -230,7 +225,7 @@ class Repository:
         packages = releases.get(package.metadata.version, [])
 
         for uploaded_package in packages:
-            if uploaded_package['filename'] == package.basefilename:
+            if uploaded_package["filename"] == package.basefilename:
                 return True
 
         return False
@@ -244,9 +239,7 @@ class Repository:
             return set()
 
         return {
-            '{}project/{}/{}/'.format(
-                url, package.safe_name, package.metadata.version
-            )
+            "{}project/{}/{}/".format(url, package.safe_name, package.metadata.version)
             for package in packages
         }
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -44,17 +44,17 @@ class Settings:
         self,
         *,
         sign: bool = False,
-        sign_with: Optional[str] = 'gpg',
+        sign_with: Optional[str] = "gpg",
         identity: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
         non_interactive: bool = False,
         comment: Optional[str] = None,
-        config_file: str = '~/.pypirc',
+        config_file: str = "~/.pypirc",
         skip_existing: bool = False,
         cacert: Optional[str] = None,
         client_cert: Optional[str] = None,
-        repository_name: str = 'pypi',
+        repository_name: str = "pypi",
         repository_url: Optional[str] = None,
         verbose: bool = False,
         disable_progress_bar: bool = False,
@@ -131,8 +131,7 @@ class Settings:
         # _handle_certificates relies on the parsed repository config
         self._handle_certificates(cacert, client_cert)
         self.auth = auth.Resolver.choose(not non_interactive)(
-            self.repository_config,
-            auth.CredentialInput(username, password),
+            self.repository_config, auth.CredentialInput(username, password),
         )
 
     @property
@@ -147,14 +146,15 @@ class Settings:
     def register_argparse_arguments(parser: argparse.ArgumentParser) -> None:
         """Register the arguments for argparse."""
         parser.add_argument(
-            "-r", "--repository",
+            "-r",
+            "--repository",
             action=utils.EnvironmentDefault,
             env="TWINE_REPOSITORY",
             default="pypi",
             help="The repository (package index) to upload the package to. "
-                 "Should be a section in the config file (default: "
-                 "%(default)s). (Can also be set via %(env)s environment "
-                 "variable.)",
+            "Should be a section in the config file (default: "
+            "%(default)s). (Can also be set via %(env)s environment "
+            "variable.)",
         )
         parser.add_argument(
             "--repository-url",
@@ -163,11 +163,12 @@ class Settings:
             default=None,
             required=False,
             help="The repository (package index) URL to upload the package to."
-                 " This overrides --repository. "
-                 "(Can also be set via %(env)s environment variable.)"
+            " This overrides --repository. "
+            "(Can also be set via %(env)s environment variable.)",
         )
         parser.add_argument(
-            "-s", "--sign",
+            "-s",
+            "--sign",
             action="store_true",
             default=False,
             help="Sign files to upload using GPG.",
@@ -178,37 +179,39 @@ class Settings:
             help="GPG program used to sign uploads (default: %(default)s).",
         )
         parser.add_argument(
-            "-i", "--identity",
-            help="GPG identity used to sign files.",
+            "-i", "--identity", help="GPG identity used to sign files.",
         )
         parser.add_argument(
-            "-u", "--username",
+            "-u",
+            "--username",
             action=utils.EnvironmentDefault,
             env="TWINE_USERNAME",
             required=False,
             help="The username to authenticate to the repository "
-                 "(package index) as. (Can also be set via "
-                 "%(env)s environment variable.)",
+            "(package index) as. (Can also be set via "
+            "%(env)s environment variable.)",
         )
         parser.add_argument(
-            "-p", "--password",
+            "-p",
+            "--password",
             action=utils.EnvironmentDefault,
             env="TWINE_PASSWORD",
             required=False,
             help="The password to authenticate to the repository "
-                 "(package index) with. (Can also be set via "
-                 "%(env)s environment variable.)",
+            "(package index) with. (Can also be set via "
+            "%(env)s environment variable.)",
         )
         parser.add_argument(
             "--non-interactive",
             action=utils.EnvironmentFlag,
             env="TWINE_NON_INTERACTIVE",
             help="Do not interactively prompt for username/password if the "
-                 "required credentials are missing. (Can also be set via "
-                 "%(env)s environment variable.)"
+            "required credentials are missing. (Can also be set via "
+            "%(env)s environment variable.)",
         )
         parser.add_argument(
-            "-c", "--comment",
+            "-c",
+            "--comment",
             help="The comment to include with the distribution file.",
         )
         parser.add_argument(
@@ -221,8 +224,8 @@ class Settings:
             default=False,
             action="store_true",
             help="Continue uploading files if one already exists. (Only valid "
-                 "when uploading to PyPI. Other implementations may not "
-                 "support this.)",
+            "when uploading to PyPI. Other implementations may not "
+            "support this.)",
         )
         parser.add_argument(
             "--cert",
@@ -232,42 +235,39 @@ class Settings:
             required=False,
             metavar="path",
             help="Path to alternate CA bundle (can also be set via %(env)s "
-                 "environment variable).",
+            "environment variable).",
         )
         parser.add_argument(
             "--client-cert",
             metavar="path",
             help="Path to SSL client certificate, a single file containing the"
-                 " private key and the certificate in PEM format.",
+            " private key and the certificate in PEM format.",
         )
         parser.add_argument(
             "--verbose",
             default=False,
             required=False,
             action="store_true",
-            help="Show verbose output."
+            help="Show verbose output.",
         )
         parser.add_argument(
             "--disable-progress-bar",
             default=False,
             required=False,
             action="store_true",
-            help="Disable the progress bar."
+            help="Disable the progress bar.",
         )
 
     @classmethod
     def from_argparse(cls, args: argparse.Namespace) -> "Settings":
         """Generate the Settings from parsed arguments."""
         settings = vars(args)
-        settings['repository_name'] = settings.pop('repository')
-        settings['cacert'] = settings.pop('cert')
+        settings["repository_name"] = settings.pop("repository")
+        settings["cacert"] = settings.pop("cert")
         return cls(**settings)
 
     def _handle_package_signing(
-        self,
-        sign: bool,
-        sign_with: Optional[str],
-        identity: Optional[str]
+        self, sign: bool, sign_with: Optional[str], identity: Optional[str]
     ) -> None:
         if not sign and identity:
             raise exceptions.InvalidSigningConfiguration(
@@ -278,29 +278,20 @@ class Settings:
         self.identity = identity
 
     def _handle_repository_options(
-        self,
-        repository_name: str,
-        repository_url: Optional[str]
+        self, repository_name: str, repository_url: Optional[str]
     ) -> None:
         self.repository_config = utils.get_repository_from_config(
-            self.config_file,
-            repository_name,
-            repository_url,
+            self.config_file, repository_name, repository_url,
         )
-        self.repository_config['repository'] = utils.normalize_repository_url(
-            cast(str, self.repository_config['repository']),
+        self.repository_config["repository"] = utils.normalize_repository_url(
+            cast(str, self.repository_config["repository"]),
         )
 
     def _handle_certificates(
-        self,
-        cacert: Optional[str],
-        client_cert: Optional[str]
+        self, cacert: Optional[str], client_cert: Optional[str]
     ) -> None:
         self.cacert = utils.get_cacert(cacert, self.repository_config)
-        self.client_cert = utils.get_clientcert(
-            client_cert,
-            self.repository_config,
-        )
+        self.client_cert = utils.get_clientcert(client_cert, self.repository_config,)
 
     def check_repository_url(self) -> None:
         """Verify we are not using legacy PyPI.
@@ -308,20 +299,19 @@ class Settings:
         :raises:
             :class:`~twine.exceptions.UploadToDeprecatedPyPIDetected`
         """
-        repository_url = cast(str, self.repository_config['repository'])
+        repository_url = cast(str, self.repository_config["repository"])
 
-        if repository_url.startswith((repository.LEGACY_PYPI,
-                                      repository.LEGACY_TEST_PYPI)):
+        if repository_url.startswith(
+            (repository.LEGACY_PYPI, repository.LEGACY_TEST_PYPI)
+        ):
             raise exceptions.UploadToDeprecatedPyPIDetected.from_args(
-                repository_url,
-                utils.DEFAULT_REPOSITORY,
-                utils.TEST_REPOSITORY
+                repository_url, utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY
             )
 
     def create_repository(self) -> repository.Repository:
         """Create a new repository for uploading."""
         repo = repository.Repository(
-            cast(str, self.repository_config['repository']),
+            cast(str, self.repository_config["repository"]),
             self.username,
             self.password,
             self.disable_progress_bar,

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -67,8 +67,9 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
             if parser.has_option("server-login", key):
                 defaults[key] = parser.get("server-login", key)
 
-    config: DefaultDict[str, RepositoryConfig] = \
-        collections.defaultdict(lambda: defaults.copy())
+    config: DefaultDict[str, RepositoryConfig] = collections.defaultdict(
+        lambda: defaults.copy()
+    )
 
     # don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY
@@ -78,8 +79,11 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
     # optional configuration values for individual repositories
     for repository in index_servers:
         for key in [
-            "username", "repository", "password",
-            "ca_cert", "client_cert",
+            "username",
+            "repository",
+            "password",
+            "ca_cert",
+            "client_cert",
         ]:
             if parser.has_option(repository, key):
                 config[repository][key] = parser.get(repository, key)
@@ -90,9 +94,7 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
 
 
 def get_repository_from_config(
-    config_file: str,
-    repository: str,
-    repository_url: Optional[str] = None
+    config_file: str, repository: str, repository_url: Optional[str] = None
 ) -> RepositoryConfig:
     # Get our config from, if provided, command-line values for the
     # repository name and URL, or the .pypirc file
@@ -106,7 +108,8 @@ def get_repository_from_config(
     if repository_url and "://" not in repository_url:
         raise exceptions.UnreachableRepositoryURLDetected(
             "Repository URL {} has no protocol. Please add "
-            "'https://'. \n".format(repository_url))
+            "'https://'. \n".format(repository_url)
+        )
     try:
         return get_config(config_file)[repository]
     except KeyError:
@@ -116,15 +119,16 @@ def get_repository_from_config(
             "Maybe you have an out-dated '{cfg}' format?\n"
             "more info: "
             "https://docs.python.org/distutils/packageindex.html#pypirc\n"
-        ).format(
-            repo=repository,
-            cfg=config_file
-        )
+        ).format(repo=repository, cfg=config_file)
         raise exceptions.InvalidConfiguration(msg)
 
 
-_HOSTNAMES = {"pypi.python.org", "testpypi.python.org", "upload.pypi.org",
-              "test.pypi.org"}
+_HOSTNAMES = {
+    "pypi.python.org",
+    "testpypi.python.org",
+    "upload.pypi.org",
+    "test.pypi.org",
+}
 
 
 def normalize_repository_url(url: str) -> str:
@@ -149,23 +153,24 @@ def check_status_code(response: requests.Response, verbose: bool) -> None:
             f"pypi.org and test.pypi.org. Try using {DEFAULT_REPOSITORY} (or "
             f"{TEST_REPOSITORY}) to upload your packages instead. These are "
             f"the default URLs for Twine now. More at "
-            f"https://packaging.python.org/guides/migrating-to-pypi-org/.")
+            f"https://packaging.python.org/guides/migrating-to-pypi-org/."
+        )
     elif response.status_code == 405 and "pypi.org" in response.url:
         raise exceptions.InvalidPyPIUploadURL(
             f"It appears you're trying to upload to pypi.org but have an "
             f"invalid URL. You probably want one of these two URLs: "
             f"{DEFAULT_REPOSITORY} or {TEST_REPOSITORY}. Check your "
-            f"--repository-url value.")
+            f"--repository-url value."
+        )
 
     try:
         response.raise_for_status()
     except requests.HTTPError as err:
         if response.text:
             if verbose:
-                print('Content received from server:\n{}'.format(
-                    response.text))
+                print("Content received from server:\n{}".format(response.text))
             else:
-                print('NOTE: Try --verbose to see response content.')
+                print("NOTE: Try --verbose to see response content.")
         raise err
 
 
@@ -173,7 +178,7 @@ def get_userpass_value(
     cli_value: Optional[str],
     config: RepositoryConfig,
     key: str,
-    prompt_strategy: Optional[Callable] = None
+    prompt_strategy: Optional[Callable] = None,
 ) -> Optional[str]:
     """Gets the username / password from config.
 
@@ -205,25 +210,15 @@ def get_userpass_value(
         return None
 
 
-get_cacert = functools.partial(
-    get_userpass_value,
-    key='ca_cert',
-)
-get_clientcert = functools.partial(
-    get_userpass_value,
-    key='client_cert',
-)
+get_cacert = functools.partial(get_userpass_value, key="ca_cert",)
+get_clientcert = functools.partial(get_userpass_value, key="client_cert",)
 
 
 class EnvironmentDefault(argparse.Action):
     """Get values from environment variable."""
 
     def __init__(
-        self,
-        env: str,
-        required: bool = True,
-        default: Optional[str] = None,
-        **kwargs
+        self, env: str, required: bool = True, default: Optional[str] = None, **kwargs
     ) -> None:
         default = os.environ.get(env, default)
         self.env = env
@@ -238,11 +233,7 @@ class EnvironmentDefault(argparse.Action):
 class EnvironmentFlag(argparse.Action):
     """Set boolean flag from environment variable."""
 
-    def __init__(
-        self,
-        env: str,
-        **kwargs
-    ) -> None:
+    def __init__(self, env: str, **kwargs) -> None:
         default = self.bool_from_env(os.environ.get(env))
         self.env = env
         super().__init__(default=default, nargs=0, **kwargs)
@@ -255,5 +246,5 @@ class EnvironmentFlag(argparse.Action):
         """
         Allow '0' and 'false' and 'no' to be False
         """
-        falsey = {'0', 'false', 'no'}
+        falsey = {"0", "false", "no"}
         return val and val.lower() not in falsey

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -30,11 +30,11 @@ wheel_file_re = re.compile(
     r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
         ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
         \.whl|\.dist-info)$""",
-    re.VERBOSE)
+    re.VERBOSE,
+)
 
 
 class Wheel(Distribution):
-
     def __init__(self, filename, metadata_version=None):
         self.filename = filename
         self.basefilename = os.path.basename(self.filename)
@@ -49,39 +49,34 @@ class Wheel(Distribution):
     @staticmethod
     def find_candidate_metadata_files(names):
         """Filter files that may be METADATA files."""
-        tuples = [x.split('/') for x in names if 'METADATA' in x]
+        tuples = [x.split("/") for x in names if "METADATA" in x]
         return [x[1] for x in sorted([(len(x), x) for x in tuples])]
 
     def read(self):
         fqn = os.path.abspath(os.path.normpath(self.filename))
         if not os.path.exists(fqn):
-            raise exceptions.InvalidDistribution(
-                'No such file: %s' % fqn
-            )
+            raise exceptions.InvalidDistribution("No such file: %s" % fqn)
 
-        if fqn.endswith('.whl'):
+        if fqn.endswith(".whl"):
             archive = zipfile.ZipFile(fqn)
             names = archive.namelist()
 
             def read_file(name):
                 return archive.read(name)
+
         else:
-            raise exceptions.InvalidDistribution(
-                'Not a known archive format: %s' % fqn
-            )
+            raise exceptions.InvalidDistribution("Not a known archive format: %s" % fqn)
 
         try:
             for path in self.find_candidate_metadata_files(names):
-                candidate = '/'.join(path)
+                candidate = "/".join(path)
                 data = read_file(candidate)
-                if b'Metadata-Version' in data:
+                if b"Metadata-Version" in data:
                     return data
         finally:
             archive.close()
 
-        raise exceptions.InvalidDistribution(
-            'No METADATA in archive: %s' % fqn
-        )
+        raise exceptions.InvalidDistribution("No METADATA in archive: %s" % fqn)
 
     def parse(self, data):
         super().parse(data)

--- a/twine/wininst.py
+++ b/twine/wininst.py
@@ -10,7 +10,6 @@ wininst_file_re = re.compile(r".*py(?P<pyver>\d+\.\d+)\.exe$")
 
 
 class WinInst(Distribution):
-
     def __init__(self, filename, metadata_version=None):
         self.filename = filename
         self.metadata_version = metadata_version
@@ -27,33 +26,33 @@ class WinInst(Distribution):
     def read(self):
         fqn = os.path.abspath(os.path.normpath(self.filename))
         if not os.path.exists(fqn):
-            raise exceptions.InvalidDistribution(
-                'No such file: %s' % fqn
-            )
+            raise exceptions.InvalidDistribution("No such file: %s" % fqn)
 
-        if fqn.endswith('.exe'):
+        if fqn.endswith(".exe"):
             archive = zipfile.ZipFile(fqn)
             names = archive.namelist()
 
             def read_file(name):
                 return archive.read(name)
+
         else:
-            raise exceptions.InvalidDistribution(
-                'Not a known archive format: %s' % fqn
-            )
+            raise exceptions.InvalidDistribution("Not a known archive format: %s" % fqn)
 
         try:
-            tuples = [x.split('/') for x in names
-                      if x.endswith(".egg-info") or x.endswith("PKG-INFO")]
+            tuples = [
+                x.split("/")
+                for x in names
+                if x.endswith(".egg-info") or x.endswith("PKG-INFO")
+            ]
             schwarz = sorted([(len(x), x) for x in tuples])
             for path in [x[1] for x in schwarz]:
-                candidate = '/'.join(path)
+                candidate = "/".join(path)
                 data = read_file(candidate)
-                if b'Metadata-Version' in data:
+                if b"Metadata-Version" in data:
                     return data
         finally:
             archive.close()
 
         raise exceptions.InvalidDistribution(
-            'No PKG-INFO/.egg-info in archive: %s' % fqn
+            "No PKG-INFO/.egg-info in archive: %s" % fqn
         )


### PR DESCRIPTION
I realize this is out of left field, so I hope y'all will forgive me. While working on type annotations, I really wished that I had an auto-formatter. I've used [black](https://github.com/psf/black) on other projects, and it felt easy to adopt. But, I'm game to fine-tune our preferences with [yapf](https://github.com/google/yapf) if folks prefer. I'm also guessing there are examples of big projects doing this that we could learn from.

Changes:

- Run `black twine tests`
- Add `.flake8` configuration for 88-character lines

TODO (once folks approve this direction):

- Add to `tox.ini`
- Mitigate impact on `git blame` via [`--ignore-revs-file`](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt) as [suggested](https://twitter.com/llanga/status/1163767833706323970) by Łukasz Langa

