### PR TITLE
Normalize to module imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,6 @@
 [settings]
+# NOTE: Consider single_line_exclusions=typing in next version of isort
+force_single_line=True
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,5 @@
 [settings]
+combine_as_imports=True
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,4 @@
 [settings]
-combine_as_imports=True
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from setuptools import setup
+import setuptools
 
 
-setup(
-    use_scm_version=True,
-)
+setuptools.setup(use_scm_version=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,8 @@
 import pytest
 
-from twine import auth, exceptions, utils
+from twine import auth
+from twine import exceptions
+from twine import utils
 
 cred = auth.CredentialInput
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -15,7 +15,8 @@ import io
 
 import pretend
 
-from twine import commands, package as package_file
+from twine import commands
+from twine import package as package_file
 from twine.commands import check
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -15,8 +15,7 @@ import io
 
 import pretend
 
-from twine import commands
-from twine import package as package_file
+from twine import commands, package as package_file
 from twine.commands import check
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -15,7 +15,7 @@ import io
 
 import pretend
 
-from twine import commands, package
+from twine import commands, package as package_file
 from twine.commands import check
 
 
@@ -53,7 +53,7 @@ def test_check_no_distributions(monkeypatch):
 
 def test_check_passing_distribution(monkeypatch):
     renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: "valid"))
