### PR TITLE
Tidy mypy and tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,23 @@ matrix:
   fast_finish: true
 
   include:
-    - python: 3.6
-    - python: 3.7
     - python: &latest_py3 3.8
+    - python: 3.7
+    - python: &oldest_py3 3.6
+
+    - python: 3.7
+      name: Linting code style
+      env:
+        TOXENV: code-style
+
+    - python: *latest_py3
+      name: Checking type annotations (latest Python)
+      env:
+        TOXENV: typing
+    - python: *oldest_py3
+      name: Checking type annotations (oldest Python)
+      env:
+        TOXENV: typing
 
     - python: 3.7
       name: Making sure that docs build is healthy

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
     - python: *latest_py3
       name: Checking type annotations (latest Python)
       env:
-        TOXENV: typing
+        TOXENV: types
     - python: *oldest_py3
       name: Checking type annotations (oldest Python)
       env:
-        TOXENV: typing
+        TOXENV: types
 
     - python: 3.7
       name: Making sure that docs build is healthy

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 3.7
       name: Linting code style
       env:
-        TOXENV: code-style
+        TOXENV: lint
 
     - python: *latest_py3
       name: Checking type annotations (latest Python)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ matrix:
     - python: &latest_py3 3.8
 
     - python: 3.7
-      name: Linting code style
-      env:
-        TOXENV: lint
-
-    - python: 3.7
       name: Making sure that docs build is healthy
       env:
         TOXENV: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       name: Linting code style
       env:
         TOXENV: code-style
-    - python: 3.7
+    - python: 3.6
       name: Linting type annotations
       env:
         TOXENV: typing

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,28 @@ matrix:
   fast_finish: true
 
   include:
+    - python: &latest_py3 3.8
+    - python: 3.7
+    - python: &oldest_py3 3.6
+
     - python: 3.7
       name: Linting code style
       env:
         TOXENV: code-style
-    - python: 3.6
-      name: Linting type annotations
+
+    - python: *latest_py3
+      name: Checking type annotations (latest Python)
       env:
         TOXENV: typing
+    - python: *oldest_py3
+      name: Checking type annotations (oldest Python)
+      env:
+        TOXENV: typing
+
     - python: 3.7
       name: Making sure that docs build is healthy
       env:
         TOXENV: docs
-    - python: &latest_py3 3.8
-    - python: 3.7
-    - python: 3.6
 
     - stage: deploy
       if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,14 @@ matrix:
   fast_finish: true
 
   include:
-    - python: &latest_py3 3.8
+    - python: 3.6
     - python: 3.7
-    - python: &oldest_py3 3.6
+    - python: &latest_py3 3.8
 
     - python: 3.7
       name: Linting code style
       env:
-        TOXENV: code-style
-
-    - python: *latest_py3
-      name: Checking type annotations (latest Python)
-      env:
-        TOXENV: typing
-    - python: *oldest_py3
-      name: Checking type annotations (oldest Python)
-      env:
-        TOXENV: typing
+        TOXENV: lint
 
     - python: 3.7
       name: Making sure that docs build is healthy

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -61,8 +61,8 @@ Code style
 ^^^^^^^^^^
 
 Run ``tox -e format`` to automatically reformat your changes. Run
-``tox -e lint`` to see any remaining code smells or type errors that
-need to be fixed manually.
+``tox -e lint,types`` to see any remaining code smells or type errors
+that need to be fixed manually.
 
 Additionally, the Twine maintainers prefer that ``import`` statements
 be used for packages and modules only, rather than individual classes

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -61,8 +61,8 @@ Code style
 ^^^^^^^^^^
 
 Run ``tox -e format`` to automatically reformat your changes. Run
-``tox -e lint`` to see any remaining code smells that need to be
-fixed manually.
+``tox -e lint`` to see any remaining code smells or type errors that
+need to be fixed manually.
 
 Additionally, the Twine maintainers prefer that ``import`` statements
 be used for packages and modules only, rather than individual classes

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -61,8 +61,8 @@ Code style
 ^^^^^^^^^^
 
 Run ``tox -e format`` to automatically reformat your changes. Run
