### PR TITLE
Logged config location

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -68,6 +68,23 @@ def test_setup_logging(verbose, log_level):
     assert logger.level == log_level
 
 
+@pytest.mark.parametrize(
+    "verbose", [True, False],
+)
+def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
+    """Log the location of the .pypirc config used by the user."""
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    make_settings(verbose=verbose)
+
+    captured = capsys.readouterr()
+
+    if verbose:
+        assert captured.out == f"Using configuration from {pypirc}\n"
+    else:
+        assert captured.out == ""
+
+
 def test_identity_requires_sign():
     """Raise an exception when user provides identity but doesn't require sigining."""
     with pytest.raises(exceptions.InvalidSigningConfiguration):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -71,8 +71,8 @@ def test_setup_logging(verbose, log_level):
 @pytest.mark.parametrize(
     "verbose", [True, False],
 )
-def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
-    """Log the location of the .pypirc config used by the user."""
+def test_print_config_path_if_verbose(tmpdir, capsys, make_settings, verbose):
+    """Print the location of the .pypirc config used by the user."""
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     make_settings(verbose=verbose)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,6 +50,7 @@ def test_get_config(tmpdir):
         },
     }
 
+
 @pytest.mark.parametrize(
     "verbose", [True, False],
 )
@@ -57,16 +58,14 @@ def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
     """Log the location of the .pypirc config used by the user."""
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
-    with capsys.disabled():
-        make_settings(verbose=verbose)
-
-    utils.get_config(pypirc)
+    make_settings(verbose=verbose)
 
     captured = capsys.readouterr()
     if verbose:
         assert captured.out == f"Using configuration from {pypirc}\n"
     else:
         assert captured.out == ""
+
 
 def test_get_config_no_distutils(tmpdir):
     """Upload by default to PyPI if an index server is not set in .pypirc."""
@@ -304,8 +303,7 @@ def test_check_status_code_for_missing_status_code(
         text="Forbidden",
     )
 
-    with capsys.disabled():
-        make_settings(verbose=verbose)
+    make_settings(verbose=verbose)
 
     with pytest.raises(requests.HTTPError):
         utils.check_status_code(response, verbose)
@@ -313,9 +311,9 @@ def test_check_status_code_for_missing_status_code(
     captured = capsys.readouterr()
 
     if verbose:
-        assert captured.out == "Content received from server:\nForbidden\n"
+        assert captured.out.count("Content received from server:\nForbidden\n") == 1
     else:
-        assert captured.out == "NOTE: Try --verbose to see response content.\n"
+        assert captured.out.count("NOTE: Try --verbose to see response content.\n") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,6 +50,23 @@ def test_get_config(tmpdir):
         },
     }
 
+@pytest.mark.parametrize(
+    "verbose", [True, False],
+)
+def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
+    """Log the location of the .pypirc config used by the user."""
+    pypirc = os.path.join(str(tmpdir), ".pypirc")
+
+    with capsys.disabled():
+        make_settings(verbose=verbose)
+
+    utils.get_config(pypirc)
+
+    captured = capsys.readouterr()
+    if verbose:
+        assert captured.out == f"Using configuration from {pypirc}\n"
+    else:
+        assert captured.out == ""
 
 def test_get_config_no_distutils(tmpdir):
     """Upload by default to PyPI if an index server is not set in .pypirc."""
@@ -287,7 +304,8 @@ def test_check_status_code_for_missing_status_code(
         text="Forbidden",
     )
 
-    make_settings(verbose=verbose)
+    with capsys.disabled():
+        make_settings(verbose=verbose)
 
     with pytest.raises(requests.HTTPError):
         utils.check_status_code(response, verbose)
@@ -295,7 +313,7 @@ def test_check_status_code_for_missing_status_code(
     captured = capsys.readouterr()
 
     if verbose:
-        assert "Content received from server:\nForbidden\n" in captured.out
+        assert captured.out == "Content received from server:\nForbidden\n"
     else:
         assert captured.out == "NOTE: Try --verbose to see response content.\n"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,22 +51,6 @@ def test_get_config(tmpdir):
     }
 
 
-# @pytest.mark.parametrize(
-#     "verbose", [True, False],
-# )
-# def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
-#     """Log the location of the .pypirc config used by the user."""
-#     pypirc = os.path.join(str(tmpdir), ".pypirc")
-
-#     make_settings(verbose=verbose)
-
-#     captured = capsys.readouterr()
-#     if verbose:
-#         assert captured.out == f"Using configuration from {pypirc}\n"
-#     else:
-#         assert captured.out == ""
-
-
 def test_get_config_no_distutils(tmpdir):
     """Upload by default to PyPI if an index server is not set in .pypirc."""
     pypirc = os.path.join(str(tmpdir), ".pypirc")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -295,7 +295,7 @@ def test_check_status_code_for_missing_status_code(
     captured = capsys.readouterr()
 
     if verbose:
-        assert captured.out == "Content received from server:\nForbidden\n"
+        assert "Content received from server:\nForbidden\n" in captured.out
     else:
         assert captured.out == "NOTE: Try --verbose to see response content.\n"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,20 +51,20 @@ def test_get_config(tmpdir):
     }
 
 
-@pytest.mark.parametrize(
-    "verbose", [True, False],
-)
-def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
-    """Log the location of the .pypirc config used by the user."""
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+# @pytest.mark.parametrize(
+#     "verbose", [True, False],
+# )
+# def test_get_config_log_location(tmpdir, capsys, make_settings, verbose):
+#     """Log the location of the .pypirc config used by the user."""
+#     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
-    make_settings(verbose=verbose)
+#     make_settings(verbose=verbose)
 
-    captured = capsys.readouterr()
-    if verbose:
-        assert captured.out == f"Using configuration from {pypirc}\n"
-    else:
-        assert captured.out == ""
+#     captured = capsys.readouterr()
+#     if verbose:
+#         assert captured.out == f"Using configuration from {pypirc}\n"
+#     else:
+#         assert captured.out == ""
 
 
 def test_get_config_no_distutils(tmpdir):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -64,7 +64,7 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
-    logger.info(f"Config Location: {path}")
+    logger.info(f"Using configuration from {path}")
 
     # Parse the rc file
     if os.path.isfile(path):

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -64,6 +64,8 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
     # Expand user strings in the path
     path = os.path.expanduser(path)
 
+    logger.info(f"Config Location: {path}")
+
     # Parse the rc file
     if os.path.isfile(path):
         parser.read(path)


### PR DESCRIPTION
Continuing #674 on a new branch/PR. I used f-strings to log the config location instead of concatenation to stay consistent as advised by @sigmavirus24. 