### PR TITLE
Update formatters

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,10 +1,6 @@
 [settings]
-# NOTE: Consider single_line_exclusions=typing in next version of isort
+profile=black
 force_single_line=True
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+single_line_exclusions=typing
 default_section=THIRDPARTY
 known_first_party=twine,helpers

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -25,7 +25,8 @@ class TestWarningStream:
     def setup(self):
         self.stream = check._WarningStream()
         self.stream.output = pretend.stub(
-            write=pretend.call_recorder(lambda a: None), getvalue=lambda: "result",
+            write=pretend.call_recorder(lambda a: None),
+            getvalue=lambda: "result",
         )
 
     def test_write_match(self):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -49,7 +49,9 @@ def test_exception_for_redirect(register_settings):
     redirect_url = "https://malicious.website.org/danger"
 
     stub_response = pretend.stub(
-        is_redirect=True, status_code=301, headers={"location": redirect_url},
+        is_redirect=True,
+        status_code=301,
+        headers={"location": redirect_url},
     )
 
     stub_repository = pretend.stub(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -127,7 +127,9 @@ def test_package_is_uploaded_with_releases_using_cache(default_repo):
     """Return True when the package is in the releases cache."""
     default_repo._releases_json_data = {"fake": {"0.1": [{"filename": "fake.whl"}]}}
     package = pretend.stub(
-        safe_name="fake", basefilename="fake.whl", metadata=pretend.stub(version="0.1"),
+        safe_name="fake",
+        basefilename="fake.whl",
+        metadata=pretend.stub(version="0.1"),
     )
 
     assert default_repo.package_is_uploaded(package) is True
@@ -143,7 +145,9 @@ def test_package_is_uploaded_with_releases_not_using_cache(default_repo):
         ),
     )
     package = pretend.stub(
-        safe_name="fake", basefilename="fake.whl", metadata=pretend.stub(version="0.1"),
+        safe_name="fake",
+        basefilename="fake.whl",
+        metadata=pretend.stub(version="0.1"),
     )
 
     assert default_repo.package_is_uploaded(package, bypass_cache=True) is True
@@ -159,7 +163,9 @@ def test_package_is_uploaded_different_filenames(default_repo):
         ),
     )
     package = pretend.stub(
-        safe_name="fake", basefilename="foo.whl", metadata=pretend.stub(version="0.1"),
+        safe_name="fake",
+        basefilename="foo.whl",
+        metadata=pretend.stub(version="0.1"),
     )
 
     assert default_repo.package_is_uploaded(package) is False
