### PR TITLE
Reformat HTTP errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,13 +10,5 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run
     if __name__ == .__main__.:
 
-
-# Paths to omit from consideration
-omit =
-    # __main__.py exists only as a very basic wrapper around warehouse.cli
-    #   and exists only to provide setuptools and python -m a place to point
-    #   at.
-    */twine/__main__.py
-
 [html]
 show_contexts = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def entered_password(monkeypatch):
     monkeypatch.setattr(getpass, "getpass", lambda prompt: "entered pw")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sampleproject_dist(tmp_path_factory):
     checkout = tmp_path_factory.mktemp("sampleproject", numbered=False)
     subprocess.run(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 import colorama
@@ -63,12 +64,14 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
     monkeypatch.setattr(sys, "argv", command)
 
     message = (
-        "HTTPError from https://test.pypi.org/legacy/: 403 Forbidden\n"
-        "Invalid or non-existent authentication information. "
-        "See https://test.pypi.org/help/#invalid-auth for details"
+        re.escape(colorama.Fore.RED)
+        + r"HTTPError from https://test.pypi.org/legacy/: 403 Forbidden\n"
+        + r".*authentication"
     )
 
-    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
+    result = dunder_main.main()
+
+    assert re.match(message, result)
 
 
 @pytest.mark.xfail(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,7 +65,7 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
 
     message = (
         re.escape(colorama.Fore.RED)
-        + r"HTTPError from https://test.pypi.org/legacy/: 403 Forbidden\n"
+        + r"HTTPError: 403 Forbidden from https://test.pypi.org/legacy/\n"
         + r".*authentication"
     )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,8 +65,8 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
 
     message = (
         re.escape(colorama.Fore.RED)
-        + r"HTTPError: 403 Forbidden from https://test.pypi.org/legacy/\n"
-        + r".*authentication"
+        + r"HTTPError: 403 Forbidden from https://test\.pypi\.org/legacy/\n"
+        + r".+?authentication"
     )
 
     result = dunder_main.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,7 @@
 import sys
 
 import colorama
-import pretend
 import pytest
-import requests
 
 from twine import __main__ as dunder_main
 from twine import cli
@@ -65,31 +63,11 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
     monkeypatch.setattr(sys, "argv", command)
 
     message = (
-        "HTTPError from https://test.pypi.org/legacy/: 403 Client Error\n"
+        "HTTPError from https://test.pypi.org/legacy/: 403 Forbidden\n"
         "Invalid or non-existent authentication information. "
         "See https://test.pypi.org/help/#invalid-auth for details"
     )
 
-    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
-
-
-def test_pypi_error_fallback(sampleproject_dist, monkeypatch):
-    command = [
-        "twine",
-        "upload",
-        "--repository-url",
-        "https://test.pypi.org/legacy/",
-        "--username",
-        "foo",
-        "--password",
-        "bar",
-        str(sampleproject_dist),
-    ]
-    monkeypatch.setattr(sys, "argv", command)
-
-    monkeypatch.setattr(cli, "dispatch", pretend.raiser(requests.HTTPError("403")))
-
-    message = "HTTPError: 403"
     assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,9 @@
 import sys
 
 import colorama
+import pretend
 import pytest
+import requests
 
 from twine import __main__ as dunder_main
 from twine import cli
@@ -68,6 +70,26 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
         "See https://test.pypi.org/help/#invalid-auth for details"
     )
 
+    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
+
+
+def test_pypi_error_fallback(sampleproject_dist, monkeypatch):
+    command = [
+        "twine",
+        "upload",
+        "--repository-url",
+        "https://test.pypi.org/legacy/",
+        "--username",
+        "foo",
+        "--password",
+        "bar",
+        str(sampleproject_dist),
+    ]
+    monkeypatch.setattr(sys, "argv", command)
+
+    monkeypatch.setattr(cli, "dispatch", pretend.raiser(requests.HTTPError("403")))
+
+    message = "HTTPError: 403"
     assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,9 @@
 import sys
 
+import colorama
 import pytest
 
+from twine import __main__ as dunder_main
 from twine import cli
 
 
@@ -44,6 +46,29 @@ def test_pypi_upload(sampleproject_dist):
         str(sampleproject_dist),
     ]
     cli.dispatch(command)
