### PR TITLE
Unit tests for twine.auth and twine.commands.check

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -164,33 +164,6 @@ def test_get_password_runtime_error_suppressed(
     assert "fail!" in str(warning)
 
 
-def test_get_username_raises_attribute_error(entered_username, monkeypatch, config):
-    """Test when Keyring's get_credential raises an AttributeError"""
-
-    class FailKeyring:
-        @staticmethod
-        def get_credential(system, username):
-            raise AttributeError("fail!")
-
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
-    assert auth.Resolver(config, cred()).username == "entered user"
-
-
-def test_get_username_raises_exception(entered_username, monkeypatch, recwarn, config):
-    """Test when Keyring's get_credential raises an Exception"""
-
-    class FailKeyring:
-        @staticmethod
-        def get_credential(system, username):
-            raise Exception("fail!")
-
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
-    assert auth.Resolver(config, cred()).username == "entered user"
-    assert len(recwarn) == 1
-    warning = recwarn.pop(UserWarning)
-    assert "fail!" in str(warning)
-
-
 def test_get_username_return_none(entered_username, monkeypatch, config):
     """Test when Keyring's get_credential returns None"""
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -162,3 +162,42 @@ def test_get_password_runtime_error_suppressed(
     assert len(recwarn) == 1
     warning = recwarn.pop(UserWarning)
     assert "fail!" in str(warning)
+
+
+def test_get_username_raises_attribute_error(entered_username, monkeypatch, config):
+    """Test when Keyring's get_credential raises an AttributeError"""
+
+    class FailKeyring:
+        @staticmethod
+        def get_credential(system, username):
+            raise AttributeError("fail!")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    assert auth.Resolver(config, cred()).username == "entered user"
+
+
+def test_get_username_raises_exception(entered_username, monkeypatch, recwarn, config):
+    """Test when Keyring's get_credential raises an Exception"""
+
+    class FailKeyring:
+        @staticmethod
+        def get_credential(system, username):
+            raise Exception("fail!")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    assert auth.Resolver(config, cred()).username == "entered user"
+    assert len(recwarn) == 1
+    warning = recwarn.pop(UserWarning)
+    assert "fail!" in str(warning)
+
+
+def test_get_username_return_none(entered_username, monkeypatch, config):
+    """Test when Keyring's get_credential returns None"""
+
+    class FailKeyring:
+        @staticmethod
+        def get_credential(system, username):
+            return None
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    assert auth.Resolver(config, cred()).username == "entered user"


### PR DESCRIPTION
Towards #7 

Add more unit tests to `twine.auth` and `twine.commands.check` to bring the coverage up to 100% for both.

```
py run-test: commands[1] | coverage report -m
Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
twine/__init__.py               14      1      2      1    88%   29->32, 32
twine/_installed.py             42      4     18      7    82%   20->57, 22->23, 23, 27->57, 46->57, 47->52, 49->53, 52, 53->46, 57-60
twine/auth.py                   57      0      4      0   100%
twine/cli.py                    29      0      4      0   100%
twine/commands/__init__.py      21      0     11      0   100%
twine/commands/check.py         73      0     22      0   100%
twine/commands/register.py      25      0      4      0   100%
twine/commands/upload.py        58      2     22      2    95%   83->84, 84, 85->86, 86
twine/exceptions.py             27      0      0      0   100%
twine/package.py               130      8     35      8    90%   82->87, 87, 100->101, 101-102, 105->106, 106, 164->165, 165, 168, 240->exit, 244->246, 246, 249->exit, 253->255, 255
twine/repository.py            124      1     38      0    99%   257
twine/settings.py               71      0      6      0   100%
twine/utils.py                 107      0     38      1    99%   191->196
twine/wheel.py                  50      0     18      0   100%
twine/wininst.py                38     26     19      0    21%   15-17, 21-25, 28-59
------------------------------------------------------------------------
TOTAL                          866     42    241     19    93%
```