-``tox -e lint`` to see any remaining code smells or type errors that
-need to be fixed manually.
+``tox -e lint`` to see any remaining code smells that need to be
+fixed manually.
 
 Additionally, the Twine maintainers prefer that ``import`` statements
 be used for packages and modules only, rather than individual classes

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,22 +19,29 @@ no_implicit_reexport = True
 strict_equality = True
 
 [mypy-keyring]
+; https://github.com/jaraco/keyring/issues/437
 ignore_missing_imports = True
 
 [mypy-pkginfo]
+; https://bugs.launchpad.net/pkginfo/+bug/1876591
 ignore_missing_imports = True
 
 [mypy-requests_toolbelt,requests_toolbelt.*]
+; https://github.com/requests/toolbelt/issues/279
 ignore_missing_imports = True
 
 [mypy-readme_renderer,readme_renderer.*]
+; https://github.com/pypa/readme_renderer/issues/166
 ignore_missing_imports = True
 
 [mypy-setuptools]
+; https://github.com/python/typeshed/issues/2171
 ignore_missing_imports = True
 
 [mypy-tqdm]
+; https://github.com/tqdm/tqdm/issues/260
 ignore_missing_imports = True
 
 [mypy-urllib3]
+; https://github.com/urllib3/urllib3/issues/867
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,10 @@ warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
 
+[mypy-importlib_metadata]
+; https://gitlab.com/python-devs/importlib_metadata/-/issues/10
+ignore_missing_imports = True
+
 [mypy-keyring]
 ; https://github.com/jaraco/keyring/issues/437
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,5 @@
 [mypy]
 show_traceback = True
-; TODO: Make this more granular; docs recommend it as a "last resort"
-; https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-type-hints-for-third-party-library
-ignore_missing_imports = True
 
 ; --strict settings
 warn_redundant_casts = True
@@ -20,3 +17,24 @@ no_implicit_optional = True
 warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
+
+[mypy-keyring]
+ignore_missing_imports = True
+
+[mypy-pkginfo]
+ignore_missing_imports = True
+
+[mypy-requests_toolbelt,requests_toolbelt.*]
+ignore_missing_imports = True
+
+[mypy-readme_renderer,readme_renderer.*]
+ignore_missing_imports = True
+
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-tqdm]
+ignore_missing_imports = True
+
+[mypy-urllib3]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -51,14 +51,6 @@ commands =
     # TODO: Consider checking the tests after the source is fully typed
     mypy {posargs:--html-report mypy --txt-report mypy twine}
 
