### PR TITLE
Log where upload configuration is being loaded from

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -289,11 +289,10 @@ def test_check_status_code_for_missing_status_code(capsys, repo_url):
     captured = capsys.readouterr()
     assert captured.out == "Content received from server:\nForbidden\n"
 
-    with pytest.raises(requests.HTTPError):
-        utils.check_status_code(response, False)
-
-    captured = capsys.readouterr()
-    assert captured.out == "NOTE: Try --verbose to see response content.\n"
+    if verbose:
+        assert "Content received from server:\nForbidden\n" in captured.out
+    else:
+        assert captured.out == "NOTE: Try --verbose to see response content.\n"
 
 
 @pytest.mark.parametrize(

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -61,6 +61,8 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
+    logger.info("Config Location: " + path)
+
     # Parse the rc file
     if os.path.isfile(path):
         parser.read(path)


### PR DESCRIPTION
As mentioned in #381, we now log where the upload configuration is being loaded from(see attached image). 

Additionally, I have the rest of the functionality, other than logging credential setting behavior, completed. @bhrutledge would one PR work for all of them or would you prefer individual PRs for each item in the checklist(like this PR). 

Edit:
I added code to the same branch as the last PR which is why there are 7 commits.
