### PR TITLE
Add unit tests for twine.register

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,6 +15,10 @@
 
 import contextlib
 import os
+import pathlib
+
+TESTS_DIR = pathlib.Path(__file__).parent
+WHEEL_FIXTURE = os.path.join(TESTS_DIR, "fixtures/twine-1.5.0-py2.py3-none-any.whl")
 
 
 @contextlib.contextmanager

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import pathlib
 import zipfile
 
 import pytest
 
+import helpers
 from twine import exceptions
 from twine import wheel
-
-TESTS_DIR = pathlib.Path(__file__).parent
 
 
 @pytest.fixture(
@@ -30,7 +28,7 @@ TESTS_DIR = pathlib.Path(__file__).parent
     ]
 )
 def example_wheel(request):
-    file_name = os.path.join(TESTS_DIR, request.param)
+    file_name = os.path.join(helpers.TESTS_DIR, request.param)
     return wheel.Wheel(file_name)
 
 


### PR DESCRIPTION
Towards #7 

Add more unit tests to `twine.register` to bring the coverage up to 100%

```
py run-test: commands[1] | coverage report -m
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
twine/__init__.py               14      1      2      1    88%   29->32, 32
twine/_installed.py             40      3     18      7    83%   19->56, 21->22, 22, 26->56, 45->56, 46->51, 48->52, 51, 52->45, 56
twine/auth.py                   55      0      4      1    98%   55->62
twine/cli.py                    25      0      4      0   100%
twine/commands/__init__.py      21      0     11      0   100%
twine/commands/check.py         72      0     24      1    99%   90->97
twine/commands/register.py      23      0      4      0   100%
twine/commands/upload.py        55      2     22      2    95%   77->78, 78, 79->80, 80
twine/exceptions.py             27      0      0      0   100%
twine/package.py               128      8     35      8    90%   83->88, 88, 101->102, 102-103, 106->107, 107, 163->164, 164, 167, 236->exit, 240->242, 242, 245->exit, 249->251, 251
twine/repository.py            120     15     38      6    85%   121-136, 183->201, 188->189, 189-190, 201, 208->209, 209, 214->217, 217->227, 229->230, 230-231, 251
twine/settings.py               68      0      4      0   100%
twine/utils.py                  98      0     40      1    99%   172->177
twine/wheel.py                  46      0     16      0   100%
twine/wininst.py                37     26     19      0    20%   14-16, 20-24, 27-58
------------------------------------------------------------------------
TOTAL                          829     55    241     27    90%
```