### PR TITLE
Update and add links to .pypirc specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ twine
 Twine is `a utility`_ for `publishing`_ Python packages on `PyPI`_.
 
 It provides build system independent uploads of source and binary
-`distribution artifacts <distributions>`_ for both new and existing
+`distribution artifact <distributions_>`_ for both new and existing
 `projects`_.
 
 
@@ -306,6 +306,14 @@ For completeness, its usage:
                             containing the private key and the certificate in PEM
                             format.
 
+Configuration File
+^^^^^^^^^^^^^^^^^^
+
+Twine can read repository configuration from a ``.pypirc`` file, either in your
+home directory, or provided with the ``--config-file`` option. For details on
+writing and using ``.pypirc``, see the `specification <pypirc_>`_ in the Python
+Packaging User Guide.
+
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -351,6 +359,7 @@ trackers, chat rooms, and mailing lists is expected to follow the
 .. _`publishing`: https://packaging.python.org/tutorials/distributing-packages/
 .. _`PyPI`: https://pypi.org
 .. _`Test PyPI`: https://packaging.python.org/guides/using-testpypi/
+.. _`pypirc`: https://packaging.python.org/specifications/pypirc/
 .. _`Python Packaging User Guide`:
    https://packaging.python.org/tutorials/distributing-packages/
 .. _`keyring`: https://pypi.org/project/keyring/

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -66,7 +66,7 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
         parser.read(path)
 
         # Get a list of index_servers from the config file
-        # format: https://docs.python.org/3/distutils/packageindex.html#pypirc
+        # format: https://packaging.python.org/specifications/pypirc/
         if parser.has_option("distutils", "index-servers"):
             index_servers = parser.get("distutils", "index-servers").split()
 
@@ -139,7 +139,7 @@ def get_repository_from_config(
             "or not a complete URL in --repository-url.\n"
             "Maybe you have an out-dated '{cfg}' format?\n"
             "more info: "
-            "https://docs.python.org/distutils/packageindex.html#pypirc\n"
+            "https://packaging.python.org/specifications/pypirc/\n"
         ).format(repo=repository, cfg=config_file)
         raise exceptions.InvalidConfiguration(msg)
 


### PR DESCRIPTION
Fixes #638

In addition to updating the exception, this adds a short section to the docs, with a link to the spec.

I also caught a broken documentation link, and learned about [embedded URIs and aliases](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases) in RST.