### PR TITLE
Prints the packages that will be uploaded when using the --verbose option

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,3 +313,16 @@ def test_check_status_code_for_missing_status_code(capsys, repo_url):
 
     captured = capsys.readouterr()
     assert captured.out == "NOTE: Try --verbose to see response content.\n"
+
+
+@pytest.mark.parametrize(
+    ("size_in_bytes, formatted_size"),
+    [(3704, "3.6 KB"), (1153433, "1.1 MB"), (21412841, "20.4 MB")],
+)
+def test_get_file_size(size_in_bytes, formatted_size, monkeypatch):
+    """Get the size of file as a string with units."""
+    monkeypatch.setattr(os.path, "getsize", lambda _: size_in_bytes)
+
+    file_size = utils.get_file_size(size_in_bytes)
+
+    assert file_size == formatted_size

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import argparse
 import os.path
+from typing import Dict
 from typing import List
 from typing import cast
 
@@ -50,24 +51,45 @@ def skip_upload(
     )
 
 
+def _make_package(
+    filename: str, signatures: Dict[str, str], upload_settings: settings.Settings
+) -> package_file.PackageFile:
+    """Create and sign a package, based off of filename, signatures and settings."""
+    package = package_file.PackageFile.from_filename(filename, upload_settings.comment)
+
+    signed_name = package.signed_basefilename
+    if signed_name in signatures:
+        package.add_gpg_signature(signatures[signed_name], signed_name)
+    elif upload_settings.sign:
+        package.sign(upload_settings.sign_with, upload_settings.identity)
+
+    if upload_settings.verbose:
+        file_size = utils.get_file_size(package.filename)
+        print(f"  {package.filename} ({file_size})")
+        if package.gpg_signature:
+            print(f"  Signed with {package.signed_filename}")
+
+    return package
+
+
 def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
     dists = commands._find_dists(dists)
-
     # Determine if the user has passed in pre-signed distributions
     signatures = {os.path.basename(d): d for d in dists if d.endswith(".asc")}
     uploads = [i for i in dists if not i.endswith(".asc")]
+
     upload_settings.check_repository_url()
     repository_url = cast(str, upload_settings.repository_config["repository"])
-
     print(f"Uploading distributions to {repository_url}")
+
+    packages_to_upload = [
+        _make_package(filename, signatures, upload_settings) for filename in uploads
+    ]
 
     repository = upload_settings.create_repository()
     uploaded_packages = []
 
-    for filename in uploads:
-        package = package_file.PackageFile.from_filename(
-            filename, upload_settings.comment
-        )
+    for package in packages_to_upload:
         skip_message = "  Skipping {} because it appears to already exist".format(
             package.basefilename
         )
@@ -78,12 +100,6 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         if upload_settings.skip_existing and repository.package_is_uploaded(package):
             print(skip_message)
             continue
-
-        signed_name = package.signed_basefilename
-        if signed_name in signatures:
-            package.add_gpg_signature(signatures[signed_name], signed_name)
-        elif upload_settings.sign:
-            package.sign(upload_settings.sign_with, upload_settings.identity)
 
         resp = repository.upload(package)
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -159,6 +159,18 @@ def normalize_repository_url(url: str) -> str:
     return urlunparse(parsed)
 
 
+def get_file_size(filename: str) -> str:
+    """Return the size of a file in KB, or MB if >= 1024 KB."""
+    file_size = os.path.getsize(filename) / 1024
+    size_unit = "KB"
+
+    if file_size > 1024:
+        file_size = file_size / 1024
+        size_unit = "MB"
+
+    return f"{file_size:.1f} {size_unit}"
+
+
 def check_status_code(response: requests.Response, verbose: bool) -> None:
     """Generate a helpful message based on the response from the repository.
 


### PR DESCRIPTION
As per discussion in #381, twine now prints the names of the packages that it will attempt to upload when the `--verbose` option is selected. The example output below is from the terminal on my MacOs(Mojave) machine. 

<img width="1677" alt="Screen Shot 2020-06-05 at 2 44 11 PM" src="https://user-images.githubusercontent.com/35483161/83925342-c3510f80-a73b-11ea-8075-7c1823fe095d.png">

This change was suggested by @bhrutledge as a simple first change to the `--verbose` option using the existing verbose pattern before more comprehensive changes are implemented using the `stdlib` logging system. 