### PR TITLE
Setup basic logging functionality(existing output) with 1 level of verbosity

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import logging
 import os.path
 import textwrap
 
@@ -53,6 +54,18 @@ def test_settings_transforms_repository_config(tmpdir):
     assert s.cacert is None
     assert s.client_cert is None
     assert s.disable_progress_bar is False
+
+
+@pytest.mark.parametrize("verbose", [True, False])
+def test_setup_logging(verbose: bool):
+    """Set log level based on verbose field."""
+    settings._setup_logging(verbose)
+    logger = logging.getLogger("twine")
+
+    if verbose:
+        assert logger.level == logging.INFO
+    else:
+        assert logger.level == logging.WARNING
 
 
 def test_identity_requires_sign():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -56,16 +56,16 @@ def test_settings_transforms_repository_config(tmpdir):
     assert s.disable_progress_bar is False
 
 
-@pytest.mark.parametrize("verbose", [True, False])
-def test_setup_logging(verbose: bool):
+@pytest.mark.parametrize(
+    "verbose, log_level", [(True, logging.INFO), (False, logging.WARNING)]
+)
+def test_setup_logging(verbose, log_level):
     """Set log level based on verbose field."""
-    settings._setup_logging(verbose)
+    settings.Settings(verbose=verbose)
+
     logger = logging.getLogger("twine")
 
-    if verbose:
-        assert logger.level == logging.INFO
-    else:
-        assert logger.level == logging.WARNING
+    assert logger.level == log_level
 
 
 def test_identity_requires_sign():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 import os
 
 import pretend
@@ -55,13 +54,7 @@ def upload_settings(make_settings, stub_repository):
     return upload_settings
 
 
-@pytest.fixture
-def caplog(caplog):
-    caplog.set_level(logging.INFO, logger="twine")
-    return caplog
-
-
-def test_make_package_pre_signed_dist(upload_settings, caplog):
+def test_make_package_pre_signed_dist(upload_settings, capsys):
     """Create a PackageFile and print path, size, and user-provided signature."""
     filename = helpers.WHEEL_FIXTURE
     expected_size = "15.4 KB"
@@ -76,12 +69,12 @@ def test_make_package_pre_signed_dist(upload_settings, caplog):
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = caplog.text
-    assert captured.count(f"{filename} ({expected_size})") == 1
-    assert captured.count(f"Signed with {signed_filename}") == 1
+    captured = capsys.readouterr()
+    assert captured.out.count(f"{filename} ({expected_size})") == 1
+    assert captured.out.count(f"Signed with {signed_filename}") == 1
 
 
-def test_make_package_unsigned_dist(upload_settings, monkeypatch, caplog):
+def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
     """Create a PackageFile and print path, size, and Twine-generated signature."""
     filename = helpers.NEW_WHEEL_FIXTURE
     expected_size = "21.9 KB"
@@ -100,9 +93,9 @@ def test_make_package_unsigned_dist(upload_settings, monkeypatch, caplog):
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = caplog.text
-    assert captured.count(f"{filename} ({expected_size})") == 1
-    assert captured.count(f"Signed with {package.signed_filename}") == 1
+    captured = capsys.readouterr()
+    assert captured.out.count(f"{filename} ({expected_size})") == 1
+    assert captured.out.count(f"Signed with {package.signed_filename}") == 1
 
 
 def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
@@ -125,7 +118,7 @@ def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
     assert captured.out.count(NEW_RELEASE_URL) == 1
 
 
