### PR TITLE
Use separate environmment for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,10 @@
 name: Integration
 
 on:
+  # TODO: Remove this after it runs successfully
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,6 @@
 name: Integration
 
 on:
-  # TODO: Remove this after it runs successfully
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,23 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * *'  # daily
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel tox
+      - name: Run tests
+        run: python -m tox -e integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Main
 
 on: [push, pull_request]
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -22,7 +22,7 @@ Python. For example:
 .. code-block:: console
 
     cd /path/to/your/local/twine
-    python3.8 -m venv venv
+    python3.6 -m venv venv
     source venv/bin/activate
 
 Then, run the following command:
@@ -107,13 +107,6 @@ To pass options to ``pytest``, e.g. the name of a test, run:
 
     tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
-You can also set the ``PYTEST_ADDOPTS`` environment variable to use the same
-options on every test run. For example, to always skip integration tests:
-
-.. code-block:: console
-
-    export PYTEST_ADDOPTS='-k "not integration"'
-
 Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
 To run the tests against a specific version, e.g. Python 3.6, you will need it
 installed on your machine. Then, run:
@@ -121,6 +114,12 @@ installed on your machine. Then, run:
 .. code-block:: console
 
     tox -e py36
+
+To run the "integration" tests of uploading to real package indexes, run:
+
+.. code-block:: console
+
+    tox -e integration
 
 To run the tests against all supported Python versions, check code style,
 and build the documentation, run:

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,3 @@ filterwarnings=
 addopts =
 	--cov=twine --cov-context=test --cov-report=
 	--disable-socket
-	-r aR

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = lint,types,py{36,37,38},docs,integration
+envlist = lint,types,py{36,37,38},integration,docs
 
 [testenv]
 deps =
@@ -45,7 +45,7 @@ deps =
     sphinx-autobuild
 commands =
     sphinx-autobuild -W -b html -d {envtmpdir}/doctrees \
-        {posargs:-H 127.0.0.1} \
+        {posargs:--host 127.0.0.1} \
         docs docs/_build/html
 
 [testenv:format]

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,31 @@
 [tox]
 minversion = 2.4
-envlist = lint,types,py{36,37,38},docs
+envlist = lint,types,py{36,37,38},docs,integration
 
 [testenv]
 deps =
     pretend
-    pytest<6.1 # https://github.com/pytest-dev/pytest-rerunfailures/issues/128
+    pytest
     pytest-cov
     pytest-socket
-    pytest-rerunfailures
-    jaraco.envs
-    portend
-    pytest-services
-    munch
-    colorama
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pytest {posargs:--cov-report term-missing --cov-report html tests}
+    pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html tests}
+
+[testenv:integration]
+deps =
+    {[testenv]deps}
+    jaraco.envs
+    munch
+    portend
+    pytest-rerunfailures
+    pytest-services
+passenv =
+    PYTEST_ADDOPTS
+commands =
+    # Skipping coverage because that should be handled by the other tests
+    pytest -r aR --no-cov tests/test_integration.py
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Towards <https://github.com/pypa/twine/issues/684>.

## Changes

- Add `testenv:integration` to `tox.ini`

- Add a new GH Action for integration tests, running daily and on push to `master`

## TODO

- [x] Remove `on.pull_request` from `integration.yml` once the job is passing and approved

- [x] Update [testing docs](https://twine.readthedocs.io/en/latest/contributing.html#testing)

