### PR TITLE
Add formatting to tox and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ matrix:
 
   include:
     - python: 3.7
-      name: Linting code smells
+      name: Linting code style
       env:
-        TOXENV: lint-code-style
+        TOXENV: code-style
     - python: 3.7
-      name: Linting type matching
+      name: Linting type annotations
       env:
-        TOXENV: lint-mypy
+        TOXENV: typing
     - python: 3.7
       name: Making sure that docs build is healthy
       env:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -55,7 +55,7 @@ environment, then, in the root directory, run:
 
   tox -e docs
 
-The HTML of the docs will be visible in :file:`twine/docs/_build/`.
+The HTML of the docs will be written to :file:`docs/_build/html`.
 
 Code style
 ^^^^^^^^^^

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,6 +57,16 @@ environment, then, in the root directory, run:
 
 The HTML of the docs will be visible in :file:`twine/docs/_build/`.
 
+Code style
+^^^^^^^^^^
+
+Run ``tox -e format`` to automatically reformat your changes. Run
+``tox -e lint`` to see any remaining code smells or type errors that
+need to be fixed manually.
+
+Additionally, the Twine maintainers prefer that ``import`` statements
+be used for packages and modules only, rather than individual classes
+or functions.
 
 Testing
 ^^^^^^^
@@ -68,14 +78,12 @@ Either run ``tox`` to build against all supported Python versions (if you have
 them installed) or run ``tox -e py{version}`` to test against a specific
 version, e.g., ``tox -e py36`` or ``tox -e py37``.
 
-Also, always run ``tox -e lint`` before submitting a pull request.
-
 Submitting changes
 ^^^^^^^^^^^^^^^^^^
 
 1. Fork `the GitHub repository`_.
 2. Make a branch off of ``master`` and commit your changes to it.
-3. Run the tests with ``tox`` and lint any docs changes with ``tox -e docs``.
+3. Run the tests, check code style, and build the docs as described above.
 4. Ensure that your name is added to the end of the :file:`AUTHORS`
    file using the format ``Name <email@domain.com> (url)``, where the
    ``(url)`` portion is optional.

--- a/tox.ini
+++ b/tox.ini
@@ -45,10 +45,17 @@ commands =
     python -m pep517.build .
     python -m twine upload dist/*
 
-[testenv:lint-code-style]
+[testenv:format]
 deps =
     isort
     black
+commands =
+    isort --recursive twine/ tests/
+    black twine/ tests/
+
+[testenv:lint-code-style]
+deps =
+    {[testenv:format]deps}
     flake8
 commands =
     isort --check-only --diff --recursive twine/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,39 @@ commands =
     python setup.py sdist
     twine check dist/*
 
+[testenv:format]
+deps =
+    isort
+    black
+commands =
+    isort --recursive twine/ tests/
+    black twine/ tests/
+
+[testenv:code-style]
+deps =
+    {[testenv:format]deps}
+    flake8
+commands =
+    isort --check-only --diff --recursive twine/ tests/
+    black --check --diff twine/ tests/
+    flake8 twine/ tests/
+
+[testenv:typing]
+deps =
+    mypy
+    lxml
+commands =
+    # TODO: Consider checking the tests after the source is fully typed
+    mypy twine
+
+[testenv:lint]
+deps =
+    {[testenv:code-style]deps}
+    {[testenv:typing]deps}
+commands =
+    {[testenv:code-style]commands}
+    {[testenv:typing]commands}
+
 [testenv:release]
 # disabled for twine to cause it to upload itself
 # skip_install = True
@@ -44,39 +77,6 @@ commands =
     python -c "import path; path.Path('dist').rmtree_p()"
     python -m pep517.build .
     python -m twine upload dist/*
-
-[testenv:format]
-deps =
-    isort
-    black
-commands =
-    isort --recursive twine/ tests/
-    black twine/ tests/
-
-[testenv:lint-code-style]
-deps =
-    {[testenv:format]deps}
-    flake8
-commands =
-    isort --check-only --diff --recursive twine/ tests/
-    black --check --diff twine/ tests/
-    flake8 twine/ tests/
-
-[testenv:lint-mypy]
-deps =
-    mypy
-    lxml
-commands =
-    # TODO: Consider checking the tests after the source is fully typed
-    mypy twine
-
-[testenv:lint]
-deps =
-    {[testenv:lint-code-style]deps}
-    {[testenv:lint-mypy]deps}
-commands =
-    {[testenv:lint-code-style]commands}
-    {[testenv:lint-mypy]commands}
 
 [testenv:devpi]
 deps =


### PR DESCRIPTION
Changes:

- Add `tox -e format` to run isort and black
- Shuffle and rename tox testenvs for readability
- Add "Code style" section to the contributing doc