### PR TITLE
Remove superfluous trailing commas

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -106,7 +106,7 @@ def test_package_is_uploaded_404s(default_repo):
     default_repo.session = pretend.stub(
         get=lambda url, headers: response_with(status_code=404)
     )
-    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"))
 
     assert default_repo.package_is_uploaded(package) is False
 
@@ -118,7 +118,7 @@ def test_package_is_uploaded_200s_with_no_releases(default_repo):
             status_code=200, _content=b'{"releases": {}}', _content_consumed=True
         ),
     )
-    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"),)
+    package = pretend.stub(safe_name="fake", metadata=pretend.stub(version="2.12.0"))
 
     assert default_repo.package_is_uploaded(package) is False
 
@@ -300,15 +300,15 @@ def test_upload_retry(tmpdir, default_repo, capsys):
             },
         ),
         # Not pypi
-        ([("fake", "2.12.0")], "http://devpi.example.com", set(),),
+        ([("fake", "2.12.0")], "http://devpi.example.com", set()),
         # No packages
-        ([], utils.DEFAULT_REPOSITORY, set(),),
+        ([], utils.DEFAULT_REPOSITORY, set()),
     ],
 )
 def test_release_urls(package_meta, repository_url, release_urls):
     """Test that the correct release urls are read"""
     packages = [
-        pretend.stub(safe_name=name, metadata=pretend.stub(version=version),)
+        pretend.stub(safe_name=name, metadata=pretend.stub(version=version))
         for name, version in package_meta
     ]
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -57,7 +57,7 @@ def dispatch(argv: List[str]) -> Any:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s version {} ({})".format(twine.__version__, dep_versions(),),
+        version="%(prog)s version {} ({})".format(twine.__version__, dep_versions()),
     )
     parser.add_argument(
         "command", choices=registered_commands.keys(),

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -155,7 +155,7 @@ class Repository:
 
         with open(package.filename, "rb") as fp:
             data_to_send.append(
-                ("content", (package.basefilename, fp, "application/octet-stream"),)
+                ("content", (package.basefilename, fp, "application/octet-stream"))
             )
             encoder = requests_toolbelt.MultipartEncoder(data_to_send)
             with ProgressBar(

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -297,7 +297,7 @@ class Settings:
         self, cacert: Optional[str], client_cert: Optional[str]
     ) -> None:
         self.cacert = utils.get_cacert(cacert, self.repository_config)
-        self.client_cert = utils.get_clientcert(client_cert, self.repository_config,)
+        self.client_cert = utils.get_clientcert(client_cert, self.repository_config)
 
     def check_repository_url(self) -> None:
         """Verify we are not using legacy PyPI.

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -231,8 +231,8 @@ def get_userpass_value(
         return None
 
 
-get_cacert = functools.partial(get_userpass_value, key="ca_cert",)
-get_clientcert = functools.partial(get_userpass_value, key="client_cert",)
+get_cacert = functools.partial(get_userpass_value, key="ca_cert")
+get_clientcert = functools.partial(get_userpass_value, key="client_cert")
 
 
 class EnvironmentDefault(argparse.Action):


### PR DESCRIPTION
I noticed these recently; it turns out black's trailing comma handling still needs some work: https://github.com/psf/black/issues/1288.

I also checked for `,}` and `,]`, but didn't find any.