### PR TITLE
Add type annotations to twine.commands.check

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,7 +17,7 @@ txt_report = mypy
 ; TODO: Adopt --strict settings, iterating towards something like:
 ; https://github.com/pypa/packaging/blob/master/setup.cfg
 ; Starting with modules that have annotations applied via MonkeyType
-[mypy-twine.auth,twine.cli,twine.exceptions,twine.package,twine.repository,twine.utils,twine.commands,twine.wheel,twine.wininst,twine.commands.register]
+[mypy-twine.auth,twine.cli,twine.exceptions,twine.package,twine.repository,twine.utils,twine.wheel,twine.wininst,twine.commands]
 ; Enabling this will fail on subclasses of untype imports, e.g. tqdm
 ; disallow_subclassing_any = True
 disallow_any_generics = True

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -48,7 +48,7 @@ def test_check_no_distributions(monkeypatch):
 
     monkeypatch.setattr(commands, "_find_dists", lambda a: [])
 
-    assert not check.check("dist/*", output_stream=stream)
+    assert not check.check(["dist/*"], output_stream=stream)
     assert stream.getvalue() == "No files to check.\n"
 
 
@@ -72,7 +72,7 @@ def test_check_passing_distribution(monkeypatch):
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 
-    assert not check.check("dist/*", output_stream=output_stream)
+    assert not check.check(["dist/*"], output_stream=output_stream)
     assert output_stream.getvalue() == "Checking dist/dist.tar.gz: PASSED\n"
     assert renderer.render.calls == [pretend.call("blah", stream=warning_stream)]
 
@@ -94,7 +94,7 @@ def test_check_no_description(monkeypatch, capsys):
 
     # used to crash with `AttributeError`
     output_stream = io.StringIO()
-    check.check("dist/*", output_stream=output_stream)
+    check.check(["dist/*"], output_stream=output_stream)
     assert output_stream.getvalue() == (
         "Checking dist/dist.tar.gz: PASSED, with warnings\n"
         "  warning: `long_description_content_type` missing. "
@@ -123,7 +123,7 @@ def test_check_failing_distribution(monkeypatch):
     )
     monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
 
-    assert check.check("dist/*", output_stream=output_stream)
+    assert check.check(["dist/*"], output_stream=output_stream)
     assert output_stream.getvalue() == (
         "Checking dist/dist.tar.gz: FAILED\n"
         "  `long_description` has syntax errors in markup and would not be "

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -80,8 +80,8 @@ def _check_file(
     package = package_file.PackageFile.from_filename(filename, comment=None)
 
     metadata = package.metadata_dictionary()
-    description = metadata["description"]
-    description_content_type = metadata["description_content_type"]
+    description = cast(str, metadata["description"])
+    description_content_type = cast(str, metadata["description_content_type"])
 
     if description_content_type is None:
         warnings.append(
@@ -89,7 +89,7 @@ def _check_file(
         )
         description_content_type = "text/x-rst"
 
-    content_type, params = cgi.parse_header(cast(str, description_content_type))
+    content_type, params = cgi.parse_header(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
     if description in {None, "UNKNOWN\n\n\n"}:

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -16,8 +16,14 @@ import cgi
 import io
 import re
 import sys
+from io import StringIO
+from typing import Any
+from typing import List
+from typing import Tuple
+from typing import Union
 
 import readme_renderer.rst
+from pretend import stub
 
 from twine import commands
 from twine import package as package_file
@@ -43,10 +49,10 @@ _REPORT_RE = re.compile(
 
 
 class _WarningStream:
-    def __init__(self):
+    def __init__(self) -> None:
         self.output = io.StringIO()
 
-    def write(self, text):
+    def write(self, text: str) -> None:
         matched = _REPORT_RE.search(text)
 
         if not matched:
@@ -61,11 +67,13 @@ class _WarningStream:
             )
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.output.getvalue()
 
 
-def _check_file(filename, render_warning_stream):
+def _check_file(
+    filename: str, render_warning_stream: Union[str, _WarningStream]
+) -> Union[Tuple[List[Any], bool], Tuple[List[str], bool]]:
     """Check given distribution."""
     warnings = []
     is_ok = True
@@ -98,7 +106,7 @@ def _check_file(filename, render_warning_stream):
 
 
 # TODO: Replace with textwrap.indent when Python 2 support is dropped
-def _indented(text, prefix):
+def _indented(text: str, prefix: str) -> str:
     """Adds 'prefix' to all non-empty lines on 'text'."""
 
     def prefixed_lines():
@@ -108,7 +116,7 @@ def _indented(text, prefix):
     return "".join(prefixed_lines())
 
 
-def check(dists, output_stream=sys.stdout):
+def check(dists: str, output_stream: StringIO = sys.stdout) -> bool:
     uploads = [i for i in commands._find_dists(dists) if not i.endswith(".asc")]
     if not uploads:  # Return early, if there are no files to check.
         output_stream.write("No files to check.\n")
@@ -144,7 +152,7 @@ def check(dists, output_stream=sys.stdout):
     return failure
 
 
-def main(args):
+def main(args: List[str]) -> stub:
     parser = argparse.ArgumentParser(prog="twine check")
     parser.add_argument(
         "dists",

--- a/twine/package.py
+++ b/twine/package.py
@@ -16,7 +16,6 @@ import hashlib
 import io
 import os
 import subprocess
-from typing import IO
 from typing import Dict
 from typing import Optional
 from typing import Sequence
@@ -46,7 +45,7 @@ DIST_EXTENSIONS = {
     ".zip": "sdist",
 }
 
-MetadataValue = Union[str, Sequence[str], Tuple[str, IO, str]]
+MetadataValue = Union[str, Sequence[str]]
 
 
 class PackageFile:

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -103,9 +103,7 @@ class Repository:
         self.session.close()
 
     @staticmethod
-    def _convert_data_to_list_of_tuples(
-        data: Dict[str, package_file.MetadataValue]
-    ) -> List[Tuple[str, package_file.MetadataValue]]:
+    def _convert_data_to_list_of_tuples(data: Dict[str, Any]) -> List[Tuple[str, Any]]:
         data_to_send = []
         for key, value in data.items():
             if key in KEYWORDS_TO_NOT_FLATTEN or not isinstance(value, (list, tuple)):


### PR DESCRIPTION
Towards #231 

I live-coded and talked my way through the first commit at a Boston Python Lightning Talk last night: https://youtu.be/BGSMwSkWphE?t=4694 (warning: lots of "umms" and face-touching).

Other changes:

- Pass the correct type to `check` in the tests
- Use `textwrap.indent` instead of home-rolled solution
- Simplify overly-specific typing for `PackageFile.metadata_dictionary()`