### PR TITLE
Use strict mypy settings globally

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,15 +4,11 @@ show_traceback = True
 ; https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-type-hints-for-third-party-library
 ignore_missing_imports = True
 
+; --strict settings
 warn_redundant_casts = True
 warn_unused_configs = True
 warn_unused_ignores = True
-
-; TODO: Adopt --strict settings, iterating towards something like:
-; https://github.com/pypa/packaging/blob/master/setup.cfg
-; Starting with modules that have annotations applied via MonkeyType
-[mypy-twine.auth,twine.cli,twine.exceptions,twine.package,twine.repository,twine.utils,twine.wheel,twine.wininst,twine.commands]
-; Enabling this will fail on subclasses of untype imports, e.g. tqdm
+; Enabling this will fail on subclasses of untyped imports, e.g. tqdm
 ; disallow_subclassing_any = True
 disallow_any_generics = True
 disallow_untyped_calls = True

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
+from typing import Any
 
 import requests
 
@@ -20,7 +21,7 @@ from twine import cli
 from twine import exceptions
 
 
-def main():
+def main() -> Any:
     try:
         return cli.dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.HTTPError) as exc:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-from typing import Any
+from typing import Union
 
 import requests
 
@@ -21,7 +21,7 @@ from twine import cli
 from twine import exceptions
 
 
-def main() -> Any:
+def main() -> Union[cli.CommandResult, str]:
     try:
         return cli.dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.HTTPError) as exc:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-from typing import Union
+from typing import Any
 
 import requests
 
@@ -21,7 +21,7 @@ from twine import cli
 from twine import exceptions
 
 
-def main() -> Union[bool, str]:
+def main() -> Any:
     try:
         return cli.dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.HTTPError) as exc:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -21,7 +21,7 @@ from twine import cli
 from twine import exceptions
 
 
-def main() -> Union[cli.CommandResult, str]:
+def main() -> Union[bool, str]:
     try:
         return cli.dispatch(sys.argv[1:])
     except (exceptions.TwineException, requests.HTTPError) as exc:

--- a/twine/_installed.py
+++ b/twine/_installed.py
@@ -9,12 +9,13 @@ import glob
 import os
 import sys
 import warnings
+from typing import Optional
 
 import pkginfo
 
 
 class Installed(pkginfo.Installed):
-    def read(self):
+    def read(self) -> Optional[str]:
         opj = os.path.join
         if self.package is not None:
             package = self.package.__package__
@@ -22,11 +23,11 @@ class Installed(pkginfo.Installed):
                 package = self.package.__name__
             egg_pattern = "%s*.egg-info" % package
             dist_pattern = "%s*.dist-info" % package
-            file = getattr(self.package, "__file__", None)
+            file: Optional[str] = getattr(self.package, "__file__", None)
             if file is not None:
                 candidates = []
 
-                def _add_candidate(where):
+                def _add_candidate(where: str) -> None:
                     candidates.extend(glob.glob(where))
 
                 for entry in sys.path:
@@ -56,3 +57,4 @@ class Installed(pkginfo.Installed):
         warnings.warn(
             "No PKG-INFO or METADATA found for package: %s" % self.package_name
         )
+        return None

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -13,7 +13,9 @@ from twine import utils
 
 
 class CredentialInput:
