### PR TITLE
Release 3.2.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@
 Changelog
 =========
 
-* :release:`3.2.0 <unreleased>`
+* :release:`3.2.0 <2020-06-24>`
 * :feature:`666` Improve display of HTTP errors during upload
 * :feature:`649` Use red text when printing errors on the command line
 * :feature:`652` Print packages and signatures to be uploaded when using

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -204,7 +204,7 @@ A checklist for creating, testing, and distributing a new version.
 #. Add a ``:release:`` line to :file:`docs/changelog.rst`.
 #. Commit and open a pull request for review.
 #. Merge the pull request, and ensure the `Travis`_ build passes.
-#. Create a new git tag with ``git tag -m tag {version}``.
+#. Create a new git tag with ``git tag -m "Release v{version}" {version}``.
 #. Push the new tag with ``git push upstream {version}``.
 #. Watch the release in `Travis`_.
 #. Send announcement email to `distutils-sig mailing list`_ and celebrate.


### PR DESCRIPTION
Following up on #643, and out of an abundance of caution for my first release, I'm opening this PR for review of the pre-release (https://pypi.org/project/twine/3.2.0rc1/), and approval of the official release.

I've installed the pre-release locally and verified uploads w/ and w/o errors to Test PyPI.

Hoping to merge and release tomorrow.