### PR TITLE
Expand "Testing" section in contributing guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,7 +91,7 @@ off the coverage report, run:
 
 .. code-block:: console
 
-  export PYTEST_ADDOPTS=-k "not integration" --cov-report=
+  export PYTEST_ADDOPTS='-k "not integration" --cov-report='
 
 Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
 To run the tests against a specific version, e.g. Python 3.6, you will need it

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -71,12 +71,35 @@ or functions.
 Testing
 ^^^^^^^
 
-Twine is tested against Python versions 3.6, 3.7, and 3.8. To run these tests
-locally, you will need these versions of Python installed on your machine.
+We use `pytest`_ for writing and running tests.
 
-Either run ``tox`` to build against all supported Python versions (if you have
-them installed) or run ``tox -e py{version}`` to test against a specific
-version, e.g., ``tox -e py36`` or ``tox -e py37``.
+To run the tests in your virtual environment, run:
+
+.. code-block:: console
+
+  tox -e py
+
+To pass options to ``pytest``, e.g. the name of a test, run:
+
+.. code-block:: console
+
+  tox -e py -- tests/test_upload.py::test_exception_for_http_status
+
+Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
+To run the tests against a specific version, e.g. Python 3.6, you will need it
+installed on your machine. Then, run:
+
+.. code-block:: console
+
+  tox -e py36
+
+To run the tests against all supported Python versions, check code style,
+and build the documentation, run:
+
+.. code-block:: console
+
+  tox
+
 
 Submitting changes
 ^^^^^^^^^^^^^^^^^^
@@ -176,7 +199,9 @@ merge into a single tool; see `ongoing discussion
 .. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
 .. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
 .. _`virtual environment`: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
-.. _`tox`: https://tox.readthedocs.io/en/latest/
+.. _`tox`: https://tox.readthedocs.io/
+.. _`pytest`: https://docs.pytest.org/
+.. _`Travis`: https://travis-ci.org/github/pypa/twine
 .. _`plugin`: https://github.com/bitprophet/releases
 .. _`projects`: https://packaging.python.org/glossary/#term-project
 .. _`open issues`: https://github.com/pypa/twine/issues

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -85,6 +85,14 @@ To pass options to ``pytest``, e.g. the name of a test, run:
 
   tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
+You can also set the ``PYTEST_ADDOPTS`` environment variable to use the same
+options on every test run. For example, to skip integration tests and turn
+off the coverage report, run:
+
+.. code-block:: console
+
+  export PYTEST_ADDOPTS=-k "not integration" --cov-report=
+
 Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
 To run the tests against a specific version, e.g. Python 3.6, you will need it
 installed on your machine. Then, run:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,12 +86,11 @@ To pass options to ``pytest``, e.g. the name of a test, run:
     tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
 You can also set the ``PYTEST_ADDOPTS`` environment variable to use the same
-options on every test run. For example, to skip integration tests and turn
-off the coverage report, run:
+options on every test run. For example, to always skip integration tests:
 
 .. code-block:: console
 
-    export PYTEST_ADDOPTS='-k "not integration" --cov-report='
+    export PYTEST_ADDOPTS='-k "not integration"'
 
 Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
 To run the tests against a specific version, e.g. Python 3.6, you will need it

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,13 +77,13 @@ To run the tests in your virtual environment, run:
 
 .. code-block:: console
 
-  tox -e py
+    tox -e py
 
 To pass options to ``pytest``, e.g. the name of a test, run:
 
 .. code-block:: console
 
-  tox -e py -- tests/test_upload.py::test_exception_for_http_status
+    tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
 You can also set the ``PYTEST_ADDOPTS`` environment variable to use the same
 options on every test run. For example, to skip integration tests and turn
@@ -91,7 +91,7 @@ off the coverage report, run:
 
 .. code-block:: console
 
-  export PYTEST_ADDOPTS='-k "not integration" --cov-report='
+    export PYTEST_ADDOPTS='-k "not integration" --cov-report='
 
 Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
 To run the tests against a specific version, e.g. Python 3.6, you will need it
@@ -99,14 +99,14 @@ installed on your machine. Then, run:
 
 .. code-block:: console
 
-  tox -e py36
+    tox -e py36
 
 To run the tests against all supported Python versions, check code style,
 and build the documentation, run:
 
 .. code-block:: console
 
-  tox
+    tox
 
 
 Submitting changes

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,7 +35,7 @@ Now, in your virtual environment, ``twine`` is pointing at your local copy, so
 when you make changes, you can easily see their effect.
 
 We use `tox`_ to run tests, check code style, and build the documentation.
-To install ``tox`` in your active your virtual environment, run:
+To install ``tox`` in your active virtual environment, run:
 
 .. code-block:: console
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,6 @@ filterwarnings=
 	ignore:Using or importing the ABCs:DeprecationWarning:bleach
 	# workaround for https://github.com/pypa/setuptools/issues/479
 	ignore:the imp module is deprecated::setuptools
+
+addopts =
+	--cov=twine --cov-context=test --cov-report=

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,11 @@ deps =
     portend
     pytest-services
     munch
+passenv = PYTEST_ADDOPTS
+setenv =
+    PYTEST_ADDOPTS = --cov=twine --cov-context=test {env:PYTEST_ADDOPTS:--cov-report term-missing --cov-report html}
 commands =
-    pytest --cov=twine --cov-context=test \
-        --cov-report term-missing --cov-report html \
-        {posargs:tests}
+    pytest {posargs:tests}
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,10 @@ deps =
     portend
     pytest-services
     munch
-passenv = PYTEST_ADDOPTS
-setenv =
-    PYTEST_ADDOPTS = --cov=twine --cov-context=test {env:PYTEST_ADDOPTS:--cov-report term-missing --cov-report html}
+passenv =
+    PYTEST_ADDOPTS
 commands =
-    pytest {posargs:tests}
+    pytest {posargs:--cov=twine --cov-context=test --cov-report term-missing --cov-report html tests}
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pytest {posargs:--cov=twine --cov-context=test --cov-report term-missing --cov-report html tests}
+    pytest {posargs:--cov-report term-missing --cov-report html tests}
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Following a similar pattern to "Code style" in #631. I started this while working on that PR, then realized it would be better on its own. I also attempted to address #543 (at least partially) by adding explicit support for `PYTEST_ADDOPTS`.

Does this accurately describe the expected testing workflow for new contributors? My own workflow is to run `pytest` directly, using a virtual environment created with `tox --devenv venv`; I'm tempted to open an PR that documents that approach for discussion.

@deveshks, as a new contributor, what do you think? Any suggestions?