### PR TITLE
Add support for "who tests what" in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 branch = True
-dynamic_context = test_function
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+dynamic_context = test_function
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -17,3 +18,6 @@ omit =
     #   and exists only to provide setuptools and python -m a place to point
     #   at.
     */twine/__main__.py
+
+[html]
+show_contexts = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,17 @@ envlist = lint,types,py{36,37,38},docs
 
 [testenv]
 deps =
-    coverage
     pretend
     pytest
+    pytest-cov
     jaraco.envs
     portend
     pytest-services
     munch
 commands =
-    coverage run --source twine -m pytest {posargs:tests}
-    coverage report -m
-    coverage html
+    pytest --cov=twine --cov-context=test \
+        --cov-report term-missing --cov-report html \
+        {posargs:tests}
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Via dynamic contexts, a new feature of Coverage 5.0: https://coverage.readthedocs.io/en/latest/contexts.html#dynamic-contexts

While reviewing #621, I found this handy to discover tests that were already executing a block of code. There's an example at https://twine-coverage.now.sh; open any of the files, then select the "ctx" dropdown on the right of each line.

This also adds the [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/index.html) plugin, instead of running coverage directly, to make the reported test function more pytest-like:

<img width="758" alt="Screen Shot 2020-05-17 at 6 03 06 AM" src="https://user-images.githubusercontent.com/1326704/82141666-6a115280-9805-11ea-8be4-d65bf422152b.png">

Without pytest-cov:

<img width="758" alt="Screen Shot 2020-05-17 at 6 00 34 AM" src="https://user-images.githubusercontent.com/1326704/82141673-73022400-9805-11ea-9826-11eab2d4e5de.png">

See: https://pytest-cov.readthedocs.io/en/latest/contexts.html
