### PR TITLE
Logging package names, file sizes, and signatures

### DIFF
--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import logging
 import os.path
 from typing import Dict
 from typing import List
@@ -56,6 +57,7 @@ def _make_package(
 ) -> package_file.PackageFile:
     """Create and sign a package, based off of filename, signatures and settings."""
     package = package_file.PackageFile.from_filename(filename, upload_settings.comment)
+    logger = logging.getLogger("LOGGER")
 
     signed_name = package.signed_basefilename
     if signed_name in signatures:
@@ -65,9 +67,9 @@ def _make_package(
 
     if upload_settings.verbose:
         file_size = utils.get_file_size(package.filename)
-        print(f"  {package.filename} ({file_size})")
+        logger.info(f"  {package.filename} ({file_size})")
         if package.gpg_signature:
-            print(f"  Signed with {package.signed_filename}")
+            logger.info(f"  Signed with {package.signed_filename}")
 
     return package
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -57,7 +57,7 @@ class Settings:
         client_cert: Optional[str] = None,
         repository_name: str = "pypi",
         repository_url: Optional[str] = None,
-        verbose: bool = False,
+        verbose: int = 0,
         disable_progress_bar: bool = False,
         **ignored_kwargs: Any,
     ) -> None:
@@ -111,7 +111,7 @@ class Settings:
         :param str repository_url:
             The URL of the repository (package index) to interact with. This
             will override the settings inferred from ``repository_name``.
-        :param bool verbose:
+        :param int verbosity:
             Show verbose output.
         :param bool disable_progress_bar:
             Disable the progress bar.
@@ -121,6 +121,8 @@ class Settings:
         self.config_file = config_file
         self.comment = comment
         self.verbose = verbose
+        # Setting up logging before the config is loaded
+        utils.setup_logging(verbose)
         self.disable_progress_bar = disable_progress_bar
         self.skip_existing = skip_existing
         self._handle_repository_options(
@@ -250,11 +252,12 @@ class Settings:
             " private key and the certificate in PEM format.",
         )
         parser.add_argument(
+            "-v",
             "--verbose",
-            default=False,
+            default=0,
             required=False,
-            action="store_true",
-            help="Show verbose output.",
+            action="count",
+            help="Show verbose output. -v to -vvv in increasing verbosity.",
         )
         parser.add_argument(
             "--disable-progress-bar",

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -15,8 +15,10 @@ import argparse
 import collections
 import configparser
 import functools
+import logging
 import os
 import os.path
+import sys
 from typing import Any
 from typing import Callable
 from typing import DefaultDict
@@ -171,13 +173,14 @@ def get_file_size(filename: str) -> str:
     return f"{file_size:.1f} {size_unit}"
 
 
-def check_status_code(response: requests.Response, verbose: bool) -> None:
+def check_status_code(response: requests.Response, verbose: int) -> None:
     """Generate a helpful message based on the response from the repository.
 
     Raise a custom exception for recognized errors. Otherwise, print the
     response content (based on the verbose option) before re-raising the
     HTTPError.
     """
+    logger = logging.getLogger("LOGGER")
     if response.status_code == 410 and "pypi.python.org" in response.url:
         raise exceptions.UploadToDeprecatedPyPIDetected(
             f"It appears you're uploading to pypi.python.org (or "
@@ -201,9 +204,9 @@ def check_status_code(response: requests.Response, verbose: bool) -> None:
     except requests.HTTPError as err:
         if response.text:
             if verbose:
-                print("Content received from server:\n{}".format(response.text))
+                logger.info("Content received from server:\n{}".format(response.text))
             else:
-                print("NOTE: Try --verbose to see response content.")
+                logger.warning("NOTE: Try --verbose to see response content.")
         raise err
 
 
@@ -295,3 +298,28 @@ class EnvironmentFlag(argparse.Action):
         """Allow '0' and 'false' and 'no' to be False."""
         falsey = {"0", "false", "no"}
         return bool(val and val.lower() not in falsey)
+
+
+_MAX_VERBOSITY = 5
+
+_VERBOSITY_TO_LOG_LEVEL = {
+    0: logging.WARNING,
+    1: logging.INFO,
+    2: logging.DEBUG,
+    3: _MAX_VERBOSITY,
+}
+
+
+def setup_logging(args_verbosity: int) -> None:
+    """Set up the logger and logging based on the verbosity inputted by the user."""
+    # 3 Vs are the maximum verbosity
+    if args_verbosity > 3:
+        args_verbosity = 3
+
+    log_level = _VERBOSITY_TO_LOG_LEVEL[args_verbosity]
+    logger = logging.getLogger("LOGGER")
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    logger.addHandler(handler)
+    # Setting a level of verbosity for the logger
+    logger.setLevel(log_level)


### PR DESCRIPTION
As mentioned in #381 I used the `stdlib` logging library to log packages being uploaded, file sizes, and signatures. These are already logged using the current `--verbose` pattern. This PR potentially serves as the start of the transition from the current `--verbose` pattern and output to a one based on logging using `stdlib` and has multiple verbosity levels. 

The logger is setup in `utils.py` and utilized throughout the upload command. The `--verbose` field in `Settings` is now an integer(not a boolean) from 0(default) to 3. The log level is determined by `verbose`'s value and the higher the verbosity, the lower(more encompassing) the log level is. I used 1 custom log level(for `-vvv`) and 2 existing levels. 

The additional information we want to output, as outlined in [#381(comment)](https://github.com/pypa/twine/issues/381#issuecomment-640955580) will be added in subsequent PRs after resolving any concerns/issue/concerns/problems in this PR. 