### PR TITLE
Update changelog for next release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,19 @@
 Changelog
 =========
 
+* :release:`3.2.0 <unreleased>`
+* :feature:`666` Improve display of HTTP errors during upload
+* :feature:`649` Use red text when printing errors on the command line
+* :feature:`652` Print packages and signatures to be uploaded when using
+  ``--verbose`` option
+* :bug:`655 major` Update URL to ``.pypirc`` specfication
+* :feature:`602` Require repository URL scheme to be ``http`` or ``https``
+* :bug:`612 major` Don't raise an exception when Python version can't be
+  parsed from filename
+* :bug:`611 major` Fix inaccurate retry message during ``upload``
+* :bug:`601 major` Clarify error messages for archive format
+* :feature:`231` Add type annotations, checked with mypy, with :pep:`561`
+  support for users of Twine's API
 * :release:`3.1.1 <2019-11-27>`
 * :bug:`548` Restore ``--non-interactive`` as a flag not expecting an
   argument.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,11 @@
 :orphan:
 
+.. See https://releases.readthedocs.io/ for instructions
+
 =========
 Changelog
 =========
+
 * :release:`3.1.1 <2019-11-27>`
 * :bug:`548` Restore ``--non-interactive`` as a flag not expecting an
   argument.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -199,10 +199,11 @@ Making a new release
 
 A checklist for creating, testing, and distributing a new version.
 
-#. Add missing changes to :file:`docs/changelog.rst`.
+#. Add user-facing changes to :file:`docs/changelog.rst`.
 #. Choose a version number, e.g. ``3.2.0``.
 #. Add a ``:release:`` line to :file:`docs/changelog.rst`.
-#. Commit, push, and ensure the `Travis`_ build passes.
+#. Commit and open a pull request for review.
+#. Merge the pull request, and ensure the `Travis`_ build passes.
 #. Create a new git tag with ``git tag -m tag {version}``.
 #. Push the new tag with ``git push upstream {version}``.
 #. Watch the release in `Travis`_.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -199,18 +199,13 @@ Making a new release
 
 A checklist for creating, testing, and distributing a new version.
 
-#. Choose a version number, e.g. "1.15.0"
-
-#. Update the changelog:
-
-   #. Add missing changes to :file:`docs/changelog.rst`.
-   #. Add a release line at the beginning referencing the release
-      and the date of the release.
-   #. Commit, push, ensure Travis build passes.
-
-#. Create a new git tag with ``git tag -m tag {number}``.
-#. Push the new tag: ``git push upstream {number}``.
-#. Watch the release `in Travis <https://travis-ci.org/pypa/twine>`_.
+#. Add missing changes to :file:`docs/changelog.rst`.
+#. Choose a version number, e.g. ``3.2.0``.
+#. Add a ``:release:`` line to :file:`docs/changelog.rst`.
+#. Commit, push, and ensure the `Travis`_ build passes.
+#. Create a new git tag with ``git tag -m tag {version}``.
+#. Push the new tag with ``git push upstream {version}``.
+#. Watch the release in `Travis`_.
 #. Send announcement email to `distutils-sig mailing list`_ and celebrate.
 
 


### PR DESCRIPTION
Prompted by @brainwane on [#pypa-dev](http://kafka.dcpython.org/day/pypa-dev/2020-05-29#18.30.00.sumanah), and with the blessing of @jaraco and @di, I'm starting the process of publishing the next release of Twine. I'd very much appreciate feedback and guidance.

Changes:

- Update releasing instructions
- Add missing changelog entries for [commits since 3.1.1](https://github.com/pypa/twine/compare/3.1.1...master) 

TODO:

- [x] Pick the next version number; I'm thinking `3.2.0`
- [x] Resolve issues in [3.2.0 Milestone](https://github.com/pypa/twine/milestone/10) and add them to the changelog
- [x] Add the release to the changelog
- [ ] Merge this PR
- [ ] Publish a pre-release to PyPI, e.g. `3.2.0rc1` (since it's my first one)
- [ ] Update release date in changelog on `master`
- [ ] Publish to PyPI

You can see a rendered version of the changelog at https://twine-docs.now.sh/changelog.html.