### PR TITLE
Sort imports based on flake8-import-order

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-# Matching black's default
-max-line-length = 88
-import-order-style = google
-application-import-names = twine,helpers

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 # Matching black's default
 max-line-length = 88
+import-order-style = google
+application-import-names = twine,helpers

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,10 @@ twine.registered_commands =
     register = twine.commands.register:main
 console_scripts =
     twine = twine.__main__:main
+
+[flake8]
+# Must be in setup.cfg due to https://github.com/sqlalchemyorg/zimports/issues/10
+# Matching black's default
+max-line-length = 88
+import-order-style = google
+application-import-names = twine,helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,18 @@
 import contextlib
-import textwrap
-import secrets
-import subprocess
-import pathlib
+import datetime
 import functools
 import getpass
+import pathlib
+import secrets
+import subprocess
 import sys
-import datetime
+import textwrap
 
-import pytest
-import portend
-import requests
 import jaraco.envs
 import munch
+import portend
+import pytest
+import requests
 
 from twine import settings
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,6 @@
 import pytest
 
-from twine import (
-    auth,
-    exceptions,
-    utils,
-)
+from twine import auth, exceptions, utils
 
 
 cred = auth.CredentialInput

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 
-from twine.commands import _find_dists, _group_wheel_files_first
 from twine import exceptions
+from twine.commands import _find_dists, _group_wheel_files_first
 
 
 def test_ensure_wheel_files_uploaded_first():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,10 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pretend
+
 from twine import __main__ as dunder_main
 from twine import exceptions
-
-import pretend
 
 
 def test_exception_handling(monkeypatch):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twine import package, exceptions
-
 import pretend
 import pytest
+
+from twine import exceptions, package
 
 
 def test_sign_file(monkeypatch):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 
-import pytest
 import pretend
+import pytest
 
-from twine.commands import register
 from twine import exceptions
+from twine.commands import register
 
 
 # TODO: Copied from test_upload.py. Extract to helpers?

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from contextlib import contextmanager
+
+import pretend
+import pytest
 import requests
 
 from twine import repository
 from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
-
-import pretend
-import pytest
-from contextlib import contextmanager
 
 
 def test_gpg_signature_structure_is_preserved():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import os.path
 import textwrap
-import argparse
+
+import pytest
 
 from twine import exceptions
 from twine import settings
-
-import pytest
 
 
 def test_settings_takes_no_positional_arguments():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -15,11 +15,10 @@ import pretend
 import pytest
 from requests.exceptions import HTTPError
 
-from twine.commands import upload
-from twine import package, cli, exceptions
-import twine
-
 import helpers
+import twine
+from twine import cli, exceptions, package
+from twine.commands import upload
 
 SDIST_FIXTURE = "tests/fixtures/twine-1.5.0.tar.gz"
 WHEEL_FIXTURE = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,12 +15,11 @@
 import os.path
 import textwrap
 
-import pytest
 import pretend
-
-from twine import exceptions, utils
+import pytest
 
 import helpers
+from twine import exceptions, utils
 
 
 def test_get_config(tmpdir):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twine import wheel
-
 import pytest
+
+from twine import wheel
 
 
 @pytest.fixture(

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ commands =
 deps =
     black
     flake8
+    flake8-import-order
 commands =
     black --check --diff twine/ tests/
     flake8 twine/ tests/

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -1,12 +1,12 @@
-import warnings
-import getpass
 import functools
-from typing import Optional, Callable
+import getpass
+from typing import Callable, Optional
+import warnings
 
 import keyring
 
-from . import utils
 from . import exceptions
+from . import utils
 
 
 class CredentialInput:

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import pkg_resources
-import setuptools
 
-import tqdm
+import pkg_resources
+import pkginfo
 import requests
 import requests_toolbelt
-import pkginfo
+import setuptools
+import tqdm
 
 import twine
 from twine._installed import Installed

--- a/twine/commands/__init__.py
+++ b/twine/commands/__init__.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
-
 import glob
 import os.path
+from typing import List
 
 from twine import exceptions
 

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import argparse
 import cgi
+from io import StringIO
 import re
 import sys
-from io import StringIO
 
 import readme_renderer.rst
 

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -14,9 +14,9 @@
 import argparse
 import os.path
 
-from twine.package import PackageFile
 from twine import exceptions
 from twine import settings
+from twine.package import PackageFile
 
 
 def register(register_settings, package):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -14,11 +14,11 @@
 import argparse
 import os.path
 
-from twine.commands import _find_dists
-from twine.package import PackageFile
 from twine import exceptions
 from twine import settings
 from twine import utils
+from twine.commands import _find_dists
+from twine.package import PackageFile
 
 
 def skip_upload(response, skip_existing, package):

--- a/twine/package.py
+++ b/twine/package.py
@@ -11,21 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, IO, Optional, Union, Sequence, Tuple
-
 import collections
 import hashlib
+from hashlib import blake2b
 import io
 import os
 import subprocess
-from hashlib import blake2b
+from typing import Dict, IO, Optional, Sequence, Tuple, Union
 
-import pkginfo
 import pkg_resources
+import pkginfo
 
+from twine import exceptions
 from twine.wheel import Wheel
 from twine.wininst import WinInst
-from twine import exceptions
 
 DIST_TYPES = {
     "bdist_wheel": Wheel,

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List, Optional, Tuple
 import sys
-
-from tqdm import tqdm
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from requests import codes
@@ -23,9 +21,10 @@ from requests.models import Response
 from requests.packages.urllib3 import util
 from requests_toolbelt.multipart import MultipartEncoder, MultipartEncoderMonitor
 from requests_toolbelt.utils import user_agent
+from tqdm import tqdm
 
-from twine.package import PackageFile, MetadataValue
 import twine
+from twine.package import MetadataValue, PackageFile
 
 KEYWORDS_TO_NOT_FLATTEN = {"gpg_signature", "content"}
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 from typing import cast, Optional
 
-import argparse
-
+from twine import auth
 from twine import exceptions
 from twine import repository
 from twine import utils
-from twine import auth
 
 
 class Settings:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, DefaultDict, Dict, Optional
-
-import os
-import os.path
-import functools
 import argparse
 import collections
 import configparser
+import functools
+import os
+import os.path
+from typing import Callable, DefaultDict, Dict, Optional
 from urllib.parse import urlparse, urlunparse
 
 import requests

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from io import StringIO
 import os
 import re
 import zipfile
-from io import StringIO
 
 from pkginfo import distribution
 from pkginfo.distribution import Distribution


### PR DESCRIPTION
As an alternative to #570, and partially out of my own curiosity. I think I prefer isort, but I don't feel strongly.

Changes:

- Add flake8-import-order to `tox -e lint-code-style`
- Add flake8 config for [Google Style Guide](http://google.github.io/styleguide/pyguide.html)
- Use [`zimports --multi-imports`](https://github.com/sqlalchemyorg/zimports) to format imports
- Move flake8 config to setup.cfg as [required by zimports](https://github.com/sqlalchemyorg/zimports/issues/10)

As in the other PR, this allows multiple imports per line, which minimizes the changes, esp. with the [`typing` module](https://github.com/sqlalchemyorg/zimports/issues/11).