### PR TITLE
Fix issue with distutils index-server name  with blank space 

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,70 @@ def test_get_config_no_distutils(tmpdir):
     }
 
 
+def test_get_config_index_server_with_space(tmpdir):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with open(pypirc, "w") as fp:
+        fp.write(
+            textwrap.dedent(
+                """
+            [distutils]
+            index-servers = pypi
+                foo bar
+
+            [foo bar]
+            username = testuser
+            password = testpassword
+
+            [pypi]
+            username = testuser
+            password = testpassword
+        """
+            )
+        )
+
+    assert utils.get_config(pypirc) == {
+        "foo bar": {"password": "testpassword", "username": "testuser"},
+        "pypi": {
+            "repository": utils.DEFAULT_REPOSITORY,
+            "username": "testuser",
+            "password": "testpassword",
+        },
+    }
+
+
+def test_get_config_multiple_index_servers(tmpdir):
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with open(pypirc, "w") as fp:
+        fp.write(
+            textwrap.dedent(
+                """
+            [distutils]
+            index-servers = pypi
+                foo
+
+            [foo]
+            username = testuser
+            password = testpassword
+
+            [pypi]
+            username = testuser
+            password = testpassword
+        """
+            )
+        )
+
+    assert utils.get_config(pypirc) == {
+        "foo": {"password": "testpassword", "username": "testuser"},
+        "pypi": {
+            "repository": utils.DEFAULT_REPOSITORY,
+            "username": "testuser",
+            "password": "testpassword",
+        },
+    }
+
+
 def test_get_config_no_section(tmpdir):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
@@ -88,7 +152,8 @@ def test_get_config_no_section(tmpdir):
             textwrap.dedent(
                 """
             [distutils]
-            index-servers = pypi foo
+            index-servers = pypi
+                foo
 
             [pypi]
             username = testuser

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -68,7 +68,11 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
         # Get a list of index_servers from the config file
         # format: https://packaging.python.org/specifications/pypirc/
         if parser.has_option("distutils", "index-servers"):
-            index_servers = parser.get("distutils", "index-servers").split()
+            index_servers = [
+                server.strip()
+                for server in parser.get("distutils", "index-servers").split("\n")
+                if server.strip() != ""
+            ]
 
         for key in ["username", "password"]:
             if parser.has_option("server-login", key):


### PR DESCRIPTION
in .pypirc distuitls index-server with spaces in the name is not working 
eg: 
```
            [distutils]
            index-servers = foo bar
            [foo bar]
            username = testuser
            password = testpassword
```
gives an error: 

```
InvalidConfiguration: Missing 'foo bar' section from the configuration file
or not a complete URL in --repository-url.
Maybe you have an out-dated '~/.pypirc' format?
more info: https://packaging.python.org/specifications/pypirc/
```
As per [distutils doc](https://docs.python.org/3.3/distutils/packageindex.html#the-pypirc-file)

>   the distutils section defines a index-servers variable that lists the name of all sections describing a repository.

in the `twine.utuls.py` the index-server is split on '' index name with spaces in it is considered as two indexes. multiple indexes should be listed on newline.  https://github.com/pypa/twine/blob/9f76951bcfef646aeb8911de08c84947d8c60205/twine/utils.py#L72-L75 

instead it should be split on newline as done in  `distutls.config` https://github.com/python/cpython/blob/bbceef6851895135c80e588a55854c1afab46499/Lib/distutils/config.py#L60-L63
```python
                index_servers = config.get('distutils', 'index-servers')
                _servers = [server.strip() for server in
                            index_servers.split('\n')
                            if server.strip() != '']