### PR TITLE
Fix enumerate list of usage instruction in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ Using Twine
 
        $ python setup.py sdist bdist_wheel
 
-2. Upload with ``twine`` to `Test PyPI`_ and verify things look right. Twine
-will automatically prompt for your username and password:
+2. Upload with ``twine`` to `Test PyPI`_ and verify things look right.
+   Twine will automatically prompt for your username and password:
 
    .. code-block:: console
 


### PR DESCRIPTION
This is done as requested at https://github.com/pypa/twine/pull/585#issuecomment-614695219 for the ease of review.