-    def __init__(self, username: str = None, password: str = None) -> None:
+    def __init__(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> None:
         self.username = username
         self.password = password
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
+from typing import cast
 
 import pkg_resources
 import pkginfo
@@ -26,6 +27,8 @@ import tqdm
 
 import twine
 from twine import _installed
+
+CommandResult = Optional[bool]
 
 
 def _registered_commands(
@@ -51,7 +54,7 @@ def dep_versions() -> str:
     )
 
 
-def dispatch(argv: List[str]) -> Any:
+def dispatch(argv: List[str]) -> CommandResult:
     registered_commands = _registered_commands()
     parser = argparse.ArgumentParser(prog="twine")
     parser.add_argument(
@@ -70,4 +73,4 @@ def dispatch(argv: List[str]) -> Any:
 
     main = registered_commands[args.command].load()
 
-    return main(args.args)
+    return cast(CommandResult, main(args.args))

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -14,9 +14,7 @@
 import argparse
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
-from typing import cast
 
 import pkg_resources
 import pkginfo
@@ -27,8 +25,6 @@ import tqdm
 
 import twine
 from twine import _installed
-
-CommandResult = Optional[bool]
 
 
 def _registered_commands(
@@ -54,7 +50,7 @@ def dep_versions() -> str:
     )
 
 
-def dispatch(argv: List[str]) -> CommandResult:
+def dispatch(argv: List[str]) -> bool:
     registered_commands = _registered_commands()
     parser = argparse.ArgumentParser(prog="twine")
     parser.add_argument(
@@ -73,4 +69,4 @@ def dispatch(argv: List[str]) -> CommandResult:
 
     main = registered_commands[args.command].load()
 
-    return cast(CommandResult, main(args.args))
+    return bool(main(args.args))

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -50,7 +51,7 @@ def dep_versions() -> str:
     )
 
 
-def dispatch(argv: List[str]) -> bool:
+def dispatch(argv: List[str]) -> Any:
     registered_commands = _registered_commands()
     parser = argparse.ArgumentParser(prog="twine")
     parser.add_argument(
@@ -69,6 +70,4 @@ def dispatch(argv: List[str]) -> bool:
 
     main = registered_commands[args.command].load()
 
-    # Normalizing return type for simplicity
-    # register() and upload() returns None, check() returns bool
-    return bool(main(args.args))
+    return main(args.args)

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -69,4 +69,6 @@ def dispatch(argv: List[str]) -> bool:
 
     main = registered_commands[args.command].load()
 
+    # Normalizing return type for simplicity
+    # register() and upload() returns None, check() returns bool
     return bool(main(args.args))

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -19,6 +19,7 @@ import sys
 import textwrap
 from typing import IO
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import cast
 
@@ -80,8 +81,8 @@ def _check_file(
     package = package_file.PackageFile.from_filename(filename, comment=None)
 
     metadata = package.metadata_dictionary()
-    description = cast(str, metadata["description"])
-    description_content_type = cast(str, metadata["description_content_type"])
+    description = cast(Optional[str], metadata["description"])
+    description_content_type = cast(Optional[str], metadata["description_content_type"])
 
     if description_content_type is None:
         warnings.append(

--- a/twine/package.py
+++ b/twine/package.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
 import hashlib
 import io
 import os
 import subprocess
 from typing import Dict
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -200,7 +200,10 @@ class PackageFile:
             )
 
 
-Hexdigest = collections.namedtuple("Hexdigest", ["md5", "sha2", "blake2"])
+class Hexdigest(NamedTuple):
+    md5: Optional[str]
+    sha2: Optional[str]
+    blake2: Optional[str]
 
 
 class HashManager:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+from typing import Any
 from typing import Optional
 from typing import cast
 
@@ -58,7 +59,7 @@ class Settings:
         repository_url: Optional[str] = None,
         verbose: bool = False,
         disable_progress_bar: bool = False,
-        **ignored_kwargs
+        **ignored_kwargs: Any,
     ) -> None:
         """Initialize our settings instance.
 


### PR DESCRIPTION
I think this completes the bulk of the work in https://github.com/pypa/twine/issues/231#issuecomment-619359423; I'll follow-up with some more housekeeping PR's..

Changes:

- Remove module whitelist in mypy.ini
- Add missing annotations
- Normalize return type of `cli.dispatch` to `bool`

If folks are curious, you can the coverage report at https://twine-mypy.now.sh/. Here's a "before & after" of the current effort:

![twine_mypy_coverage](https://user-images.githubusercontent.com/1326704/80474201-32557000-8915-11ea-9e73-083c266f6024.png)

Thanks @deveshks for helping us get here!