### PR TITLE
Use short repo name in usage instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Using Twine
 
    .. code-block:: console
 
-       $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+       $ twine upload -r testpypi dist/*
        username: ...
        password:
        ...


### PR DESCRIPTION
This seems more friendly to newcomers.