### PR TITLE
Rewrite remaining test docstrings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,4 @@ per-file-ignores =
     # D104 Missing docstring in public package
     twine/*: D100,D101,D102,D103,D104
     twine/commands/*: D100,D101,D102,D103,D104
-    # TODO: Rewrite test docstrings https://github.com/pypa/twine/issues/628
-    # D205 1 blank line required between summary line and description
-    # D400 First line should end with a period
-    tests/*: D100,D101,D102,D103,D104,D205,D400
+    tests/*: D100,D101,D102,D103,D104

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -82,10 +82,7 @@ def test_get_username_and_password_keyring_overrides_prompt(monkeypatch, config)
 
 @pytest.fixture
 def keyring_missing_get_credentials(monkeypatch):
-    """
-    Simulate keyring prior to 15.2 that does not have the
-    'get_credential' API.
-    """
+    """Simulate keyring prior to 15.2 that does not have the 'get_credential' API."""
     monkeypatch.delattr(auth.keyring, "get_credential")
 
 
@@ -116,11 +113,7 @@ def test_get_password_keyring_missing_non_interactive_aborts(
 
 @pytest.fixture
 def keyring_no_backends(monkeypatch):
-    """
-    Simulate that keyring has no available backends. When keyring
-    has no backends for the system, the backend will be a
-    fail.Keyring, which raises RuntimeError on get_password.
-    """
+    """Simulate missing keyring backend raising RuntimeError on get_password."""
 
     class FailKeyring:
         @staticmethod
@@ -132,11 +125,7 @@ def keyring_no_backends(monkeypatch):
 
 @pytest.fixture
 def keyring_no_backends_get_credential(monkeypatch):
-    """
-    Simulate that keyring has no available backends. When keyring
-    has no backends for the system, the backend will be a
-    fail.Keyring, which raises RuntimeError on get_credential.
-    """
+    """Simulate missing keyring backend raising RuntimeError on get_credential."""
 
     class FailKeyring:
         @staticmethod

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -227,10 +227,9 @@ def test_fips_hash_manager(monkeypatch):
 
 
 def test_pkginfo_returns_no_metadata(monkeypatch):
-    """
-    Fail gracefully if pkginfo can't interpret the metadata (possibly due to
-    seeing a version number it doesn't support yet) and gives us back an
-    'empty' object with no metadata
+    """Raise an exception when pkginfo can't interpret the metadata.
+
+    This could be caused a version number it doesn't support yet.
     """
 
     def EmptyDist(filename):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -207,7 +207,7 @@ TWINE_1_5_0_WHEEL_HEXDIGEST = package_file.Hexdigest(
 
 
 def test_hash_manager():
-    """Verify our HashManager works."""
+    """Generate hexdigest via HashManager."""
     filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
     hasher = package_file.HashManager(filename)
     hasher.hash()
@@ -215,7 +215,7 @@ def test_hash_manager():
 
 
 def test_fips_hash_manager(monkeypatch):
-    """Verify the behaviour if hashlib is using FIPS mode."""
+    """Generate hexdigest without MD5 when hashlib is using FIPS mode."""
     replaced_md5 = pretend.raiser(ValueError("fipsmode"))
     monkeypatch.setattr(package_file.hashlib, "md5", replaced_md5)
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -229,7 +229,7 @@ def test_fips_hash_manager(monkeypatch):
 def test_pkginfo_returns_no_metadata(monkeypatch):
     """Raise an exception when pkginfo can't interpret the metadata.
 
-    This could be caused a version number it doesn't support yet.
+    This could be caused by a version number or format it doesn't support yet.
     """
 
     def EmptyDist(filename):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -77,7 +77,7 @@ def test_password_is_required_if_no_client_cert(client_cert, entered_password):
 
 
 def test_client_cert_is_set_and_password_not_if_both_given(entered_password):
-    """Verify that if both password and client_cert are given they are set"""
+    """Verify that if both password and client_cert are given they are set."""
     client_cert = "/random/path"
     settings_obj = settings.Settings(
         username="fakeuser", password="anything", client_cert=client_cert

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,13 +23,13 @@ from twine import settings
 
 
 def test_settings_takes_no_positional_arguments():
-    """Verify that the Settings initialization is kw-only."""
+    """Raise an exception when Settings is initialized without keyword arguments."""
     with pytest.raises(TypeError):
         settings.Settings("a", "b", "c")
 
 
-def test_settings_transforms_config(tmpdir):
-    """Verify that the settings object transforms the passed in options."""
+def test_settings_transforms_repository_config(tmpdir):
+    """Set repository config and defaults when .pypirc is provided."""
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with open(pypirc, "w") as fp:
@@ -56,13 +56,13 @@ def test_settings_transforms_config(tmpdir):
 
 
 def test_identity_requires_sign():
-    """Verify that if a user passes identity, we require sign=True."""
+    """Raise an exception when user provides identity but doesn't require sigining."""
     with pytest.raises(exceptions.InvalidSigningConfiguration):
         settings.Settings(sign=False, identity="fakeid")
 
 
 def test_password_not_required_if_client_cert(entered_password):
-    """Verify that if client_cert is provided then a password is not."""
+    """Don't set password when only client_cert is provided."""
     test_client_cert = "/random/path"
     settings_obj = settings.Settings(username="fakeuser", client_cert=test_client_cert)
     assert not settings_obj.password
@@ -71,13 +71,13 @@ def test_password_not_required_if_client_cert(entered_password):
 
 @pytest.mark.parametrize("client_cert", [None, ""])
 def test_password_is_required_if_no_client_cert(client_cert, entered_password):
-    """Verify that if client_cert is not provided then a password must be."""
+    """Set password when client_cert is not provided."""
     settings_obj = settings.Settings(username="fakeuser", client_cert=client_cert)
     assert settings_obj.password == "entered pw"
 
 
 def test_client_cert_is_set_and_password_not_if_both_given(entered_password):
-    """Verify that if both password and client_cert are given they are set."""
+    """Set password and client_cert when both are provided."""
     client_cert = "/random/path"
     settings_obj = settings.Settings(
         username="fakeuser", password="anything", client_cert=client_cert


### PR DESCRIPTION
Closes #628

As in other PR's, I favored succinct one-line docstrings that describe the desired behavior of the code under test, using the imperative mood, and avoiding redundant words like "Test" and "Verify".