### PR TITLE
Add tox environment for previewing docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,10 +273,11 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
-# Avoid errors due to GitHub rate limit
-# https://github.com/sphinx-doc/sphinx/issues/7388
 linkcheck_ignore = [
-    "https://github.com/pypa/twine/issues/*"
+    "http://127.0.0.1*",
+    # Avoid errors due to GitHub rate limit
+    # https://github.com/sphinx-doc/sphinx/issues/7388
+    "https://github.com/pypa/twine/issues/*",
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -47,9 +47,16 @@ Building the documentation
 Additions and edits to twine's documentation are welcome and
 appreciated.
 
-After making docs changes, lint and build the docs locally, using
-``tox``, before making a pull request. Activate your virtual
-environment, then, in the root directory, run:
+To preview the docs while you're making changes, run:
+
+.. code-block:: console
+
+    tox -e watch-docs
+
+Then open a web browser to `<http://127.0.0.1:8000>`_.
+
+When you're done making changes, lint and build the docs locally before making
+a pull request. In your active virtual environment, run:
 
 .. code-block:: console
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,19 @@ commands =
     python setup.py sdist
     twine check dist/*
 
+[testenv:watch-docs]
+skip_install = True
+deps =
+    -rdocs/requirements.txt
+    sphinx-autobuild
+commands =
+    sphinx-autobuild -W -b html -d {envtmpdir}/doctrees \
+        {posargs:-H 127.0.0.1} \
+        # HACK: Detect changes in README.rst; results in superfluous builds
+        # Mitigated somewhat by ignoring dotfiles
+        -z . -i '.*' \
+        docs docs/_build/html
+
 [testenv:format]
 skip_install = True
 deps =


### PR DESCRIPTION
Add `tox -e watch-docs` for quickly rebuilding and previewing docs during development. This intentionally skips all of the checks that are performed by `tox -e docs`. It's got a dedicated environment to keep the tox configuration simple, inspired by https://github.com/marshmallow-code/marshmallow/blob/dev/tox.ini.