-[testenv:monkeytype]
-deps = 
-    {[testenv]deps}
-    {[testenv:typing]deps}
-    monkeytype
-commands = 
-    monkeytype {posargs:run -m pytest}
-
 [testenv:lint]
 deps =
     {[testenv:code-style]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
 commands =
     coverage run --source twine -m pytest tests
     coverage report -m
+    coverage html
     {[testenv:typing]commands}
     {[testenv:lint]commands}
 
@@ -26,6 +27,7 @@ deps =
     lxml
 commands =
     mypy --html-report mypy --txt-report mypy twine
+    python -c 'with open("mypy/index.txt") as f: print(f.read())'
 
 [testenv:format]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = lint,py{36,37,38},docs
+envlist = py{36,37,38},docs
 
 [testenv]
 deps =
@@ -12,10 +12,12 @@ deps =
     pytest-services
     munch
     {[testenv:typing]deps}
+    {[testenv:lint]deps}
 commands =
     coverage run --source twine -m pytest tests
     coverage report -m
     {[testenv:typing]commands}
+    {[testenv:lint]commands}
 
 [testenv:typing]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,10 @@
 [tox]
 minversion = 2.4
-envlist = py{36,37,38},docs
+envlist = lint,docs,py38,py37,py36
 
 [testenv]
 deps =
     coverage
-    {[testenv:test]deps}
-    {[testenv:typing]deps}
-    {[testenv:lint]deps}
-commands =
-    coverage run --source twine -m pytest tests
-    coverage report -m
-    coverage html
-    {[testenv:typing]commands}
-    {[testenv:lint]commands}
-
-[testenv:test]
-deps =
     pretend
     pytest
     jaraco.envs
@@ -24,35 +12,8 @@ deps =
     pytest-services
     munch
 commands =
-    pytest {posargs:tests}
-
-[testenv:typing]
-skip_install = True
-deps =
-    mypy
-    lxml
-commands =
-    mypy --html-report mypy --txt-report mypy twine
-    python -c 'with open("mypy/index.txt") as f: print(f.read())'
-
-[testenv:format]
-skip_install = True
-deps =
-    isort
-    black
-commands =
-    isort --recursive twine/ tests/
-    black twine/ tests/
-
-[testenv:lint]
-skip_install = True
-deps =
-    {[testenv:format]deps}
-    flake8
-commands =
-    isort --check-only --diff --recursive twine/ tests/
-    black --check --diff twine/ tests/
-    flake8 twine/ tests/
+    coverage run --source twine -m pytest {posargs:tests}
+    coverage report -m
 
 [testenv:docs]
 deps =
@@ -64,6 +25,43 @@ commands =
     sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
     python setup.py sdist
     twine check dist/*
+
+[testenv:format]
+skip_install = True
+deps =
+    isort
+    black
+commands =
+    isort --recursive twine/ tests/
+    black twine/ tests/
+
+[testenv:code-style]
+skip_install = True
+deps =
+    {[testenv:format]deps}
+    flake8
+commands =
+    isort --check-only --diff --recursive twine/ tests/
+    black --check --diff twine/ tests/
+    flake8 twine/ tests/
+
+[testenv:typing]
+skip_install = True
+deps =
+    mypy
+    lxml
+commands =
+    # TODO: Consider checking the tests after the source is fully typed
+    mypy {posargs:--html-report mypy --txt-report mypy twine}
+
+[testenv:lint]
+skip_install = True
+deps =
+    {[testenv:code-style]deps}
+    {[testenv:typing]deps}
+commands =
+    {[testenv:code-style]commands}
+    {[testenv:typing]commands}
 
 [testenv:release]
 # disabled for twine to cause it to upload itself

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ commands =
     flake8 twine/ tests/
 
 [testenv:typing]
+basepython = python3.6
 skip_install = True
 deps =
     mypy

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,7 @@ envlist = py{36,37,38},docs
 [testenv]
 deps =
     coverage
-    pretend
-    pytest
-    jaraco.envs
-    portend
-    pytest-services
-    munch
+    {[testenv:test]deps}
     {[testenv:typing]deps}
     {[testenv:lint]deps}
 commands =
@@ -19,6 +14,17 @@ commands =
     coverage html
     {[testenv:typing]commands}
     {[testenv:lint]commands}
+
+[testenv:test]
+deps =
+    pretend
+    pytest
+    jaraco.envs
+    portend
+    pytest-services
+    munch
+commands =
+    pytest {posargs:tests}
 
 [testenv:typing]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ commands =
     flake8 twine/ tests/
 
 [testenv:typing]
-basepython = python3.6
 skip_install = True
 deps =
     mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = lint,docs,py38,py37,py36
+envlist = lint,py{36,37,38},docs
 
 [testenv]
 deps =
@@ -11,9 +11,38 @@ deps =
     portend
     pytest-services
     munch
+    {[testenv:typing]deps}
 commands =
-    coverage run --source twine -m pytest {posargs:tests}
+    coverage run --source twine -m pytest tests
     coverage report -m
+    {[testenv:typing]commands}
+
+[testenv:typing]
+skip_install = True
+deps =
+    mypy
+    lxml
+commands =
+    mypy --html-report mypy --txt-report mypy twine
+
+[testenv:format]
+skip_install = True
+deps =
+    isort
+    black
+commands =
+    isort --recursive twine/ tests/
+    black twine/ tests/
+
+[testenv:lint]
+skip_install = True
+deps =
+    {[testenv:format]deps}
+    flake8
+commands =
+    isort --check-only --diff --recursive twine/ tests/
+    black --check --diff twine/ tests/
+    flake8 twine/ tests/
 
 [testenv:docs]
 deps =
@@ -25,43 +54,6 @@ commands =
     sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
     python setup.py sdist
     twine check dist/*
-
-[testenv:format]
-skip_install = True
-deps =
-    isort
-    black
-commands =
-    isort --recursive twine/ tests/
-    black twine/ tests/
-
-[testenv:code-style]
-skip_install = True
-deps =
-    {[testenv:format]deps}
-    flake8
-commands =
-    isort --check-only --diff --recursive twine/ tests/
-    black --check --diff twine/ tests/
-    flake8 twine/ tests/
-
-[testenv:typing]
-skip_install = True
-deps =
-    mypy
-    lxml
-commands =
-    # TODO: Consider checking the tests after the source is fully typed
-    mypy {posargs:--html-report mypy --txt-report mypy twine}
-
-[testenv:lint]
-skip_install = True
-deps =
-    {[testenv:code-style]deps}
-    {[testenv:typing]deps}
-commands =
-    {[testenv:code-style]commands}
-    {[testenv:typing]commands}
 
 [testenv:release]
 # disabled for twine to cause it to upload itself

--- a/tox.ini
+++ b/tox.ini
@@ -45,23 +45,22 @@ commands =
     black --check --diff twine/ tests/
     flake8 twine/ tests/
 
-[testenv:typing]
+[testenv:types]
 skip_install = True
 deps =
     mypy
     lxml
 commands =
-    # TODO: Consider checking the tests after the source is fully typed
     mypy {posargs:--html-report mypy --txt-report mypy twine}
 
 [testenv:lint]
 skip_install = True
 deps =
     {[testenv:code-style]deps}
-    {[testenv:typing]deps}
+    {[testenv:types]deps}
 commands =
     {[testenv:code-style]commands}
-    {[testenv:typing]commands}
+    {[testenv:types]commands}
 
 [testenv:release]
 # disabled for twine to cause it to upload itself

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
 commands =
     coverage run --source twine -m pytest {posargs:tests}
     coverage report -m
+    coverage html
 
 [testenv:docs]
 deps =
@@ -51,7 +52,8 @@ deps =
     mypy
     lxml
 commands =
-    mypy {posargs:--html-report mypy --txt-report mypy twine}
+    mypy --html-report mypy --txt-report mypy {posargs:twine}
+    python -c 'with open("mypy/index.txt") as f: print(f.read())'
 
 [testenv:release]
 # disabled for twine to cause it to upload itself

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
     twine check dist/*
 
 [testenv:format]
+skip_install = True
 deps =
     isort
     black
@@ -35,6 +36,7 @@ commands =
     black twine/ tests/
 
 [testenv:code-style]
+skip_install = True
 deps =
     {[testenv:format]deps}
     flake8
@@ -44,6 +46,7 @@ commands =
     flake8 twine/ tests/
 
 [testenv:typing]
+skip_install = True
 deps =
     mypy
     lxml
@@ -52,6 +55,7 @@ commands =
     mypy {posargs:--html-report mypy --txt-report mypy twine}
 
 [testenv:lint]
+skip_install = True
 deps =
     {[testenv:code-style]deps}
     {[testenv:typing]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = lint,docs,py38,py37,py36
+envlist = lint,types,py{36,37,38},docs
 
 [testenv]
 deps =
@@ -35,7 +35,7 @@ commands =
     isort --recursive twine/ tests/
     black twine/ tests/
 
-[testenv:code-style]
+[testenv:lint]
 skip_install = True
 deps =
     {[testenv:format]deps}
@@ -52,15 +52,6 @@ deps =
     lxml
 commands =
     mypy {posargs:--html-report mypy --txt-report mypy twine}
-
-[testenv:lint]
-skip_install = True
-deps =
-    {[testenv:code-style]deps}
-    {[testenv:types]deps}
-commands =
-    {[testenv:code-style]commands}
-    {[testenv:types]commands}
 
 [testenv:release]
 # disabled for twine to cause it to upload itself


### PR DESCRIPTION
Towards https://github.com/pypa/twine/issues/231

- Use explicit `ignore_missing_imports`. I think this could us keep an eye on projects that might add annotations in the future. It will also cause mypy to fail if somebody adds a library that's missing them, which seems like an opportunity to make a thoughtful choice about how to proceed.

- Remove monketype from tox.ini, since it's no longer needed

- Add `skip_install = True` to formatting and linting tox environments, to speed them up

- Reworked tox and Travis config: https://github.com/pypa/twine/pull/614#issuecomment-623387923