### PR TITLE
Move mypy reporting options to tox

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+show_traceback = True
 ; TODO: Make this more granular; docs recommend it as a "last resort"
 ; https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-type-hints-for-third-party-library
 ignore_missing_imports = True
@@ -6,13 +7,6 @@ ignore_missing_imports = True
 warn_redundant_casts = True
 warn_unused_configs = True
 warn_unused_ignores = True
-
-; Reporting
-show_traceback = True
-html_report = mypy
-linecount_report = mypy
-lineprecision_report = mypy
-txt_report = mypy
 
 ; TODO: Adopt --strict settings, iterating towards something like:
 ; https://github.com/pypa/packaging/blob/master/setup.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     lxml
 commands =
     # TODO: Consider checking the tests after the source is fully typed
-    mypy twine
+    mypy {posargs:--html-report mypy --txt-report mypy twine}
 
 [testenv:monkeytype]
 deps = 


### PR DESCRIPTION
To avoid reporting on single files, e.g. while editing.

Using only the most useful ones; others can be specified on the command line.