### PR TITLE
Multi Platform CI Pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run linting
+        run: python -m tox -e lint
+
+  test:
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run tests
+        run: python -m tox -e py  # Run tox using the version of Python in `PATH`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,11 @@ jobs:
         run: python -m tox -e lint
 
   test:
-    runs-on: [ubuntu-latest, macos-latest, windows-latest]
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires=
     importlib_metadata; python_version < "3.8"
     keyring >= 15.1
     rfc3986 >= 1.4.0
-    pathlib >= 1.0.1
 setup_requires =
     setuptools_scm >= 1.15
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires=
     importlib_metadata; python_version < "3.8"
     keyring >= 15.1
     rfc3986 >= 1.4.0
+    pathlib >= 1.0.1
 setup_requires =
     setuptools_scm >= 1.15
 include_package_data = True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 from twine import cli
 
 
@@ -24,6 +28,10 @@ twine_sampleproject_token = (
 )
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="pytest-services watcher_getter fixture does not support Windows",
+)
 def test_pypi_upload(sampleproject_dist):
     command = [
         "upload",
@@ -38,6 +46,10 @@ def test_pypi_upload(sampleproject_dist):
     cli.dispatch(command)
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="pytest-services watcher_getter fixture does not support Windows",
+)
 def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
     command = [
         "upload",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,10 @@ import pytest
 from twine import cli
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="pytest-services watcher_getter fixture does not support Windows",
+)
 def test_devpi_upload(devpi_server, uploadable_dist):
     command = [
         "upload",
@@ -28,10 +32,6 @@ twine_sampleproject_token = (
 )
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="pytest-services watcher_getter fixture does not support Windows",
-)
 def test_pypi_upload(sampleproject_dist):
     command = [
         "upload",

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import pathlib
+import re
 import zipfile
 
-import pathlib
 import pretend
 import pytest
 
@@ -73,17 +74,19 @@ def test_read_non_existent_wheel_file_name():
     """Test reading a wheel file which doesn't exist"""
     file_name = str(pathlib.Path("/foo/bar/baz.whl"))
     with pytest.raises(
-        exceptions.InvalidDistribution, match=f"No such file: {file_name}"
+        exceptions.InvalidDistribution, match=re.escape(f"No such file: {file_name}")
     ):
         wheel.Wheel(file_name)
 
 
 def test_read_invalid_wheel_extension():
     """Test reading a wheel file without a .whl extension"""
-    file_name = str(pathlib.Path(os.path.dirname(__file__)) / "fixtures" / "twine-1.5.0.tar.gz")
+    file_name = str(
+        pathlib.Path(os.path.dirname(__file__)) / "fixtures" / "twine-1.5.0.tar.gz"
+    )
     with pytest.raises(
         exceptions.InvalidDistribution,
-        match=f"Not a known archive format for file: {file_name}",
+        match=re.escape(f"Not a known archive format for file: {file_name}"),
     ):
         wheel.Wheel(file_name)
 
@@ -95,6 +98,7 @@ def test_read_wheel_empty_metadata(tmpdir):
         zip_file.writestr("METADATA", "")
 
     with pytest.raises(
-        exceptions.InvalidDistribution, match=f"No METADATA in archive: {whl_file}"
+        exceptions.InvalidDistribution,
+        match=re.escape(f"No METADATA in archive: {whl_file}"),
     ):
         wheel.Wheel(whl_file)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -14,6 +14,7 @@
 import os
 import zipfile
 
+import pathlib
 import pretend
 import pytest
 
@@ -70,7 +71,7 @@ def test_read_valid(example_wheel):
 
 def test_read_non_existent_wheel_file_name():
     """Test reading a wheel file which doesn't exist"""
-    file_name = "/foo/bar/baz.whl"
+    file_name = str(pathlib.Path("/foo/bar/baz.whl"))
     with pytest.raises(
         exceptions.InvalidDistribution, match=f"No such file: {file_name}"
     ):
@@ -79,7 +80,7 @@ def test_read_non_existent_wheel_file_name():
 
 def test_read_invalid_wheel_extension():
     """Test reading a wheel file without a .whl extension"""
-    file_name = os.path.join(os.path.dirname(__file__), "fixtures/twine-1.5.0.tar.gz")
+    file_name = str(pathlib.Path(os.path.dirname(__file__)) / "fixtures" / "twine-1.5.0.tar.gz")
     with pytest.raises(
         exceptions.InvalidDistribution,
         match=f"Not a known archive format for file: {file_name}",

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -72,7 +72,7 @@ def test_read_valid(example_wheel):
 
 def test_read_non_existent_wheel_file_name():
     """Test reading a wheel file which doesn't exist"""
-    file_name = str(pathlib.Path("/foo/bar/baz.whl"))
+    file_name = str(os.path.abspath(pathlib.Path("/foo/bar/baz.whl")))
     with pytest.raises(
         exceptions.InvalidDistribution, match=re.escape(f"No such file: {file_name}")
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     portend
     pytest-services
     munch
+    pathlib
 passenv =
     PYTEST_ADDOPTS
 commands =


### PR DESCRIPTION
Per discussion in #650, this PR leverages GitHub Actions to test twine against Ubuntu, macOS, and Windows.

This involved some changes to the twine.wheel unit tests, specifically surrounding the assumption of Unix/Posix environments for path representations. To fix this, we now use [`pathlib`](https://docs.python.org/3/library/pathlib.html) in the wheel unit tests to represent paths, since when initializing a [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#concrete-paths) object, `pathlib` automatically returns a `PosixPath` or a `WindowsPath` dependent on the operating system at runtime.

Additionally, integration tests `test_devpi_upload` and `test_pypi_server_upload` are expected to fail on Windows and thus skipped since they're using `pytest-services`' [`watcher-getter`](https://github.com/pytest-dev/pytest-services#infrastructure-fixtures) fixture, which [doesn't support Windows according to pytestservices:#22](https://github.com/pytest-dev/pytest-services/issues/22).

There has also been discussion in #650 about replacing Travis entirely with GitHub Actions, which is reasonable enough, though [.travis.yml](https://github.com/pypa/twine/blob/master/.travis.yml#L50) also includes a code coverage step (`codecov --env TRAVIS_OS_NAME, TOX_ENV`) which I don't believe we currently have with GitHub Actions. Talking with @di, we could move to using a different coverage tool like https://pypi.org/project/coverage/. This can be done in this PR or a later one which migrates away from Travis completely towards GitHub Actions.