+
+
+def test_pypi_error(sampleproject_dist, monkeypatch):
+    command = [
+        "twine",
+        "upload",
+        "--repository-url",
+        "https://test.pypi.org/legacy/",
+        "--username",
+        "foo",
+        "--password",
+        "bar",
+        str(sampleproject_dist),
+    ]
+    monkeypatch.setattr(sys, "argv", command)
+
+    message = (
+        "HTTPError from https://test.pypi.org/legacy/: 403 Client Error\n"
+        "Invalid or non-existent authentication information. "
+        "See https://test.pypi.org/help/#invalid-auth for details"
+    )
+
+    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
 
 
 @pytest.mark.xfail(

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -25,8 +25,14 @@ from twine import exceptions
 def main() -> Any:
     try:
         return cli.dispatch(sys.argv[1:])
-    except (exceptions.TwineException, requests.HTTPError) as exc:
+    except requests.HTTPError as exc:
+        return _format_error(_format_http_error(exc))
+    except exceptions.TwineException as exc:
         return _format_error(f"{exc.__class__.__name__}: {exc.args[0]}")
+
+
+def _format_http_error(exc: requests.HTTPError) -> str:
+    return f"{exc.__class__.__name__}: {exc.args[0]}"
 
 
 def _format_error(message: str) -> str:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -25,25 +25,19 @@ from twine import exceptions
 
 def main() -> Any:
     try:
-        return cli.dispatch(sys.argv[1:])
+        result = cli.dispatch(sys.argv[1:])
     except requests.HTTPError as exc:
-        return _format_error(_format_http_exception(exc))
+        status_code = exc.response.status_code
+        status_phrase = http.HTTPStatus(status_code).phrase
+        result = (
+            f"{exc.__class__.__name__} from {exc.response.url}: "
+            f"{status_code} {status_phrase}\n"
+            f"{exc.response.reason}"
+        )
     except exceptions.TwineException as exc:
-        return _format_error(_format_exception(exc))
+        result = f"{exc.__class__.__name__}: {exc.args[0]}"
 
-
-def _format_http_exception(exc: requests.HTTPError) -> str:
-    status_code = exc.response.status_code
-    status_phrase = http.HTTPStatus(status_code).phrase
-    return (
-        f"{exc.__class__.__name__} from {exc.response.url}: "
-        f"{status_code} {status_phrase}\n"
-        f"{exc.response.reason}"
-    )
-
-
-def _format_exception(exc: Exception) -> str:
-    return f"{exc.__class__.__name__}: {exc.args[0]}"
+    return _format_error(result) if isinstance(result, str) else result
 
 
 def _format_error(message: str) -> str:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import re
+import http
 import sys
 from typing import Any
 
@@ -33,16 +33,13 @@ def main() -> Any:
 
 
 def _format_http_exception(exc: requests.HTTPError) -> str:
-    # '%s Client Error: %s for url: %s'
-    # '%s Server Error: %s for url: %s'
-    pattern = r"(?P<status>.*Error): (?P<reason>.*) for url: (?P<url>.*)"
-    match = re.match(pattern, exc.args[0])
-    if match:
-        return (
-            f"{exc.__class__.__name__} from {match['url']}: {match['status']}\n"
-            f"{match['reason']}"
-        )
-    return _format_exception(exc)
+    status_code = exc.response.status_code
+    status_phrase = http.HTTPStatus(status_code).phrase
+    return (
+        f"{exc.__class__.__name__} from {exc.response.url}: "
+        f"{status_code} {status_phrase}\n"
+        f"{exc.response.reason}"
+    )
 
 
 def _format_exception(exc: Exception) -> str:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -30,8 +30,8 @@ def main() -> Any:
         status_code = exc.response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase
         result = (
-            f"{exc.__class__.__name__} from {exc.response.url}: "
-            f"{status_code} {status_phrase}\n"
+            f"{exc.__class__.__name__}: {status_code} {status_phrase} "
+            f"from {exc.response.url}\n"
             f"{exc.response.reason}"
         )
     except exceptions.TwineException as exc:


### PR DESCRIPTION
Fixes #587, in which my main goal was to make the source and potential resolution of errors from Warehouse more obvious, which might have mitigated issues like #577 and #424.

New format:

<img width="643" alt="Screen Shot 2020-06-21 at 5 44 40 AM" src="https://user-images.githubusercontent.com/1326704/85221764-9e3bde00-b384-11ea-8e42-5521df26ae99.png">

Old format:

<img width="648" alt="Screen Shot 2020-06-18 at 8 54 07 AM" src="https://user-images.githubusercontent.com/1326704/85022609-87f21000-b141-11ea-9532-b57d3faddfcc.png">

This intentionally wraps at 80 characters, but I've also seen reports where it wasn't wrapped, and the Warehouse URL was buried at the end of the line.