### PR TITLE
Fix exception causes in package.py

### DIFF
--- a/twine/package.py
+++ b/twine/package.py
@@ -182,22 +182,22 @@ class PackageFile:
         try:
             subprocess.check_call(gpg_args)
             return
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             if gpg_args[0] != "gpg":
                 raise exceptions.InvalidSigningExecutable(
                     "{} executable not available.".format(gpg_args[0])
-                )
+                ) from e
 
         print("gpg executable not available. Attempting fallback to gpg2.")
         try:
             subprocess.check_call(("gpg2",) + gpg_args[1:])
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             print("gpg2 executable not available.")
             raise exceptions.InvalidSigningExecutable(
                 "'gpg' or 'gpg2' executables not available. "
                 "Try installing one of these or specifying an executable "
                 "with the --sign-with flag."
-            )
+            ) from e
 
 
 class Hexdigest(NamedTuple):


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 