### PR TITLE
Add unit tests for twine.wheel

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,6 @@ import requests
 
 from twine import settings
 
-TESTS_DIR = pathlib.Path(__file__).parent
-
 
 @pytest.fixture()
 def pypirc(tmpdir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ import requests
 
 from twine import settings
 
+TESTS_DIR = pathlib.Path(__file__).parent
+
 
 @pytest.fixture()
 def pypirc(tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -277,18 +277,18 @@ def test_check_status_code_for_missing_status_code(capsys, repo_url):
     response = pretend.stub(
         status_code=403,
         url=repo_url,
-        raise_for_status=pretend.raiser(requests.exceptions.HTTPError),
+        raise_for_status=pretend.raiser(requests.HTTPError),
         text="Forbidden",
     )
 
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(requests.HTTPError):
         utils.check_status_code(response, True)
 
     # Different messages are printed based on the verbose level
     captured = capsys.readouterr()
     assert captured.out == "Content received from server:\nForbidden\n"
 
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(requests.HTTPError):
         utils.check_status_code(response, False)
 
     captured = capsys.readouterr()

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -11,19 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+from io import BytesIO
+from textwrap import dedent
+from zipfile import ZipFile
+
 import pytest
 
+from twine import exceptions
 from twine import wheel
 
 
 @pytest.fixture(
     params=[
-        "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl",
-        "tests/alt-fixtures/twine-1.5.0-py2.py3-none-any.whl",
+        "fixtures/twine-1.5.0-py2.py3-none-any.whl",
+        "alt-fixtures/twine-1.5.0-py2.py3-none-any.whl",
     ]
 )
 def example_wheel(request):
-    return wheel.Wheel(request.param)
+    file_name = os.path.join(os.path.dirname(__file__), request.param)
+    return wheel.Wheel(file_name)
 
 
 def test_version_parsing(example_wheel):
@@ -45,3 +52,62 @@ def test_find_metadata_files():
     ]
     candidates = wheel.Wheel.find_candidate_metadata_files(names)
     assert expected == candidates
+
+
+def test_read_valid(example_wheel):
+    """Test reading a valid wheel file"""
+    metadata = example_wheel.read().decode().splitlines()
+    assert "Name: twine" in metadata
+    assert "Version: 1.5.0" in metadata
+
+
+def test_read_non_existent_wheel_file_name():
+    """Test reading a wheel file which doesn't exist"""
+
+    file_name = "/foo/bar/baz.whl"
+    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+        wheel.Wheel(file_name)
+
+    assert "No such file: {}".format(file_name) == str(excinfo.value)
+
+
+def test_read_invalid_wheel_extension():
+    """Test reading a wheel file without a .whl extension"""
+
+    file_name = os.path.join(os.path.dirname(__file__), "fixtures/twine-1.5.0.tar.gz")
+    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+        wheel.Wheel(file_name)
+
+    assert "Not a known archive format: {}".format(file_name) == str(excinfo.value)
+
+
+def test_read_wheel_without_metadata(capsys, tmpdir):
+    """Test reading a wheel file with empty metadata"""
+
+    def create_empty_metadata_wheel(name, version):
+        def add_file(path, text):
+            contents = text.encode("utf-8")
+            z.writestr(path, contents)
+            records.append((path, text, str(len(text))))
+
+        dist_info = "{}-{}.dist-info".format(name, version)
+        record_path = "{}/RECORD".format(dist_info)
+        records = []
+        buf = BytesIO()
+        with ZipFile(buf, "w") as z:
+            add_file("{}/WHEEL".format(dist_info), "Wheel-Version: 1.0")
+            add_file(
+                "{}/METADATA".format(dist_info), dedent(""),
+            )
+            z.writestr(record_path, "\n".join(",".join(r) for r in records))
+        buf.seek(0)
+        return buf.read()
+
+    wheel_data = create_empty_metadata_wheel("badwheel", "1.0")
+    whl_file = tmpdir.mkdir("wheel").join("badwheel.whl")
+    whl_file.write(wheel_data, mode="wb")
+
+    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+        wheel.Wheel(whl_file)
+
+    assert "No METADATA in archive: {}".format(whl_file) == str(excinfo.value)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from zipfile import ZipFile
+import pathlib
+import zipfile
 
 import pytest
-from tests.conftest import TESTS_DIR
 
 from twine import exceptions
 from twine import wheel
+
+TESTS_DIR = pathlib.Path(__file__).parent
 
 
 @pytest.fixture(
@@ -84,7 +86,7 @@ def test_read_wheel_empty_metadata(tmpdir):
     """Test reading a wheel file with an empty METADATA file"""
 
     whl_file = tmpdir.mkdir("wheel").join("not-a-wheel.whl")
-    with ZipFile(whl_file, "w") as zip_file:
+    with zipfile.ZipFile(whl_file, "w") as zip_file:
         zip_file.writestr("METADATA", "")
 
     with pytest.raises(

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -64,10 +64,10 @@ def test_read_non_existent_wheel_file_name():
     """Test reading a wheel file which doesn't exist"""
 
     file_name = "/foo/bar/baz.whl"
-    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+    with pytest.raises(
+        exceptions.InvalidDistribution, match=f"No such file: {file_name}"
+    ):
         wheel.Wheel(file_name)
-
-    assert "No such file: {}".format(file_name) == str(excinfo.value)
 
 
 def test_read_invalid_wheel_extension():

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -17,6 +17,7 @@ from textwrap import dedent
 from zipfile import ZipFile
 
 import pytest
+from tests.conftest import TESTS_DIR
 
 from twine import exceptions
 from twine import wheel
@@ -29,7 +30,7 @@ from twine import wheel
     ]
 )
 def example_wheel(request):
-    file_name = os.path.join(os.path.dirname(__file__), request.param)
+    file_name = os.path.join(TESTS_DIR, request.param)
     return wheel.Wheel(file_name)
 
 
@@ -75,10 +76,10 @@ def test_read_invalid_wheel_extension():
     """Test reading a wheel file without a .whl extension"""
 
     file_name = os.path.join(os.path.dirname(__file__), "fixtures/twine-1.5.0.tar.gz")
-    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+    with pytest.raises(
+        exceptions.InvalidDistribution, match=f"Not a known archive format: {file_name}"
+    ):
         wheel.Wheel(file_name)
-
-    assert "Not a known archive format: {}".format(file_name) == str(excinfo.value)
 
 
 def test_read_wheel_without_metadata(capsys, tmpdir):
@@ -107,7 +108,7 @@ def test_read_wheel_without_metadata(capsys, tmpdir):
     whl_file = tmpdir.mkdir("wheel").join("badwheel.whl")
     whl_file.write(wheel_data, mode="wb")
 
-    with pytest.raises(exceptions.InvalidDistribution) as excinfo:
+    with pytest.raises(
+        exceptions.InvalidDistribution, match=f"No METADATA in archive: {whl_file}"
+    ):
         wheel.Wheel(whl_file)
-
-    assert "No METADATA in archive: {}".format(whl_file) == str(excinfo.value)


### PR DESCRIPTION
Towards #7 

Add more unit tests to `twine.wheel` to bring the coverage up to 100%

```
py run-test: commands[1] | coverage report -m
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
twine/__init__.py               14      1      2      1    88%   29->32, 32
twine/_installed.py             40      3     18      7    83%   19->56, 21->22, 22, 26->56, 45->56, 46->51, 48->52, 51, 52->45, 56
twine/auth.py                   55      0      4      1    98%   55->62
twine/cli.py                    25      0      4      0   100%
twine/commands/__init__.py      21      0     11      0   100%
twine/commands/check.py         72      0     24      1    99%   90->97
twine/commands/register.py      23      8      4      2    63%   28->29, 29, 38->43, 43, 47-62
twine/commands/upload.py        55      2     22      2    95%   77->78, 78, 79->80, 80
twine/exceptions.py             27      0      0      0   100%
twine/package.py               128      8     35      8    90%   83->88, 88, 101->102, 102-103, 106->107, 107, 163->164, 164, 167, 236->exit, 240->242, 242, 245->exit, 249->251, 251
twine/repository.py            120     15     38      6    85%   121-136, 183->201, 188->189, 189-190, 201, 208->209, 209, 214->217, 217->227, 229->230, 230-231, 251
twine/settings.py               68      0      4      0   100%
twine/utils.py                  98      0     40      1    99%   172->177
twine/wheel.py                  46      0     16      0   100%
twine/wininst.py                37     26     19      0    20%   14-16, 20-24, 27-56
------------------------------------------------------------------------
TOTAL                          829     63    241     29    89%
```