-def test_print_packages_if_verbose(upload_settings, caplog):
+def test_print_packages_if_verbose(upload_settings, capsys):
     """Print the path and file size of each distribution attempting to be uploaded."""
     dists_to_upload = {
         helpers.WHEEL_FIXTURE: "15.4 KB",
@@ -136,14 +129,13 @@ def test_print_packages_if_verbose(upload_settings, caplog):
 
     upload_settings.verbose = True
 
-    result = upload.upload(upload_settings, dists_to_upload)
-
+    result = upload.upload(upload_settings, dists_to_upload.keys())
     assert result is None
 
-    captured = caplog.text
+    captured = capsys.readouterr()
 
     for filename, size in dists_to_upload.items():
-        assert captured.count(f"{filename} ({size})") == 1
+        assert captured.out.count(f"{filename} ({size})") == 1
 
 
 def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
@@ -189,10 +181,8 @@ def test_success_when_gpg_is_run(upload_settings, stub_repository, monkeypatch):
 
 
 @pytest.mark.parametrize("verbose", [False, True])
-def test_exception_for_http_status(verbose, upload_settings, stub_response, caplog):
+def test_exception_for_http_status(verbose, upload_settings, stub_response, capsys):
     upload_settings.verbose = verbose
-    log_level = logging.INFO if verbose else logging.WARNING
-    caplog.set_level(log_level, logger="twine")
 
     stub_response.is_redirect = False
     stub_response.status_code = 403
@@ -202,15 +192,15 @@ def test_exception_for_http_status(verbose, upload_settings, stub_response, capl
     with pytest.raises(requests.HTTPError):
         upload.upload(upload_settings, [helpers.WHEEL_FIXTURE])
 
-    captured = caplog.text
-    assert RELEASE_URL not in captured
+    captured = capsys.readouterr()
+    assert RELEASE_URL not in captured.out
 
     if verbose:
-        assert stub_response.text in captured
-        assert "--verbose" not in captured
+        assert stub_response.text in captured.out
+        assert "--verbose" not in captured.out
     else:
-        assert stub_response.text not in captured
-        assert "--verbose" in captured
+        assert stub_response.text not in captured.out
+        assert "--verbose" in captured.out
 
 
 def test_get_config_old_format(make_settings, pypirc):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import os
 
 import pretend
@@ -54,7 +55,7 @@ def upload_settings(make_settings, stub_repository):
     return upload_settings
 
 
-def test_make_package_pre_signed_dist(upload_settings, capsys):
+def test_make_package_pre_signed_dist(upload_settings, caplog):
     """Create a PackageFile and print path, size, and user-provided signature."""
     filename = helpers.WHEEL_FIXTURE
     expected_size = "15.4 KB"
@@ -63,18 +64,19 @@ def test_make_package_pre_signed_dist(upload_settings, capsys):
 
     upload_settings.sign = True
     upload_settings.verbose = True
+    caplog.set_level(logging.INFO, logger="twine")
 
     package = upload._make_package(filename, signatures, upload_settings)
 
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = capsys.readouterr()
-    assert captured.out.count(f"{filename} ({expected_size})") == 1
-    assert captured.out.count(f"Signed with {signed_filename}") == 1
+    captured = caplog.text
+    assert captured.count(f"{filename} ({expected_size})") == 1
+    assert captured.count(f"Signed with {signed_filename}") == 1
 
 
-def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
+def test_make_package_unsigned_dist(upload_settings, monkeypatch, caplog):
     """Create a PackageFile and print path, size, and Twine-generated signature."""
     filename = helpers.NEW_WHEEL_FIXTURE
     expected_size = "21.9 KB"
@@ -82,6 +84,7 @@ def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
 
     upload_settings.sign = True
     upload_settings.verbose = True
+    caplog.set_level(logging.INFO, logger="twine")
 
     def stub_sign(package, *_):
         package.gpg_signature = (package.signed_basefilename, b"signature")
@@ -93,9 +96,9 @@ def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = capsys.readouterr()
-    assert captured.out.count(f"{filename} ({expected_size})") == 1
-    assert captured.out.count(f"Signed with {package.signed_filename}") == 1
+    captured = caplog.text
+    assert captured.count(f"{filename} ({expected_size})") == 1
+    assert captured.count(f"Signed with {package.signed_filename}") == 1
 
 
 def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
@@ -118,7 +121,7 @@ def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
     assert captured.out.count(NEW_RELEASE_URL) == 1
 
 
-def test_print_packages_if_verbose(upload_settings, capsys):
+def test_print_packages_if_verbose(upload_settings, caplog):
     """Print the path and file size of each distribution attempting to be uploaded."""
     dists_to_upload = {
         helpers.WHEEL_FIXTURE: "15.4 KB",
@@ -128,14 +131,16 @@ def test_print_packages_if_verbose(upload_settings, capsys):
     }
 
     upload_settings.verbose = True
+    caplog.set_level(logging.INFO, logger="twine")
 
-    result = upload.upload(upload_settings, dists_to_upload.keys())
+    result = upload.upload(upload_settings, dists_to_upload)
+
     assert result is None
 
-    captured = capsys.readouterr()
+    captured = caplog.text
 
     for filename, size in dists_to_upload.items():
-        assert captured.out.count(f"{filename} ({size})") == 1
+        assert captured.count(f"{filename} ({size})") == 1
 
 
 def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
@@ -181,8 +186,12 @@ def test_success_when_gpg_is_run(upload_settings, stub_repository, monkeypatch):
 
 
 @pytest.mark.parametrize("verbose", [False, True])
-def test_exception_for_http_status(verbose, upload_settings, stub_response, capsys):
+def test_exception_for_http_status(verbose, upload_settings, stub_response, caplog):
     upload_settings.verbose = verbose
+    if verbose:
+        caplog.set_level(logging.INFO, logger="twine")
+    else:
+        caplog.set_level(logging.WARNING, logger="twine")
 
     stub_response.is_redirect = False
     stub_response.status_code = 403
@@ -192,15 +201,15 @@ def test_exception_for_http_status(verbose, upload_settings, stub_response, caps
     with pytest.raises(requests.HTTPError):
         upload.upload(upload_settings, [helpers.WHEEL_FIXTURE])
 
-    captured = capsys.readouterr()
-    assert RELEASE_URL not in captured.out
+    captured = caplog.text
+    assert RELEASE_URL not in captured
 
     if verbose:
-        assert stub_response.text in captured.out
-        assert "--verbose" not in captured.out
+        assert stub_response.text in captured
+        assert "--verbose" not in captured
     else:
-        assert stub_response.text not in captured.out
-        assert "--verbose" in captured.out
+        assert stub_response.text not in captured
+        assert "--verbose" in captured
 
 
 def test_get_config_old_format(make_settings, pypirc):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -55,6 +55,12 @@ def upload_settings(make_settings, stub_repository):
     return upload_settings
 
 
+@pytest.fixture
+def caplog(caplog):
+    caplog.set_level(logging.INFO, logger="twine")
+    return caplog
+
+
 def test_make_package_pre_signed_dist(upload_settings, caplog):
     """Create a PackageFile and print path, size, and user-provided signature."""
     filename = helpers.WHEEL_FIXTURE
@@ -64,7 +70,6 @@ def test_make_package_pre_signed_dist(upload_settings, caplog):
 
     upload_settings.sign = True
     upload_settings.verbose = True
-    caplog.set_level(logging.INFO, logger="twine")
 
     package = upload._make_package(filename, signatures, upload_settings)
 
@@ -84,7 +89,6 @@ def test_make_package_unsigned_dist(upload_settings, monkeypatch, caplog):
 
     upload_settings.sign = True
     upload_settings.verbose = True
-    caplog.set_level(logging.INFO, logger="twine")
 
     def stub_sign(package, *_):
         package.gpg_signature = (package.signed_basefilename, b"signature")
@@ -131,7 +135,6 @@ def test_print_packages_if_verbose(upload_settings, caplog):
     }
 
     upload_settings.verbose = True
-    caplog.set_level(logging.INFO, logger="twine")
 
     result = upload.upload(upload_settings, dists_to_upload)
 
@@ -188,10 +191,8 @@ def test_success_when_gpg_is_run(upload_settings, stub_repository, monkeypatch):
 @pytest.mark.parametrize("verbose", [False, True])
 def test_exception_for_http_status(verbose, upload_settings, stub_response, caplog):
     upload_settings.verbose = verbose
-    if verbose:
-        caplog.set_level(logging.INFO, logger="twine")
-    else:
-        caplog.set_level(logging.WARNING, logger="twine")
+    log_level = logging.INFO if verbose else logging.WARNING
+    caplog.set_level(log_level, logger="twine")
 
     stub_response.is_redirect = False
     stub_response.status_code = 403

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
+
 import os.path
 import textwrap
 
@@ -273,7 +273,12 @@ def test_check_status_code_for_deprecated_pypi_url(repo_url):
 @pytest.mark.parametrize(
     "repo_url", ["https://pypi.python.org", "https://testpypi.python.org"],
 )
-def test_check_status_code_for_missing_status_code(caplog, repo_url):
+@pytest.mark.parametrize(
+    "verbose", [True, False],
+)
+def test_check_status_code_for_missing_status_code(
+    capsys, repo_url, verbose, make_settings
+):
     """Print HTTP errors based on verbosity level."""
     response = pretend.stub(
         status_code=403,
@@ -282,22 +287,17 @@ def test_check_status_code_for_missing_status_code(caplog, repo_url):
         text="Forbidden",
     )
 
-    caplog.set_level(logging.INFO, logger="twine")
+    make_settings(verbose=verbose)
 
     with pytest.raises(requests.HTTPError):
-        utils.check_status_code(response, True)
+        utils.check_status_code(response, verbose)
 
-    # Different messages are printed based on the verbose level
-    captured = caplog.text
-    assert "Content received from server:\nForbidden\n" in captured
+    captured = capsys.readouterr()
 
-    caplog.set_level(logging.WARNING, logger="twine")
-
-    with pytest.raises(requests.HTTPError):
-        utils.check_status_code(response, False)
-
-    captured = caplog.text
-    assert "NOTE: Try --verbose to see response content.\n" in captured
+    if verbose:
+        assert captured.out == "Content received from server:\nForbidden\n"
+    else:
+        assert captured.out == "NOTE: Try --verbose to see response content.\n"
 
 
 @pytest.mark.parametrize(

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -23,11 +23,10 @@ __all__ = (
 )
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
-
 import sys
 
 if sys.version_info[:2] >= (3, 8):
-    import importlib.metadata as importlib_metadata
+    from importlib import metadata as importlib_metadata
 else:
     import importlib_metadata
 

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -23,10 +23,11 @@ __all__ = (
 )
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
+
 import sys
 
 if sys.version_info[:2] >= (3, 8):
-    import importlib.metadata as importlib_metadata
+    from importlib import metadata as importlib_metadata
 else:
     import importlib_metadata
 

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -26,7 +26,7 @@ __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 import sys
 
 if sys.version_info[:2] >= (3, 8):
-    from importlib import metadata as importlib_metadata
+    import importlib.metadata as importlib_metadata
 else:
     import importlib_metadata
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -26,7 +26,7 @@ from twine import package as package_file
 from twine import settings
 from twine import utils
 
-logger = logging.getLogger("twine")
+logger = logging.getLogger(__name__)
 
 
 def skip_upload(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import logging
 import os.path
 from typing import Dict
 from typing import List
@@ -24,6 +25,8 @@ from twine import exceptions
 from twine import package as package_file
 from twine import settings
 from twine import utils
+
+logger = logging.getLogger("twine")
 
 
 def skip_upload(
@@ -63,11 +66,10 @@ def _make_package(
     elif upload_settings.sign:
         package.sign(upload_settings.sign_with, upload_settings.identity)
 
-    if upload_settings.verbose:
-        file_size = utils.get_file_size(package.filename)
-        print(f"  {package.filename} ({file_size})")
-        if package.gpg_signature:
-            print(f"  Signed with {package.signed_filename}")
+    file_size = utils.get_file_size(package.filename)
+    logger.info(f"  {package.filename} ({file_size})")
+    if package.gpg_signature:
+        logger.info(f"  Signed with {package.signed_filename}")
 
     return package
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -26,13 +26,10 @@ from twine import utils
 
 
 def _setup_logging(verbose: bool) -> None:
-    """Initialize a logger based on verbosity available throughout twine."""
-    logger = logging.getLogger("twine")
-    log_level = logging.INFO if verbose else logging.WARNING
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(log_level)
-    logger.addHandler(handler)
-    logger.setLevel(log_level)
+    """Initialize a logger based on the --verbose option."""
+    root_logger = logging.getLogger("twine")
+    root_logger.addHandler(logging.StreamHandler(sys.stdout))
+    root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
 
 class Settings:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -25,13 +25,6 @@ from twine import repository
 from twine import utils
 
 
-def _setup_logging(verbose: bool) -> None:
-    """Initialize a logger based on the --verbose option."""
-    root_logger = logging.getLogger("twine")
-    root_logger.addHandler(logging.StreamHandler(sys.stdout))
-    root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
-
-
 class Settings:
     """Object that manages the configuration for Twine.
 
@@ -130,7 +123,6 @@ class Settings:
         self.config_file = config_file
         self.comment = comment
         self.verbose = verbose
-        _setup_logging(verbose)
         self.disable_progress_bar = disable_progress_bar
         self.skip_existing = skip_existing
         self._handle_repository_options(
@@ -157,6 +149,18 @@ class Settings:
 
         # Workaround for https://github.com/python/mypy/issues/5858
         return cast(Optional[str], self.auth.password)
+
+    @property
+    def verbose(self) -> bool:
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, verbose: bool) -> None:
+        """Initialize a logger based on the --verbose option."""
+        self._verbose = verbose
+        root_logger = logging.getLogger("twine")
+        root_logger.addHandler(logging.StreamHandler(sys.stdout))
+        root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     @staticmethod
     def register_argparse_arguments(parser: argparse.ArgumentParser) -> None:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import logging
+import sys
 from typing import Any
 from typing import Optional
 from typing import cast
@@ -21,6 +23,16 @@ from twine import auth
 from twine import exceptions
 from twine import repository
 from twine import utils
+
+
+def _setup_logging(verbose: bool) -> None:
+    """Initialize a logger based on verbosity available throughout twine."""
+    logger = logging.getLogger("twine")
+    log_level = logging.INFO if verbose else logging.WARNING
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    logger.addHandler(handler)
+    logger.setLevel(log_level)
 
 
 class Settings:
@@ -121,6 +133,7 @@ class Settings:
         self.config_file = config_file
         self.comment = comment
         self.verbose = verbose
+        _setup_logging(verbose)
         self.disable_progress_bar = disable_progress_bar
         self.skip_existing = skip_existing
         self._handle_repository_options(

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -46,7 +46,7 @@ TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 # get_userpass_value.
 RepositoryConfig = Dict[str, Optional[str]]
 
-logger = logging.getLogger("twine")
+logger = logging.getLogger(__name__)
 
 
 def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
@@ -203,9 +203,8 @@ def check_status_code(response: requests.Response, verbose: bool) -> None:
         response.raise_for_status()
     except requests.HTTPError as err:
         if response.text:
-            if verbose:
-                logger.info("Content received from server:\n{}".format(response.text))
-            else:
+            logger.info("Content received from server:\n{}".format(response.text))
+            if not verbose:
                 logger.warning("NOTE: Try --verbose to see response content.")
         raise err
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -15,6 +15,7 @@ import argparse
 import collections
 import configparser
 import functools
+import logging
 import os
 import os.path
 from typing import Any
@@ -44,6 +45,8 @@ TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 # requires reworking the username/password handling, probably starting with
 # get_userpass_value.
 RepositoryConfig = Dict[str, Optional[str]]
+
+logger = logging.getLogger("twine")
 
 
 def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
@@ -201,9 +204,9 @@ def check_status_code(response: requests.Response, verbose: bool) -> None:
     except requests.HTTPError as err:
         if response.text:
             if verbose:
-                print("Content received from server:\n{}".format(response.text))
+                logger.info("Content received from server:\n{}".format(response.text))
             else:
-                print("NOTE: Try --verbose to see response content.")
+                logger.warning("NOTE: Try --verbose to see response content.")
         raise err
 
 


### PR DESCRIPTION
As suggested by @bhrutledge in #669, I created a new branch and have replicated existing `verbose` functionality(distribution names, signatures,Etc.) using `stdlib`. The goal is to use this logging system and potentially add multiple levels of verbosity and consequently more detailed output(as mentioned in #381). 