### PR TITLE
Remove hook for notifying irc channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,3 @@ script:
 
 after_script:
   - codecov --env TRAVIS_OS_NAME,TOXENV
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#pypa-dev"
-    use_notice: true
-    skip_join: true


### PR DESCRIPTION
Removes the hook from travis which notifies irc channel #pypa-dev in case of build success/failure, effectively overrides the suggestion made in, and closes https://github.com/pypa/twine/issues/581