### PR TITLE
Black integration

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# When making commits that are strictly formatting/style changes, add the
+# commit hash here, so git blame can ignore the change.
+# Use as needed with:
+#     git blame --ignore-revs-file .git-blame-ignore-revs
+# Or automatically with:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+a12ad693137d82770e6118ea8d90955e2c753305  # Format twine and tests with black

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,10 @@ commands =
 
 [testenv:lint-code-style]
 deps =
+    black
     flake8
 commands =
+    black --check --diff twine/ tests/
     flake8 twine/ tests/
 
 [testenv:lint-mypy]


### PR DESCRIPTION
Changes:

- Add check for black to linting. Note that this won't apply changes; it will just fail if there would be changes.
- Add support for ignoring initial format in a12ad69 with `git blame --ignore-revs-file`. Note that this requires opt-in, and won't work in GitHub.

Questions/TODO:

- Is the "ignore revs" support worth it?

- A common pattern for applying black seems to be pre-commit, but I'm honestly not a fan. It's an additional layer of tooling that eschews familiar approaches to virtual environments, and seems to require managing dependencies in multiple places.

    However, our current use of tox doesn't seem to facilitate running black/flake8/mypy directly, or via editor integration. I'm curious how the rest of the @pypa/twine-maintainers handle that. Thus far, I've just been installing them as-needed into a  virtual environment, and relying on auto-format in VS Code. However, I'd love a one-liner for installing all of the development dependencies, equivalent to `pip install -r requirements.txt`.

- Pending the resolution of the previous item, I'd normally be inclined to document the use of black in the [contributing doc](https://twine.readthedocs.io/en/latest/contributing.html). However, it currently doesn't mention flake8, mypy, or even pytest. I think that leaves new contributors to figure discover those tools by waiting for failures and/or reading tox.ini. So, maybe it's worth a separate issue/PR to improve that documentation.