### PR TITLE
Add stubs for some missing imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 show_traceback = True
+mypy_path = stubs
 
 ; --strict settings
 warn_redundant_casts = True
@@ -24,10 +25,6 @@ ignore_missing_imports = True
 
 [mypy-keyring]
 ; https://github.com/jaraco/keyring/issues/437
-ignore_missing_imports = True
-
-[mypy-pkginfo]
-; https://bugs.launchpad.net/pkginfo/+bug/1876591
 ignore_missing_imports = True
 
 [mypy-requests_toolbelt,requests_toolbelt.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,10 +19,6 @@ warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
 
-[mypy-importlib_metadata]
-; https://gitlab.com/python-devs/importlib_metadata/-/issues/10
-ignore_missing_imports = True
-
 [mypy-keyring]
 ; https://github.com/jaraco/keyring/issues/437
 ignore_missing_imports = True

--- a/stubs/.flake8
+++ b/stubs/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+filenames = *.pyi
+# Matching black's default
+max-line-length = 88
+extend_ignore =
+    E301
+    E302
+    E305
+    F401

--- a/stubs/importlib_metadata.pyi
+++ b/stubs/importlib_metadata.pyi
@@ -1,0 +1,3 @@
+from email.message import Message
+
+def metadata(distribution_name: str) -> Message: ...

--- a/stubs/pkginfo/__init__.pyi
+++ b/stubs/pkginfo/__init__.pyi
@@ -1,4 +1,4 @@
-from .bdist import BDist as BDist  # type: ignore
+from .bdist import BDist as BDist
 from .distribution import Distribution as Distribution
 from .installed import Installed as Installed
 from .sdist import SDist as SDist  # type: ignore

--- a/stubs/pkginfo/__init__.pyi
+++ b/stubs/pkginfo/__init__.pyi
@@ -1,4 +1,4 @@
 from .bdist import BDist as BDist  # type: ignore
 from .distribution import Distribution as Distribution
-from .installed import Installed as Installed  # type: ignore
+from .installed import Installed as Installed
 from .sdist import SDist as SDist  # type: ignore

--- a/stubs/pkginfo/__init__.pyi
+++ b/stubs/pkginfo/__init__.pyi
@@ -1,4 +1,4 @@
 from .bdist import BDist as BDist
 from .distribution import Distribution as Distribution
 from .installed import Installed as Installed
-from .sdist import SDist as SDist  # type: ignore
+from .sdist import SDist as SDist

--- a/stubs/pkginfo/__init__.pyi
+++ b/stubs/pkginfo/__init__.pyi
@@ -1,0 +1,4 @@
+from .bdist import BDist as BDist  # type: ignore
+from .distribution import Distribution as Distribution
+from .installed import Installed as Installed  # type: ignore
+from .sdist import SDist as SDist  # type: ignore

--- a/stubs/pkginfo/bdist.pyi
+++ b/stubs/pkginfo/bdist.pyi
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from .distribution import Distribution
+
+class BDist(Distribution):
+    filename: str
+    metadata_version: Optional[str]
+    def __init__(
+        self, filename: str, metadata_version: Optional[str] = ...
+    ) -> None: ...
+    def read(self) -> bytes: ...

--- a/stubs/pkginfo/distribution.pyi
+++ b/stubs/pkginfo/distribution.pyi
@@ -1,0 +1,56 @@
+from email import message
+from typing import IO
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+
+def must_decode(value: Union[str, bytes]) -> str: ...
+def parse(fp: IO[str]) -> message.Message: ...
+def get(msg: message.Message, header: str) -> str: ...
+def get_all(msg: message.Message, header: str) -> List[str]: ...
+
+HeaderAttrs = Tuple[Tuple[str, str, bool], ...]
+HEADER_ATTRS_1_0: HeaderAttrs
+HEADER_ATTRS_1_1: HeaderAttrs
+HEADER_ATTRS_1_2: HeaderAttrs
+HEADER_ATTRS_2_0: HeaderAttrs
+HEADER_ATTRS_2_1: HeaderAttrs
+HEADER_ATTRS: Dict[str, HeaderAttrs]
+
+class Distribution:
+    metadata_version: Optional[str]
+    # version 1.0
+    name: Optional[str]
+    version: Optional[str]
+    platforms: Sequence[str]
+    supported_platforms: Sequence[str]
+    summary: Optional[str]
+    description: Optional[str]
+    keywords: Optional[str]
+    home_page: Optional[str]
+    author: Optional[str]
+    author_email: Optional[str]
+    license: Optional[str]
+    # version 1.1
+    classifiers: Sequence[str]
+    download_url: Optional[str]
+    requires: Sequence[str]
+    provides: Sequence[str]
+    obsoletes: Sequence[str]
+    # version 1.2
+    maintainer: Optional[str]
+    maintainer_email: Optional[str]
+    requires_python: Optional[str]
+    requires_external: Sequence[str]
+    requires_dist: Sequence[str]
+    provides_dist: Sequence[str]
+    obsoletes_dist: Sequence[str]
+    project_urls: Sequence[str]
+    # version 2.1
+    provides_extras: Sequence[str]
+    description_content_type: Optional[str]
+    def extractMetadata(self) -> None: ...
+    def parse(self, data: Union[str, bytes]) -> None: ...

--- a/stubs/pkginfo/distribution.pyi
+++ b/stubs/pkginfo/distribution.pyi
@@ -21,26 +21,29 @@ HEADER_ATTRS_2_1: HeaderAttrs
 HEADER_ATTRS: Dict[str, HeaderAttrs]
 
 class Distribution:
+    # Required in all versions, but treated as optional by Distribution subclasses
     metadata_version: Optional[str]
-    # version 1.0
-    name: Optional[str]
-    version: Optional[str]
+    # version 1.0, PEP 241
+    # Some attributes are non-optional because they're required in all versions,
+    # and make downstream type annotations cleaner.
+    name: str
+    version: str
     platforms: Sequence[str]
     supported_platforms: Sequence[str]
-    summary: Optional[str]
+    summary: str
     description: Optional[str]
     keywords: Optional[str]
     home_page: Optional[str]
     author: Optional[str]
     author_email: Optional[str]
     license: Optional[str]
-    # version 1.1
+    # version 1.1, PEP 314
     classifiers: Sequence[str]
     download_url: Optional[str]
     requires: Sequence[str]
     provides: Sequence[str]
     obsoletes: Sequence[str]
-    # version 1.2
+    # version 1.2, PEP 345
     maintainer: Optional[str]
     maintainer_email: Optional[str]
     requires_python: Optional[str]
@@ -49,7 +52,7 @@ class Distribution:
     provides_dist: Sequence[str]
     obsoletes_dist: Sequence[str]
     project_urls: Sequence[str]
-    # version 2.1
+    # version 2.1, PEP 566
     provides_extras: Sequence[str]
     description_content_type: Optional[str]
     def extractMetadata(self) -> None: ...

--- a/stubs/pkginfo/distribution.pyi
+++ b/stubs/pkginfo/distribution.pyi
@@ -21,29 +21,26 @@ HEADER_ATTRS_2_1: HeaderAttrs
 HEADER_ATTRS: Dict[str, HeaderAttrs]
 
 class Distribution:
-    # Required in all versions, but treated as optional by Distribution subclasses
     metadata_version: Optional[str]
-    # version 1.0, PEP 241
-    # Some attributes are non-optional because they're required in all versions,
-    # and make downstream type annotations cleaner.
-    name: str
-    version: str
+    # version 1.0
+    name: Optional[str]
+    version: Optional[str]
     platforms: Sequence[str]
     supported_platforms: Sequence[str]
-    summary: str
+    summary: Optional[str]
     description: Optional[str]
     keywords: Optional[str]
     home_page: Optional[str]
     author: Optional[str]
     author_email: Optional[str]
     license: Optional[str]
-    # version 1.1, PEP 314
+    # version 1.1
     classifiers: Sequence[str]
     download_url: Optional[str]
     requires: Sequence[str]
     provides: Sequence[str]
     obsoletes: Sequence[str]
-    # version 1.2, PEP 345
+    # version 1.2
     maintainer: Optional[str]
     maintainer_email: Optional[str]
     requires_python: Optional[str]
@@ -52,7 +49,7 @@ class Distribution:
     provides_dist: Sequence[str]
     obsoletes_dist: Sequence[str]
     project_urls: Sequence[str]
-    # version 2.1, PEP 566
+    # version 2.1
     provides_extras: Sequence[str]
     description_content_type: Optional[str]
     def extractMetadata(self) -> None: ...

--- a/stubs/pkginfo/installed.pyi
+++ b/stubs/pkginfo/installed.pyi
@@ -1,0 +1,15 @@
+from types import ModuleType
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from .distribution import Distribution
+
+class Installed(Distribution):
+    package_name: str
+    package: ModuleType
+    metadata_version: Optional[str]
+    def __init__(
+        self, package: ModuleType, metadata_version: Optional[str] = ...
+    ) -> None: ...
+    def read(self) -> Optional[str]: ...

--- a/stubs/pkginfo/sdist.pyi
+++ b/stubs/pkginfo/sdist.pyi
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from .distribution import Distribution
+
+class SDist(Distribution):
+    filename: str
+    metadata_version: Optional[str]
+    def __init__(
+        self, filename: str, metadata_version: Optional[str] = ...
+    ) -> None: ...
+    def read(self) -> bytes: ...

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,8 @@ deps =
     isort
     black
 commands =
-    isort --recursive twine/ tests/
-    black twine/ tests/
+    isort --recursive twine/ tests/ stubs/
+    black twine/ tests/ stubs/
 
 [testenv:lint]
 skip_install = True
@@ -42,9 +42,9 @@ deps =
     {[testenv:format]deps}
     flake8
 commands =
-    isort --check-only --diff --recursive twine/ tests/
-    black --check --diff twine/ tests/
-    flake8 twine/ tests/
+    isort --check-only --diff --recursive twine/ tests/ stubs/
+    black --check --diff twine/ tests/ stubs/
+    flake8 twine/ tests/ stubs/
 
 [testenv:types]
 skip_install = True

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import cast
 
 import pkg_resources
 import pkginfo
@@ -37,7 +38,7 @@ def _registered_commands(
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
     return [
-        ("pkginfo", _installed.Installed(pkginfo).version),
+        ("pkginfo", cast(str, _installed.Installed(pkginfo).version)),
         ("requests", requests.__version__),
         ("setuptools", setuptools.__version__),
         ("requests-toolbelt", requests_toolbelt.__version__),

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -16,7 +16,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
-from typing import cast
 
 import pkg_resources
 import pkginfo
@@ -38,7 +37,7 @@ def _registered_commands(
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
     return [
-        ("pkginfo", cast(str, _installed.Installed(pkginfo).version)),
+        ("pkginfo", _installed.Installed(pkginfo).version),
         ("requests", requests.__version__),
         ("setuptools", setuptools.__version__),
         ("requests-toolbelt", requests_toolbelt.__version__),

--- a/twine/package.py
+++ b/twine/package.py
@@ -65,7 +65,7 @@ class PackageFile:
         self.metadata = metadata
         self.python_version = python_version
         self.filetype = filetype
-        self.safe_name = pkg_resources.safe_name(cast(str, metadata.name))
+        self.safe_name = pkg_resources.safe_name(metadata.name)
         self.signed_filename = self.filename + ".asc"
         self.signed_basefilename = self.basefilename + ".asc"
         self.gpg_signature: GpgSignature = None

--- a/twine/package.py
+++ b/twine/package.py
@@ -21,6 +21,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import Union
+from typing import cast
 
 import pkg_resources
 import pkginfo
@@ -45,7 +46,8 @@ DIST_EXTENSIONS = {
     ".zip": "sdist",
 }
 
-MetadataValue = Union[str, Sequence[str]]
+GpgSignature = Optional[Tuple[str, bytes]]
+MetadataValue = Union[Optional[str], Sequence[str], GpgSignature]
 
 
 class PackageFile:
@@ -63,10 +65,10 @@ class PackageFile:
         self.metadata = metadata
         self.python_version = python_version
         self.filetype = filetype
-        self.safe_name = pkg_resources.safe_name(metadata.name)
+        self.safe_name = pkg_resources.safe_name(cast(str, metadata.name))
         self.signed_filename = self.filename + ".asc"
         self.signed_basefilename = self.basefilename + ".asc"
-        self.gpg_signature: Optional[Tuple[str, bytes]] = None
+        self.gpg_signature: GpgSignature = None
 
         hasher = HashManager(filename)
         hasher.hash()
@@ -111,7 +113,7 @@ class PackageFile:
 
     def metadata_dictionary(self) -> Dict[str, MetadataValue]:
         meta = self.metadata
-        data = {
+        data: Dict[str, MetadataValue] = {
             # identify release
             "name": self.safe_name,
             "version": meta.version,

--- a/twine/package.py
+++ b/twine/package.py
@@ -103,9 +103,9 @@ class PackageFile:
             pkgd = pkg_resources.Distribution.from_filename(filename)
             py_version = pkgd.py_version
         elif dtype == "bdist_wheel":
-            py_version = meta.py_version
+            py_version = cast(wheel.Wheel, meta).py_version
         elif dtype == "bdist_wininst":
-            py_version = meta.py_version
+            py_version = cast(wininst.WinInst, meta).py_version
         else:
             py_version = None
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -65,7 +65,7 @@ class PackageFile:
         self.metadata = metadata
         self.python_version = python_version
         self.filetype = filetype
-        self.safe_name = pkg_resources.safe_name(metadata.name)
+        self.safe_name = pkg_resources.safe_name(cast(str, metadata.name))
         self.signed_filename = self.filename + ".asc"
         self.signed_basefilename = self.basefilename + ".asc"
         self.gpg_signature: GpgSignature = None

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -230,7 +230,7 @@ class Repository:
                 releases = {}
             self._releases_json_data[safe_name] = releases
 
-        packages = releases.get(package.metadata.version, [])
+        packages = releases.get(cast(str, package.metadata.version), [])
 
         for uploaded_package in packages:
             if uploaded_package["filename"] == package.basefilename:

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -230,7 +230,7 @@ class Repository:
                 releases = {}
             self._releases_json_data[safe_name] = releases
 
-        packages = releases.get(cast(str, package.metadata.version), [])
+        packages = releases.get(package.metadata.version, [])
 
         for uploaded_package in packages:
             if uploaded_package["filename"] == package.basefilename:

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -17,6 +17,7 @@ import re
 import zipfile
 from typing import List
 from typing import Optional
+from typing import Union
 
 from pkginfo import distribution
 
@@ -84,7 +85,7 @@ class Wheel(distribution.Distribution):
 
         raise exceptions.InvalidDistribution("No METADATA in archive: %s" % fqn)
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: Union[str, bytes]) -> None:
         super().parse(data)
 
         fp = io.StringIO(distribution.must_decode(data))


### PR DESCRIPTION
Related to #231 

Okay, this is *definitely* yak-shaving, but I was curious how hard it might be to add our own stubs, and what value they might bring. If nothing else, I found it to be an informative exercise, and thought others might as well. Before I go further, I'm curious if there's any appetite for merging something like this.

Changes:

- Add stubs for the bits of the `pkginfo` and `importlib_metadata` API that twine uses
- Fix resulting mypy errors
- Add formatting and linting for stubs (incomplete)
- Type coverage: https://twine-mypy.now.sh/

```
+-------------------------+-------------------+-------------------+
| Module                  | Before            | After             |
+-------------------------+-------------------+-------------------+
| twine                   |  22.73% imprecise |   2.27% imprecise |
| twine._installed        |  10.00% imprecise |   8.33% imprecise |
| twine.cli               |  17.81% imprecise |  13.51% imprecise |
| twine.package           |  17.10% imprecise |   1.48% imprecise |
| twine.repository        |  16.73% imprecise |  16.34% imprecise |
| twine.wheel             |   7.61% imprecise |   2.15% imprecise |
| twine.wininst           |   3.28% imprecise |   1.64% imprecise |
+-------------------------+-------------------+-------------------+
| Total                   |   8.95% imprecise |   5.99% imprecise |
+-------------------------+-------------------+-------------------+
```

TODO:

- [ ] Review [typeshed/CONTRIBUTING.md](https://github.com/python/typeshed/blob/master/CONTRIBUTING.md) for stub code style
- [ ] Rework linting/formatting for stubs. I don't think the flake8 configuration is right. I tried [flake8-pyi](https://github.com/ambv/flake8-pyi), but saw some inconsistent behavior, though it might be worth a closer look.
- [ ] Maybe: Add stubs for more missing imports