### PR TITLE
Remove pinned dependency of semantic-version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,3 @@ readme-renderer>=17.4
 releases>=1.4.0
 Sphinx>=1.7.0
 sphinx_rtd_theme>=0.2.4
-
-# workaround for #492
-semantic-version<2.7


### PR DESCRIPTION
Fixes and closes https://github.com/pypa/twine/issues/492