### PR TITLE
Fix client cert password bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Brian Rutledge <bhrutledge@gmail.com>
 Peter Stensmyr <peter.stensmyr@gmail.com> (http://www.peterstensmyr.com)
 Felipe Mulinari Rocha Campos <felipecampos@google.com>
 Devesh Kumar Singh <deveshkusingh@gmail.com>
+Yesha Maggi <yesha.maggic@gmail.com>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,14 +74,6 @@ def test_identity_requires_sign():
         settings.Settings(sign=False, identity="fakeid")
 
 
-def test_password_not_required_if_client_cert(entered_password):
-    """Don't set password when only client_cert is provided."""
-    test_client_cert = "/random/path"
-    settings_obj = settings.Settings(username="fakeuser", client_cert=test_client_cert)
-    assert not settings_obj.password
-    assert settings_obj.client_cert == test_client_cert
-
-
 @pytest.mark.parametrize("client_cert", [None, ""])
 def test_password_is_required_if_no_client_cert(client_cert, entered_password):
     """Set password when client_cert is not provided."""
@@ -89,14 +81,30 @@ def test_password_is_required_if_no_client_cert(client_cert, entered_password):
     assert settings_obj.password == "entered pw"
 
 
-def test_client_cert_is_set_and_password_not_if_both_given(entered_password):
+def test_client_cert_and_password_both_set_if_given():
     """Set password and client_cert when both are provided."""
     client_cert = "/random/path"
     settings_obj = settings.Settings(
         username="fakeuser", password="anything", client_cert=client_cert
     )
-    assert not settings_obj.password
+    assert settings_obj.password == "anything"
     assert settings_obj.client_cert == client_cert
+
+
+def test_password_required_if_no_client_cert_and_non_interactive():
+    """Raise exception if no password or client_cert when non interactive."""
+    settings_obj = settings.Settings(username="fakeuser", non_interactive=True)
+    with pytest.raises(exceptions.NonInteractive):
+        settings_obj.password
+
+
+def test_no_password_prompt_if_client_cert_and_non_interactive(entered_password):
+    """Don't prompt for password when client_cert is provided and non interactive."""
+    client_cert = "/random/path"
+    settings_obj = settings.Settings(
+        username="fakeuser", client_cert=client_cert, non_interactive=True
+    )
+    assert not settings_obj.password
 
 
 class TestArgumentParsing:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -145,7 +145,10 @@ class Settings:
     @property
     def password(self) -> Optional[str]:
         if self.client_cert:
-            return None
+            try:
+                return cast(Optional[str], self.auth.password)
+            except exceptions.NonInteractive:
+                return None
 
         # Workaround for https://github.com/python/mypy/issues/5858
         return cast(Optional[str], self.auth.password)


### PR DESCRIPTION
This does change what flags would be required for a specific use-case, but there is better use-case coverage with this change.

- `twine --client-cert` with no password will now prompt unless `--non-interactive` is set

Fixes #579 