-    pkg = pretend.stub(
+    package = pretend.stub(
         metadata_dictionary=lambda: {
             "description": "blah",
             "description_content_type": "text/markdown",
@@ -65,7 +65,9 @@ def test_check_passing_distribution(monkeypatch):
     monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
     monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        package, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: pkg),
+        package_file,
+        "PackageFile",
+        pretend.stub(from_filename=lambda *a, **kw: package),
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 
@@ -75,7 +77,7 @@ def test_check_passing_distribution(monkeypatch):
 
 
 def test_check_no_description(monkeypatch, capsys):
-    pkg = pretend.stub(
+    package = pretend.stub(
         metadata_dictionary=lambda: {
             "description": None,
             "description_content_type": None,
@@ -84,7 +86,9 @@ def test_check_no_description(monkeypatch, capsys):
 
     monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        package, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: pkg),
+        package_file,
+        "PackageFile",
+        pretend.stub(from_filename=lambda *a, **kw: package),
     )
 
     # used to crash with `AttributeError`
@@ -100,7 +104,7 @@ def test_check_no_description(monkeypatch, capsys):
 
 def test_check_failing_distribution(monkeypatch):
     renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: None))
-    pkg = pretend.stub(
+    package = pretend.stub(
         metadata_dictionary=lambda: {
             "description": "blah",
             "description_content_type": "text/markdown",
@@ -112,7 +116,9 @@ def test_check_failing_distribution(monkeypatch):
     monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
     monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
     monkeypatch.setattr(
-        package, "PackageFile", pretend.stub(from_filename=lambda *a, **kw: pkg),
+        package_file,
+        "PackageFile",
+        pretend.stub(from_filename=lambda *a, **kw: package),
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,13 +14,13 @@
 import pretend
 import pytest
 
-import twine.commands.upload
 from twine import cli
+from twine.commands import upload
 
 
 def test_dispatch_to_subcommand(monkeypatch):
     replaced_main = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(twine.commands.upload, "main", replaced_main)
+    monkeypatch.setattr(upload, "main", replaced_main)
 
     cli.dispatch(["upload", "path/to/file"])
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 
-from twine import commands, exceptions
+from twine import commands
+from twine import exceptions
 
 
 def test_ensure_wheel_files_uploaded_first():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,12 +2,11 @@ import os
 
 import pytest
 
-from twine import exceptions
-from twine.commands import _find_dists, _group_wheel_files_first
+from twine import commands, exceptions
 
 
 def test_ensure_wheel_files_uploaded_first():
-    files = _group_wheel_files_first(
+    files = commands._group_wheel_files_first(
         ["twine/foo.py", "twine/first.whl", "twine/bar.py", "twine/second.whl"]
     )
     expected = [
@@ -20,13 +19,13 @@ def test_ensure_wheel_files_uploaded_first():
 
 
 def test_ensure_if_no_wheel_files():
-    files = _group_wheel_files_first(["twine/foo.py", "twine/bar.py"])
+    files = commands._group_wheel_files_first(["twine/foo.py", "twine/bar.py"])
     expected = ["twine/foo.py", "twine/bar.py"]
     assert expected == files
 
 
 def test_find_dists_expands_globs():
-    files = sorted(_find_dists(["twine/__*.py"]))
+    files = sorted(commands._find_dists(["twine/__*.py"]))
     expected = [
         os.path.join("twine", "__init__.py"),
         os.path.join("twine", "__main__.py"),
@@ -36,7 +35,7 @@ def test_find_dists_expands_globs():
 
 def test_find_dists_errors_on_invalid_globs():
     with pytest.raises(exceptions.InvalidDistribution):
-        _find_dists(["twine/*.rb"])
+        commands._find_dists(["twine/*.rb"])
 
 
 def test_find_dists_handles_real_files():
@@ -47,5 +46,5 @@ def test_find_dists_handles_real_files():
         "twine/utils.py",
         "twine/wheel.py",
     ]
-    files = _find_dists(expected)
+    files = commands._find_dists(expected)
     assert expected == files

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,4 @@
-from twine.cli import dispatch
+from twine import cli
 
 
 def test_devpi_upload(devpi_server, uploadable_dist):
@@ -12,7 +12,7 @@ def test_devpi_upload(devpi_server, uploadable_dist):
         devpi_server.password,
         str(uploadable_dist),
     ]
-    dispatch(command)
+    cli.dispatch(command)
 
 
 twine_sampleproject_token = (
@@ -35,7 +35,7 @@ def test_pypi_upload(sampleproject_dist):
         twine_sampleproject_token,
         str(sampleproject_dist),
     ]
-    dispatch(command)
+    cli.dispatch(command)
 
 
 def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
@@ -49,4 +49,4 @@ def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
         "any",
         str(uploadable_dist),
     ]
-    dispatch(command)
+    cli.dispatch(command)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,7 @@
 
 import pretend
 
-from twine import __main__ as dunder_main
-from twine import cli, exceptions
+from twine import __main__ as dunder_main, cli, exceptions
 
 
 def test_exception_handling(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,8 @@
 
 import pretend
 
-from twine import __main__ as dunder_main, cli, exceptions
+from twine import __main__ as dunder_main
+from twine import cli, exceptions
 
 
 def test_exception_handling(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,8 @@
 import pretend
 
 from twine import __main__ as dunder_main
-from twine import cli, exceptions
+from twine import cli
+from twine import exceptions
 
 
 def test_exception_handling(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,10 +13,10 @@
 import pretend
 
 from twine import __main__ as dunder_main
-from twine import exceptions
+from twine import cli, exceptions
 
 
 def test_exception_handling(monkeypatch):
     replaced_dispatch = pretend.raiser(exceptions.InvalidConfiguration("foo"))
-    monkeypatch.setattr(dunder_main, "dispatch", replaced_dispatch)
+    monkeypatch.setattr(cli, "dispatch", replaced_dispatch)
     assert dunder_main.main() == "InvalidConfiguration: foo"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -14,15 +14,15 @@
 import pretend
 import pytest
 
-from twine import exceptions, package
+from twine import exceptions, package as package_file
 
 
 def test_sign_file(monkeypatch):
     replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
     filename = "tests/fixtures/deprecated-pypirc"
 
-    pkg = package.PackageFile(
+    package = package_file.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
@@ -30,7 +30,7 @@ def test_sign_file(monkeypatch):
         filetype=None,
     )
     try:
-        pkg.sign("gpg2", None)
+        package.sign("gpg2", None)
     except IOError:
         pass
     args = ("gpg2", "--detach-sign", "-a", filename)
@@ -39,10 +39,10 @@ def test_sign_file(monkeypatch):
 
 def test_sign_file_with_identity(monkeypatch):
     replaced_check_call = pretend.call_recorder(lambda args: None)
-    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
     filename = "tests/fixtures/deprecated-pypirc"
 
-    pkg = package.PackageFile(
+    package = package_file.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
@@ -50,7 +50,7 @@ def test_sign_file_with_identity(monkeypatch):
         filetype=None,
     )
     try:
-        pkg.sign("gpg", "identity")
+        package.sign("gpg", "identity")
     except IOError:
         pass
     args = ("gpg", "--detach-sign", "--local-user", "identity", "-a", filename)
@@ -59,22 +59,22 @@ def test_sign_file_with_identity(monkeypatch):
 
 def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
     replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
-    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
     gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
-        package.PackageFile.run_gpg(gpg_args)
+        package_file.PackageFile.run_gpg(gpg_args)
 
     assert "executables not available" in err.value.args[0]
 
 
 def test_run_gpg_raises_exception_if_not_using_gpg(monkeypatch):
     replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
-    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
     gpg_args = ("not_gpg", "--detach-sign", "-a", "pypircfile")
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
-        package.PackageFile.run_gpg(gpg_args)
+        package_file.PackageFile.run_gpg(gpg_args)
 
     assert "not_gpg executable not available" in err.value.args[0]
 
@@ -85,10 +85,10 @@ def test_run_gpg_falls_back_to_gpg2(monkeypatch):
             raise FileNotFoundError("gpg not found")
 
     replaced_check_call = pretend.call_recorder(check_call)
-    monkeypatch.setattr(package.subprocess, "check_call", replaced_check_call)
+    monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
     gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
 
-    package.PackageFile.run_gpg(gpg_args)
+    package_file.PackageFile.run_gpg(gpg_args)
 
     gpg2_args = replaced_check_call.calls[1].args
     assert gpg2_args[0][0] == "gpg2"
@@ -97,7 +97,7 @@ def test_run_gpg_falls_back_to_gpg2(monkeypatch):
 def test_package_signed_name_is_correct():
     filename = "tests/fixtures/deprecated-pypirc"
 
-    pkg = package.PackageFile(
+    package = package_file.PackageFile(
         filename=filename,
         comment=None,
         metadata=pretend.stub(name="deprecated-pypirc"),
@@ -105,8 +105,8 @@ def test_package_signed_name_is_correct():
         filetype=None,
     )
 
-    assert pkg.signed_basefilename == "deprecated-pypirc.asc"
-    assert pkg.signed_filename == (filename + ".asc")
+    assert package.signed_basefilename == "deprecated-pypirc.asc"
+    assert package.signed_filename == (filename + ".asc")
 
 
 @pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])
@@ -141,24 +141,24 @@ def test_metadata_dictionary(gpg_signature):
         description_content_type=pretend.stub(),
     )
 
-    pkg = package.PackageFile(
+    package = package_file.PackageFile(
         filename="tests/fixtures/twine-1.5.0-py2.py3-none-any.whl",
         comment=pretend.stub(),
         metadata=meta,
         python_version=pretend.stub(),
         filetype=pretend.stub(),
     )
-    pkg.gpg_signature = gpg_signature
+    package.gpg_signature = gpg_signature
 
-    result = pkg.metadata_dictionary()
+    result = package.metadata_dictionary()
 
     # identify release
-    assert result["name"] == pkg.safe_name
+    assert result["name"] == package.safe_name
     assert result["version"] == meta.version
 
     # file content
-    assert result["filetype"] == pkg.filetype
-    assert result["pyversion"] == pkg.python_version
+    assert result["filetype"] == package.filetype
+    assert result["pyversion"] == package.python_version
 
     # additional meta-data
     assert result["metadata_version"] == meta.metadata_version
@@ -175,7 +175,7 @@ def test_metadata_dictionary(gpg_signature):
     assert result["classifiers"] == meta.classifiers
     assert result["download_url"] == meta.download_url
     assert result["supported_platform"] == meta.supported_platforms
-    assert result["comment"] == pkg.comment
+    assert result["comment"] == package.comment
 
     # PEP 314
     assert result["provides"] == meta.provides
@@ -198,7 +198,7 @@ def test_metadata_dictionary(gpg_signature):
     assert result.get("gpg_signature") == gpg_signature
 
 
-TWINE_1_5_0_WHEEL_HEXDIGEST = package.Hexdigest(
+TWINE_1_5_0_WHEEL_HEXDIGEST = package_file.Hexdigest(
     "1919f967e990bee7413e2a4bc35fd5d1",
     "d86b0f33f0c7df49e888b11c43b417da5520cbdbce9f20618b1494b600061e67",
     "b657a4148d05bd0098c1d6d8cc4e14e766dbe93c3a5ab6723b969da27a87bac0",
@@ -208,7 +208,7 @@ TWINE_1_5_0_WHEEL_HEXDIGEST = package.Hexdigest(
 def test_hash_manager():
     """Verify our HashManager works."""
     filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
-    hasher = package.HashManager(filename)
+    hasher = package_file.HashManager(filename)
     hasher.hash()
     assert hasher.hexdigest() == TWINE_1_5_0_WHEEL_HEXDIGEST
 
@@ -216,10 +216,10 @@ def test_hash_manager():
 def test_fips_hash_manager(monkeypatch):
     """Verify the behaviour if hashlib is using FIPS mode."""
     replaced_md5 = pretend.raiser(ValueError("fipsmode"))
-    monkeypatch.setattr(package.hashlib, "md5", replaced_md5)
+    monkeypatch.setattr(package_file.hashlib, "md5", replaced_md5)
 
     filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
-    hasher = package.HashManager(filename)
+    hasher = package_file.HashManager(filename)
     hasher.hash()
     hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(md5=None)
     assert hasher.hexdigest() == hashes
@@ -235,10 +235,10 @@ def test_pkginfo_returns_no_metadata(monkeypatch):
     def EmptyDist(filename):
         return pretend.stub(name=None, version=None)
 
-    monkeypatch.setattr(package, "DIST_TYPES", {"bdist_wheel": EmptyDist})
+    monkeypatch.setattr(package_file, "DIST_TYPES", {"bdist_wheel": EmptyDist})
     filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
 
     with pytest.raises(exceptions.InvalidDistribution) as err:
-        package.PackageFile.from_filename(filename, comment=None)
+        package_file.PackageFile.from_filename(filename, comment=None)
 
     assert "Invalid distribution metadata" in err.value.args[0]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -14,8 +14,7 @@
 import pretend
 import pytest
 
-from twine import exceptions
-from twine import package as package_file
+from twine import exceptions, package as package_file
 
 
 def test_sign_file(monkeypatch):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -225,17 +225,6 @@ def test_fips_hash_manager(monkeypatch):
     assert hasher.hexdigest() == hashes
 
 
-def test_no_blake2_hash_manager(monkeypatch):
-    """Verify the behaviour with missing blake2."""
-    monkeypatch.setattr(package, "blake2b", None)
-
-    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
-    hasher = package.HashManager(filename)
-    hasher.hash()
-    hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(blake2=None)
-    assert hasher.hexdigest() == hashes
-
-
 def test_pkginfo_returns_no_metadata(monkeypatch):
     """
     Fail gracefully if pkginfo can't interpret the metadata (possibly due to

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -14,7 +14,8 @@
 import pretend
 import pytest
 
-from twine import exceptions, package as package_file
+from twine import exceptions
+from twine import package as package_file
 
 
 def test_sign_file(monkeypatch):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -28,7 +28,7 @@ def test_exception_for_redirect(make_settings):
     )
 
     stub_repository = pretend.stub(
-        register=lambda package: stub_response, close=lambda: None
+        register=lambda pkg: stub_response, close=lambda: None
     )
 
     register_settings.create_repository = lambda: stub_repository

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -28,7 +28,7 @@ def test_exception_for_redirect(make_settings):
     )
 
     stub_repository = pretend.stub(
-        register=lambda pkg: stub_response, close=lambda: None
+        register=lambda package: stub_response, close=lambda: None
     )
 
     register_settings.create_repository = lambda: stub_repository

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -17,8 +17,7 @@ import pretend
 import pytest
 import requests
 
-from twine import repository
-from twine.utils import DEFAULT_REPOSITORY, TEST_REPOSITORY
+from twine import repository, utils
 
 
 def test_gpg_signature_structure_is_preserved():
@@ -57,7 +56,9 @@ def test_iterables_are_flattened():
 
 def test_set_client_certificate():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username="username",
+        password="password",
     )
 
     assert repo.session.cert is None
@@ -68,7 +69,9 @@ def test_set_client_certificate():
 
 def test_set_certificate_authority():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username="username",
+        password="password",
     )
 
     assert repo.session.verify is True
@@ -79,7 +82,9 @@ def test_set_certificate_authority():
 
 def test_make_user_agent_string():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username="username",
+        password="password",
     )
 
     assert "User-Agent" in repo.session.headers
@@ -103,26 +108,30 @@ def response_with(**kwattrs):
 
 def test_package_is_uploaded_404s():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username="username",
+        password="password",
     )
     repo.session = pretend.stub(get=lambda url, headers: response_with(status_code=404))
-    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    pkg = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
-    assert repo.package_is_uploaded(package) is False
+    assert repo.package_is_uploaded(pkg) is False
 
 
 def test_package_is_uploaded_200s_with_no_releases():
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY, username="username", password="password",
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username="username",
+        password="password",
     )
     repo.session = pretend.stub(
         get=lambda url, headers: response_with(
             status_code=200, _content=b'{"releases": {}}', _content_consumed=True
         ),
     )
-    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    pkg = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
-    assert repo.package_is_uploaded(package) is False
+    assert repo.package_is_uploaded(pkg) is False
 
 
 @pytest.mark.parametrize("disable_progress_bar", [True, False])
@@ -142,7 +151,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
 
     monkeypatch.setattr(repository, "ProgressBar", progressbarstub)
     repo = repository.Repository(
-        repository_url=DEFAULT_REPOSITORY,
+        repository_url=utils.DEFAULT_REPOSITORY,
         username="username",
         password="password",
         disable_progress_bar=disable_progress_bar,
@@ -158,7 +167,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
     def dictfunc():
         return {"name": "fake"}
 
-    package = pretend.stub(
+    pkg = pretend.stub(
         safe_name="fake",
         metadata=pretend.stub(version="2.12.0"),
         basefilename="fake.whl",
@@ -166,7 +175,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
         metadata_dictionary=dictfunc,
     )
 
-    repo.upload(package)
+    repo.upload(pkg)
 
 
 @pytest.mark.parametrize(
@@ -175,25 +184,25 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
         # Single package
         (
             [("fake", "2.12.0")],
-            DEFAULT_REPOSITORY,
+            utils.DEFAULT_REPOSITORY,
             {"https://pypi.org/project/fake/2.12.0/"},
         ),
         # Single package to testpypi
         (
             [("fake", "2.12.0")],
-            TEST_REPOSITORY,
+            utils.TEST_REPOSITORY,
             {"https://test.pypi.org/project/fake/2.12.0/"},
         ),
         # Multiple packages (faking a wheel and an sdist)
         (
             [("fake", "2.12.0"), ("fake", "2.12.0")],
-            DEFAULT_REPOSITORY,
+            utils.DEFAULT_REPOSITORY,
             {"https://pypi.org/project/fake/2.12.0/"},
         ),
         # Multiple releases
         (
             [("fake", "2.12.0"), ("fake", "2.12.1")],
-            DEFAULT_REPOSITORY,
+            utils.DEFAULT_REPOSITORY,
             {
                 "https://pypi.org/project/fake/2.12.0/",
                 "https://pypi.org/project/fake/2.12.1/",
@@ -202,7 +211,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
         # Not pypi
         ([("fake", "2.12.0")], "http://devpi.example.com", set(),),
         # No packages
-        ([], DEFAULT_REPOSITORY, set(),),
+        ([], utils.DEFAULT_REPOSITORY, set(),),
     ],
 )
 def test_release_urls(package_meta, repository_url, release_urls):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -17,7 +17,8 @@ import pretend
 import pytest
 import requests
 
-from twine import repository, utils
+from twine import repository
+from twine import utils
 
 
 def test_gpg_signature_structure_is_preserved():

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -113,9 +113,9 @@ def test_package_is_uploaded_404s():
         password="password",
     )
     repo.session = pretend.stub(get=lambda url, headers: response_with(status_code=404))
-    pkg = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
-    assert repo.package_is_uploaded(pkg) is False
+    assert repo.package_is_uploaded(package) is False
 
 
 def test_package_is_uploaded_200s_with_no_releases():
@@ -129,9 +129,9 @@ def test_package_is_uploaded_200s_with_no_releases():
             status_code=200, _content=b'{"releases": {}}', _content_consumed=True
         ),
     )
-    pkg = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
 
-    assert repo.package_is_uploaded(pkg) is False
+    assert repo.package_is_uploaded(package) is False
 
 
 @pytest.mark.parametrize("disable_progress_bar", [True, False])
@@ -167,7 +167,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
     def dictfunc():
         return {"name": "fake"}
 
-    pkg = pretend.stub(
+    package = pretend.stub(
         safe_name="fake",
         metadata=pretend.stub(version="2.12.0"),
         basefilename="fake.whl",
@@ -175,7 +175,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
         metadata_dictionary=dictfunc,
     )
 
-    repo.upload(pkg)
+    repo.upload(package)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,7 +18,8 @@ import textwrap
 
 import pytest
 
-from twine import exceptions, settings
+from twine import exceptions
+from twine import settings
 
 
 def test_settings_takes_no_positional_arguments():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,7 +16,8 @@ import pytest
 import requests
 
 import helpers
-from twine import cli, exceptions, package as package_file
+from twine import cli, exceptions
+from twine import package as package_file
 from twine.commands import upload
 
 SDIST_FIXTURE = "tests/fixtures/twine-1.5.0.tar.gz"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 
 import helpers
-from twine import cli, exceptions, package
+from twine import cli, exceptions, package as package_file
 from twine.commands import upload
 
 SDIST_FIXTURE = "tests/fixtures/twine-1.5.0.tar.gz"
@@ -35,7 +35,7 @@ def test_successful_upload(make_settings, capsys):
     )
 
     stub_repository = pretend.stub(
-        upload=lambda pkg: stub_response,
+        upload=lambda package: stub_response,
         close=lambda: None,
         release_urls=lambda packages: {RELEASE_URL, NEW_RELEASE_URL},
     )
@@ -68,7 +68,7 @@ def test_exception_for_http_status(verbose, make_settings, capsys):
     )
 
     stub_repository = pretend.stub(
-        upload=lambda pkg: stub_response, close=lambda: None,
+        upload=lambda package: stub_response, close=lambda: None,
     )
 
     upload_settings.create_repository = lambda: stub_repository
@@ -148,7 +148,9 @@ def test_exception_for_redirect(make_settings):
         headers={"location": "https://test.pypi.org/legacy/"},
     )
 
-    stub_repository = pretend.stub(upload=lambda pkg: stub_response, close=lambda: None)
+    stub_repository = pretend.stub(
+        upload=lambda package: stub_response, close=lambda: None
+    )
 
     upload_settings.create_repository = lambda: stub_repository
 
@@ -163,7 +165,7 @@ def test_prints_skip_message_for_uploaded_package(make_settings, capsys):
 
     stub_repository = pretend.stub(
         # Short-circuit the upload, so no need for a stub response
-        package_is_uploaded=lambda pkg: True,
+        package_is_uploaded=lambda package: True,
         release_urls=lambda packages: {},
         close=lambda: None,
     )
@@ -187,9 +189,9 @@ def test_prints_skip_message_for_response(make_settings, capsys):
 
     stub_repository = pretend.stub(
         # Do the upload, triggering the error response
-        package_is_uploaded=lambda pkg: False,
+        package_is_uploaded=lambda package: False,
         release_urls=lambda packages: {},
-        upload=lambda pkg: stub_response,
+        upload=lambda package: stub_response,
         close=lambda: None,
     )
 
@@ -266,7 +268,7 @@ def test_skip_existing_skips_files_on_repository(response_kwargs):
     assert upload.skip_upload(
         response=pretend.stub(**response_kwargs),
         skip_existing=True,
-        pkg=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
+        package=package_file.PackageFile.from_filename(WHEEL_FIXTURE, None),
     )
 
 
@@ -283,7 +285,7 @@ def test_skip_upload_doesnt_match(response_kwargs):
     assert not upload.skip_upload(
         response=pretend.stub(**response_kwargs),
         skip_existing=True,
-        pkg=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
+        package=package_file.PackageFile.from_filename(WHEEL_FIXTURE, None),
     )
 
 
@@ -291,7 +293,7 @@ def test_skip_upload_respects_skip_existing():
     assert not upload.skip_upload(
         response=pretend.stub(),
         skip_existing=False,
-        pkg=package.PackageFile.from_filename(WHEEL_FIXTURE, None),
+        package=package_file.PackageFile.from_filename(WHEEL_FIXTURE, None),
     )
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,8 +16,7 @@ import pytest
 import requests
 
 import helpers
-from twine import cli, exceptions
-from twine import package as package_file
+from twine import cli, exceptions, package as package_file
 from twine.commands import upload
 
 SDIST_FIXTURE = "tests/fixtures/twine-1.5.0.tar.gz"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -16,7 +16,8 @@ import pytest
 import requests
 
 import helpers
-from twine import cli, exceptions
+from twine import cli
+from twine import exceptions
 from twine import package as package_file
 from twine.commands import upload
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,8 @@ import pretend
 import pytest
 
 import helpers
-from twine import exceptions, utils
+from twine import exceptions
+from twine import utils
 
 
 def test_get_config(tmpdir):

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -16,14 +16,13 @@ import sys
 
 import requests
 
-from twine import exceptions
-from twine.cli import dispatch
+from twine import cli, exceptions
 
 
 def main():
     try:
-        return dispatch(sys.argv[1:])
-    except (exceptions.TwineException, requests.exceptions.HTTPError) as exc:
+        return cli.dispatch(sys.argv[1:])
+    except (exceptions.TwineException, requests.HTTPError) as exc:
         return "{}: {}".format(exc.__class__.__name__, exc.args[0])
 
 

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -16,7 +16,8 @@ import sys
 
 import requests
 
-from twine import cli, exceptions
+from twine import cli
+from twine import exceptions
 
 
 def main():

--- a/twine/_installed.py
+++ b/twine/_installed.py
@@ -17,11 +17,11 @@ class Installed(pkginfo.Installed):
     def read(self):
         opj = os.path.join
         if self.package is not None:
-            package = self.package.__package__
-            if package is None:
-                package = self.package.__name__
-            egg_pattern = "%s*.egg-info" % package
-            dist_pattern = "%s*.dist-info" % package
+            pkg = self.package.__package__
+            if pkg is None:
+                pkg = self.package.__name__
+            egg_pattern = "%s*.egg-info" % pkg
+            dist_pattern = "%s*.dist-info" % pkg
             file = getattr(self.package, "__file__", None)
             if file is not None:
                 candidates = []

--- a/twine/_installed.py
+++ b/twine/_installed.py
@@ -17,11 +17,11 @@ class Installed(pkginfo.Installed):
     def read(self):
         opj = os.path.join
         if self.package is not None:
-            pkg = self.package.__package__
-            if pkg is None:
-                pkg = self.package.__name__
-            egg_pattern = "%s*.egg-info" % pkg
-            dist_pattern = "%s*.dist-info" % pkg
+            package = self.package.__package__
+            if package is None:
+                package = self.package.__name__
+            egg_pattern = "%s*.egg-info" % package
+            dist_pattern = "%s*.dist-info" % package
             file = getattr(self.package, "__file__", None)
             if file is not None:
                 candidates = []

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -1,11 +1,13 @@
 import functools
 import getpass
 import warnings
-from typing import Callable, Optional
+from typing import Callable
+from typing import Optional
 
 import keyring
 
-from twine import exceptions, utils
+from twine import exceptions
+from twine import utils
 
 
 class CredentialInput:

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional
 
 import keyring
 
-from . import exceptions, utils
+from twine import exceptions, utils
 
 
 class CredentialInput:

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -21,7 +21,7 @@ import setuptools
 import tqdm
 
 import twine
-from twine._installed import Installed
+from twine import _installed
 
 
 def _registered_commands(group="twine.registered_commands"):
@@ -31,7 +31,7 @@ def _registered_commands(group="twine.registered_commands"):
 
 def list_dependencies_and_versions():
     return [
-        ("pkginfo", Installed(pkginfo).version),
+        ("pkginfo", _installed.Installed(pkginfo).version),
         ("requests", requests.__version__),
         ("setuptools", setuptools.__version__),
         ("requests-toolbelt", requests_toolbelt.__version__),

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -19,7 +19,7 @@ import sys
 
 import readme_renderer.rst
 
-from twine import commands, package
+from twine import commands, package as package_file
 
 _RENDERERS = {
     None: readme_renderer.rst,  # Default if description_content_type is None
@@ -69,9 +69,9 @@ def _check_file(filename, render_warning_stream):
     warnings = []
     is_ok = True
 
-    pkg = package.PackageFile.from_filename(filename, comment=None)
+    package = package_file.PackageFile.from_filename(filename, comment=None)
 
-    metadata = pkg.metadata_dictionary()
+    metadata = package.metadata_dictionary()
     description = metadata["description"]
     description_content_type = metadata["description_content_type"]
 

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 import argparse
 import cgi
+import io
 import re
 import sys
-from io import StringIO
 
 import readme_renderer.rst
 
-from twine.commands import _find_dists
-from twine.package import PackageFile
+from twine import commands, package
 
 _RENDERERS = {
     None: readme_renderer.rst,  # Default if description_content_type is None
@@ -44,7 +43,7 @@ _REPORT_RE = re.compile(
 
 class _WarningStream:
     def __init__(self):
-        self.output = StringIO()
+        self.output = io.StringIO()
 
     def write(self, text):
         matched = _REPORT_RE.search(text)
@@ -70,9 +69,9 @@ def _check_file(filename, render_warning_stream):
     warnings = []
     is_ok = True
 
-    package = PackageFile.from_filename(filename, comment=None)
+    pkg = package.PackageFile.from_filename(filename, comment=None)
 
-    metadata = package.metadata_dictionary()
+    metadata = pkg.metadata_dictionary()
     description = metadata["description"]
     description_content_type = metadata["description_content_type"]
 
@@ -109,7 +108,7 @@ def _indented(text, prefix):
 
 
 def check(dists, output_stream=sys.stdout):
-    uploads = [i for i in _find_dists(dists) if not i.endswith(".asc")]
+    uploads = [i for i in commands._find_dists(dists) if not i.endswith(".asc")]
     if not uploads:  # Return early, if there are no files to check.
         output_stream.write("No files to check.\n")
         return False

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -19,7 +19,8 @@ import sys
 
 import readme_renderer.rst
 
-from twine import commands, package as package_file
+from twine import commands
+from twine import package as package_file
 
 _RENDERERS = {
     None: readme_renderer.rst,  # Default if description_content_type is None

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -19,8 +19,7 @@ import sys
 
 import readme_renderer.rst
 
-from twine import commands
-from twine import package as package_file
+from twine import commands, package as package_file
 
 _RENDERERS = {
     None: readme_renderer.rst,  # Default if description_content_type is None

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -14,20 +14,22 @@
 import argparse
 import os.path
 
-from twine import exceptions, package, settings
+from twine import exceptions, package as package_file, settings
 
 
-def register(register_settings, pkg):
+def register(register_settings, package):
     repository_url = register_settings.repository_config["repository"]
 
     print(f"Registering package to {repository_url}")
     repository = register_settings.create_repository()
 
-    if not os.path.exists(pkg):
-        raise exceptions.PackageNotFound(f'"{pkg}" does not exist on the file system.')
+    if not os.path.exists(package):
+        raise exceptions.PackageNotFound(
+            f'"{package}" does not exist on the file system.'
+        )
 
     resp = repository.register(
-        package.PackageFile.from_filename(pkg, register_settings.comment)
+        package_file.PackageFile.from_filename(package, register_settings.comment)
     )
     repository.close()
 

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -14,23 +14,20 @@
 import argparse
 import os.path
 
-from twine import exceptions, settings
-from twine.package import PackageFile
+from twine import exceptions, package, settings
 
 
-def register(register_settings, package):
+def register(register_settings, pkg):
     repository_url = register_settings.repository_config["repository"]
 
     print(f"Registering package to {repository_url}")
     repository = register_settings.create_repository()
 
-    if not os.path.exists(package):
-        raise exceptions.PackageNotFound(
-            f'"{package}" does not exist on the file system.'
-        )
+    if not os.path.exists(pkg):
+        raise exceptions.PackageNotFound(f'"{pkg}" does not exist on the file system.')
 
     resp = repository.register(
-        PackageFile.from_filename(package, register_settings.comment)
+        package.PackageFile.from_filename(pkg, register_settings.comment)
     )
     repository.close()
 

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -14,9 +14,7 @@
 import argparse
 import os.path
 
-from twine import exceptions
-from twine import package as package_file
-from twine import settings
+from twine import exceptions, package as package_file, settings
 
 
 def register(register_settings, package):

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -14,7 +14,9 @@
 import argparse
 import os.path
 
-from twine import exceptions, package as package_file, settings
+from twine import exceptions
+from twine import package as package_file
+from twine import settings
 
 
 def register(register_settings, package):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -14,9 +14,7 @@
 import argparse
 import os.path
 
-from twine import commands, exceptions
-from twine import package as package_file
-from twine import settings, utils
+from twine import commands, exceptions, package as package_file, settings, utils
 
 
 def skip_upload(response, skip_existing, package):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -14,7 +14,9 @@
 import argparse
 import os.path
 
-from twine import commands, exceptions, package as package_file, settings, utils
+from twine import commands, exceptions
+from twine import package as package_file
+from twine import settings, utils
 
 
 def skip_upload(response, skip_existing, package):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -14,9 +14,11 @@
 import argparse
 import os.path
 
-from twine import commands, exceptions
+from twine import commands
+from twine import exceptions
 from twine import package as package_file
-from twine import settings, utils
+from twine import settings
+from twine import utils
 
 
 def skip_upload(response, skip_existing, package):

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -47,7 +47,7 @@ class RedirectDetected(TwineException):
 class PackageNotFound(TwineException):
     """A package file was provided that could not be found on the file system.
 
-    This is only used when attempting to register a package.
+    This is only used when attempting to register a package_file.
     """
 
     pass

--- a/twine/package.py
+++ b/twine/package.py
@@ -16,19 +16,16 @@ import hashlib
 import io
 import os
 import subprocess
-from hashlib import blake2b
 from typing import IO, Dict, Optional, Sequence, Tuple, Union
 
 import pkg_resources
 import pkginfo
 
-from twine import exceptions
-from twine.wheel import Wheel
-from twine.wininst import WinInst
+from twine import exceptions, wheel, wininst
 
 DIST_TYPES = {
-    "bdist_wheel": Wheel,
-    "bdist_wininst": WinInst,
+    "bdist_wheel": wheel.Wheel,
+    "bdist_wininst": wininst.WinInst,
     "bdist_egg": pkginfo.BDist,
     "sdist": pkginfo.SDist,
 }
@@ -217,9 +214,7 @@ class HashManager:
 
         self._sha2_hasher = hashlib.sha256()
 
-        self._blake_hasher = None
-        if blake2b is not None:
-            self._blake_hasher = blake2b(digest_size=256 // 8)
+        self._blake_hasher = hashlib.blake2b(digest_size=256 // 8)
 
     def _md5_update(self, content: bytes) -> None:
         if self._md5_hasher is not None:

--- a/twine/package.py
+++ b/twine/package.py
@@ -16,12 +16,19 @@ import hashlib
 import io
 import os
 import subprocess
-from typing import IO, Dict, Optional, Sequence, Tuple, Union
+from typing import IO
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
 
 import pkg_resources
 import pkginfo
 
-from twine import exceptions, wheel, wininst
+from twine import exceptions
+from twine import wheel
+from twine import wininst
 
 DIST_TYPES = {
     "bdist_wheel": wheel.Wheel,

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 import requests
 import requests_toolbelt

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from typing import Optional, cast
+from typing import Optional
+from typing import cast
 
-from twine import auth, exceptions, repository, utils
+from twine import auth
+from twine import exceptions
+from twine import repository
+from twine import utils
 
 
 class Settings:

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -17,8 +17,12 @@ import configparser
 import functools
 import os
 import os.path
-from typing import Callable, DefaultDict, Dict, Optional
-from urllib.parse import urlparse, urlunparse
+from typing import Callable
+from typing import DefaultDict
+from typing import Dict
+from typing import Optional
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 import requests
 

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
 import os
 import re
 import zipfile
-from io import StringIO
 
 from pkginfo import distribution
-from pkginfo.distribution import Distribution
 
 from twine import exceptions
 
@@ -34,7 +33,7 @@ wheel_file_re = re.compile(
 )
 
 
-class Wheel(Distribution):
+class Wheel(distribution.Distribution):
     def __init__(self, filename, metadata_version=None):
         self.filename = filename
         self.basefilename = os.path.basename(self.filename)
@@ -81,6 +80,6 @@ class Wheel(Distribution):
     def parse(self, data):
         super().parse(data)
 
-        fp = StringIO(distribution.must_decode(data))
+        fp = io.StringIO(distribution.must_decode(data))
         msg = distribution.parse(fp)
         self.description = msg.get_payload()

--- a/twine/wininst.py
+++ b/twine/wininst.py
@@ -2,14 +2,14 @@ import os
 import re
 import zipfile
 
-from pkginfo.distribution import Distribution
+from pkginfo import distribution
 
 from twine import exceptions
 
 wininst_file_re = re.compile(r".*py(?P<pyver>\d+\.\d+)\.exe$")
 
 
-class WinInst(Distribution):
+class WinInst(distribution.Distribution):
     def __init__(self, filename, metadata_version=None):
         self.filename = filename
         self.metadata_version = metadata_version


### PR DESCRIPTION
Per discussion in #570 and https://github.com/pypa/twine/pull/572#discussion_r377600302, and as suggested by the [Google Style Guide](http://google.github.io/styleguide/pyguide.html#22-imports):

> Use import statements for packages and modules only, not for individual classes or functions

Additional changes:

- Renamed frequently-used `package` variable to `pkg`, because this change introduced more instances of `from twine import package`; I saw `pkg` used elsewhere in the code

- Used higher-level APIs (e.g. `requests.HTTPError` instead of `requests.exceptions.HTTPError`, `urllib3` instead of `requests.packages.urllib3`, etc.) when I saw the opportunity

- Removed the conditional checks for `hashlib.blake2b`, since that's included in Python 3.6+

- Left imports from `contextlib` and `urllib.parse` alone, because those seem to be accepted conventions.

If folks are curious, here's the current results for `from .*import`: [from_import.txt](https://github.com/pypa/twine/files/4208444/from_import.txt).