@@ -313,7 +319,9 @@ def test_release_urls(package_meta, repository_url, release_urls):
     ]
 
     repo = repository.Repository(
-        repository_url=repository_url, username="username", password="password",
+        repository_url=repository_url,
+        username="username",
+        password="password",
     )
 
     assert repo.release_urls(packages) == release_urls

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -69,7 +69,8 @@ def test_setup_logging(verbose, log_level):
 
 
 @pytest.mark.parametrize(
-    "verbose", [True, False],
+    "verbose",
+    [True, False],
 )
 def test_print_config_path_if_verbose(tmpdir, capsys, make_settings, verbose):
     """Print the location of the .pypirc config used by the user."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -196,7 +196,8 @@ def test_get_repository_config_with_invalid_url(tmpdir, repo_url, message):
     pypirc = os.path.join(str(tmpdir), ".pypirc")
 
     with pytest.raises(
-        exceptions.UnreachableRepositoryURLDetected, match=message,
+        exceptions.UnreachableRepositoryURLDetected,
+        match=message,
     ):
         utils.get_repository_from_config(pypirc, "pypi", repo_url)
 
@@ -253,7 +254,10 @@ def test_default_to_environment_action(env_name, default, environ, expected):
     dest = "example"
     with helpers.set_env(**environ):
         action = utils.EnvironmentDefault(
-            env=env_name, default=default, option_strings=option_strings, dest=dest,
+            env=env_name,
+            default=default,
+            option_strings=option_strings,
+            dest=dest,
         )
     assert action.env == env_name
     assert action.default == expected
@@ -271,10 +275,12 @@ def test_check_status_code_for_deprecated_pypi_url(repo_url):
 
 
 @pytest.mark.parametrize(
-    "repo_url", ["https://pypi.python.org", "https://testpypi.python.org"],
+    "repo_url",
+    ["https://pypi.python.org", "https://testpypi.python.org"],
 )
 @pytest.mark.parametrize(
-    "verbose", [True, False],
+    "verbose",
+    [True, False],
 )
 def test_check_status_code_for_missing_status_code(
     capsys, repo_url, verbose, make_settings

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     isort
     black
 commands =
-    isort --recursive twine/ tests/
+    isort twine/ tests/
     black twine/ tests/
 
 [testenv:lint]
@@ -55,7 +55,7 @@ deps =
     flake8
     flake8-docstrings
 commands =
-    isort --check-only --diff --recursive twine/ tests/
+    isort --check-only --diff twine/ tests/
     black --check --diff twine/ tests/
     flake8 twine/ tests/
 

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -1,10 +1,7 @@
 import functools
 import getpass
 import warnings
-from typing import Callable
-from typing import Optional
-from typing import Type
-from typing import cast
+from typing import Callable, Optional, Type, cast
 
 import keyring
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -69,10 +69,13 @@ def dispatch(argv: List[str]) -> Any:
         help="disable colored output",
     )
     parser.add_argument(
-        "command", choices=registered_commands.keys(),
+        "command",
+        choices=registered_commands.keys(),
     )
     parser.add_argument(
-        "args", help=argparse.SUPPRESS, nargs=argparse.REMAINDER,
+        "args",
+        help=argparse.SUPPRESS,
+        nargs=argparse.REMAINDER,
     )
 
     parser.parse_args(argv, namespace=args)

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Tuple
+from typing import Any, Dict, List, Tuple
 
 import pkg_resources
 import pkginfo

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -17,11 +17,7 @@ import io
 import re
 import sys
 import textwrap
-from typing import IO
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import cast
+from typing import IO, List, Optional, Tuple, cast
 
 import readme_renderer.rst
 

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 import argparse
 import os.path
-from typing import List
-from typing import cast
+from typing import List, cast
 
 from twine import exceptions
 from twine import package as package_file

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -38,7 +38,8 @@ def register(register_settings: settings.Settings, package: str) -> None:
 
     if resp.is_redirect:
         raise exceptions.RedirectDetected.from_args(
-            repository_url, resp.headers["location"],
+            repository_url,
+            resp.headers["location"],
         )
 
     resp.raise_for_status()

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -14,9 +14,7 @@
 import argparse
 import logging
 import os.path
-from typing import Dict
-from typing import List
-from typing import cast
+from typing import Dict, List, cast
 
 import requests
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -111,7 +111,8 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         # redirects as well.
         if resp.is_redirect:
             raise exceptions.RedirectDetected.from_args(
-                repository_url, resp.headers["location"],
+                repository_url,
+                resp.headers["location"],
             )
 
         if skip_upload(resp, upload_settings.skip_existing, package):

--- a/twine/package.py
+++ b/twine/package.py
@@ -265,5 +265,7 @@ class HashManager:
     def hexdigest(self) -> Hexdigest:
         """Return the hexdigest for the file."""
         return Hexdigest(
-            self._md5_hexdigest(), self._sha2_hexdigest(), self._blake_hexdigest(),
+            self._md5_hexdigest(),
+            self._sha2_hexdigest(),
+            self._blake_hexdigest(),
         )

--- a/twine/package.py
+++ b/twine/package.py
@@ -15,12 +15,7 @@ import hashlib
 import io
 import os
 import subprocess
-from typing import Dict
-from typing import NamedTuple
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Union
+from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
 import pkg_resources
 import pkginfo

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import cast
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 import requests
 import requests_toolbelt

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -16,10 +16,7 @@ import argparse
 import contextlib
 import logging
 import sys
-from typing import Any
-from typing import ContextManager
-from typing import Optional
-from typing import cast
+from typing import Any, ContextManager, Optional, cast
 
 from twine import auth
 from twine import exceptions

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -128,15 +128,19 @@ class Settings:
         self.disable_progress_bar = disable_progress_bar
         self.skip_existing = skip_existing
         self._handle_repository_options(
-            repository_name=repository_name, repository_url=repository_url,
+            repository_name=repository_name,
+            repository_url=repository_url,
         )
         self._handle_package_signing(
-            sign=sign, sign_with=sign_with, identity=identity,
+            sign=sign,
+            sign_with=sign_with,
+            identity=identity,
         )
         # _handle_certificates relies on the parsed repository config
         self._handle_certificates(cacert, client_cert)
         self.auth = auth.Resolver.choose(not non_interactive)(
-            self.repository_config, auth.CredentialInput(username, password),
+            self.repository_config,
+            auth.CredentialInput(username, password),
         )
 
     @property
@@ -204,7 +208,9 @@ class Settings:
             help="GPG program used to sign uploads (default: %(default)s).",
         )
         parser.add_argument(
-            "-i", "--identity", help="GPG identity used to sign files.",
+            "-i",
+            "--identity",
+            help="GPG identity used to sign files.",
         )
         parser.add_argument(
             "-u",
@@ -306,7 +312,9 @@ class Settings:
         self, repository_name: str, repository_url: Optional[str]
     ) -> None:
         self.repository_config = utils.get_repository_from_config(
-            self.config_file, repository_name, repository_url,
+            self.config_file,
+            repository_name,
+            repository_url,
         )
         self.repository_config["repository"] = utils.normalize_repository_url(
             cast(str, self.repository_config["repository"]),

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -18,13 +18,7 @@ import functools
 import logging
 import os
 import os.path
-from typing import Any
-from typing import Callable
-from typing import DefaultDict
-from typing import Dict
-from typing import Optional
-from typing import Sequence
-from typing import Union
+from typing import Any, Callable, DefaultDict, Dict, Optional, Sequence, Union
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -15,8 +15,7 @@ import io
 import os
 import re
 import zipfile
-from typing import List
-from typing import Optional
+from typing import List, Optional
 
 from pkginfo import distribution
 


### PR DESCRIPTION
There's a [new release of black](https://github.com/psf/black/releases), which changes/fixes some behavior related to trailing commas.

Also took the opportunity to use new features of isort 5, namely an explicit `black` profile, and supporting exceptions to the single-line style for `typing`.