### PR TITLE
Pin pytest until rerunfailures is updated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = lint,types,py{36,37,38},docs
 [testenv]
 deps =
     pretend
-    pytest
+    pytest<6.1 # https://github.com/pytest-dev/pytest-rerunfailures/issues/128
     pytest-cov
     pytest-socket
     pytest-rerunfailures


### PR DESCRIPTION
Addressing the [CI failures](https://travis-ci.com/github/pypa/twine/jobs/391402377):

```
  File "/home/travis/build/pypa/twine/.tox/python/lib/python3.8/site-packages/pytest_rerunfailures.py", line 7, in <module>
    from _pytest.resultlog import ResultLog
ModuleNotFoundError: No module named '_pytest.resultlog'
```

https://github.com/pytest-dev/pytest-rerunfailures/issues/128
https://docs.pytest.org/en/stable/changelog.html#pytest-6-1-0-2020-09-26

And yes, I'm aware of the "irony" of a change meant to mitigate test failures causing more test failures.