### PR TITLE
isort integration

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,4 @@
 #     git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 a12ad693137d82770e6118ea8d90955e2c753305  # Format twine and tests with black
+f468612c021eae225b07f1b654bdb620d1500bf1  # Sort imports with isort

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,11 @@ commands =
 
 [testenv:lint-code-style]
 deps =
+    isort
     black
     flake8
 commands =
+    isort --check-only --diff --recursive twine/ tests/
     black --check --diff twine/ tests/
     flake8 twine/ tests/
 


### PR DESCRIPTION
Changes:

- Add isort check to `tox -e lint-code-style`
- Ignore #570 during `git blame`

Note that if any of the `lint-code-style` commands fail, then the subsequent commands won't run. We could:

- Put them in different testenvs (at the expense of a longer tox.ini)
- Set [`ignore_errors=true`](https://tox.readthedocs.io/en/latest/config.html#conf-ignore_errors) (to run all the commands if one fails)
- Not worry about it :)