### PR TITLE
Move more Travis jobs to GitHub Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel tox
+        run: python -m pip install tox
       - name: Run tests
         run: python -m tox -e integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install dependencies
@@ -25,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -43,8 +41,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -57,8 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Main
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'  # daily
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,17 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel tox
       - name: Run tests
         run: python -m tox -e py  # Use the version of Python in $PATH
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel tox
+      - name: Build docs
+        run: python -m tox -e docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel tox
       - name: Run tests
-        run: python -m tox -e py  # Use the version of Python in $PATH
+        run: python -m tox -e py -- --cov-report xml
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          name: ${{ matrix.python }} - ${{ matrix.platform }}
+          fail_ci_if_error: true
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel tox
+        run: python -m pip install tox
       - name: Run linting
         run: python -m tox -e lint
 
@@ -32,8 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel tox
+        run: python -m pip install tox
       - name: Run type-checking
         run: python -m tox -e types
 
@@ -49,8 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel tox
+        run: python -m pip install tox
       - name: Run tests
         run: python -m tox -e py -- --cov-report xml
       - uses: codecov/codecov-action@v1
@@ -67,7 +64,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel tox
+        run: python -m pip install tox
       - name: Build docs
         run: python -m tox -e docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,23 @@ jobs:
       - name: Run linting
         run: python -m tox -e lint
 
+  types:
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel tox
+      - name: Run type-checking
+        run: python -m tox -e types
+
   test:
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Main
 on: [push, pull_request]
 
 jobs:
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -11,8 +12,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install tox
-        run: python -m pip install tox
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel tox
       - name: Run linting
         run: python -m tox -e lint
 
@@ -28,8 +30,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: "Install dependencies"
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel tox
       - name: Run tests
-        run: python -m tox -e py  # Run tox using the version of Python in `PATH`
+        run: python -m tox -e py  # Use the version of Python in $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
       after_script: skip
 
 install:
-  - pip install tox codecov
+  - pip install tox
 
 script:
   - tox
-
-after_script:
-  - codecov --env TRAVIS_OS_NAME,TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ matrix:
   include:
     - python: &latest_py3 3.8
 
-    - python: 3.7
-      name: Making sure that docs build is healthy
-      env:
-        TOXENV: docs
-
     - stage: deploy
       if: tag IS present
       python: *latest_py3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,7 @@ matrix:
 
   include:
     - python: &latest_py3 3.8
-    - python: 3.7
     - python: &oldest_py3 3.6
-
-    - python: 3.7
-      name: Linting code style
-      env:
-        TOXENV: lint
 
     - python: *latest_py3
       name: Checking type annotations (latest Python)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,6 @@ matrix:
 
   include:
     - python: &latest_py3 3.8
-    - python: &oldest_py3 3.6
-
-    - python: *latest_py3
-      name: Checking type annotations (latest Python)
-      env:
-        TOXENV: types
-    - python: *oldest_py3
-      name: Checking type annotations (oldest Python)
-      env:
-        TOXENV: types
 
     - python: 3.7
       name: Making sure that docs build is healthy

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@
 .. image:: https://img.shields.io/readthedocs/twine
     :target: https://twine.readthedocs.io
 
-.. image:: https://img.shields.io/travis/com/pypa/twine
-    :target: https://travis-ci.com/github/pypa/twine
+.. image:: https://img.shields.io/github/workflow/status/pypa/twine/Main
+    :target: https://github.com/pypa/twine/actions
 
 .. image:: https://img.shields.io/codecov/c/github/pypa/twine
     :target: https://codecov.io/gh/pypa/twine

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -107,9 +107,9 @@ To pass options to ``pytest``, e.g. the name of a test, run:
 
     tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
-Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `Travis`_.
-To run the tests against a specific version, e.g. Python 3.6, you will need it
-installed on your machine. Then, run:
+Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `GitHub
+Actions`_. To run the tests against a specific version, e.g. Python 3.6, you
+will need it installed on your machine. Then, run:
 
 .. code-block:: console
 
@@ -183,9 +183,7 @@ Adding a maintainer
 
 A checklist for adding a new maintainer to the project.
 
-#. Add them as a Member in the GitHub repo settings. (This will also
-   give them privileges on the `Travis CI project
-   <https://travis-ci.com/github/pypa/twine>`_.)
+#. Add them as a Member in the GitHub repo settings.
 #. Get them Test PyPI and canon PyPI usernames and add them as a
    Maintainer on `our Test PyPI project
    <https://test.pypi.org/manage/project/twine/collaboration/>`_ and
@@ -202,7 +200,7 @@ A checklist for creating, testing, and distributing a new version.
 #. Choose a version number, e.g. ``3.2.0``.
 #. Add a ``:release:`` line to :file:`docs/changelog.rst`.
 #. Commit and open a pull request for review.
-#. Merge the pull request, and ensure the `Travis`_ build passes.
+#. Merge the pull request, and ensure the `GitHub Actions`_ build passes.
 #. Create a new git tag with ``git tag -m "Release v{version}" {version}``.
 #. Push the new tag with ``git push upstream {version}``.
 #. Watch the release in `Travis`_.
@@ -225,6 +223,7 @@ merge into a single tool; see `ongoing discussion
 .. _`virtual environment`: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 .. _`tox`: https://tox.readthedocs.io/
 .. _`pytest`: https://docs.pytest.org/
+.. _`GitHub Actions`: https://github.com/pypa/twine/actions
 .. _`Travis`: https://travis-ci.com/github/pypa/twine
 .. _`isort`: https://timothycrosley.github.io/isort/
 .. _`black`: https://black.readthedocs.io/

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ long_description = file:README.rst
 url = https://twine.readthedocs.io/
 project_urls =
     Packaging tutorial = https://packaging.python.org/tutorials/distributing-packages/
-    Travis CI = https://travis-ci.com/github/pypa/twine
     Twine documentation = https://twine.readthedocs.io/en/latest/
     Twine source = https://github.com/pypa/twine/
 classifiers =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pip list
     pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html tests}
+    pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
 
 [testenv:integration]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
+    pip list
     pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
 
 [testenv:integration]


### PR DESCRIPTION
Towards <https://github.com/pypa/twine/issues/650>.

## Changes

- Remove redundant jobs from Travis

- Move `tox -e types` to main workflow

- Move `tox -e docs` to main workflow

- Update [setup-python](https://github.com/actions/setup-python/releases/tag/v2) action

## TODO

- [x] Update docs to refer to GH Actions instead of Travis
- [x] Move Codecov to `test` job

    WRT to replacing Travis with GH Actions, this seems less impactful than [replacing Codecov](https://github.com/pypa/twine/issues/658).

- [x] Add `on.schedule` to run daily
- [x] ~~DRY out workflows (e.g. `python-version`, "Install dependencies")~~
- [ ] Update "Required" checks    
- Later: Add publishing workflow

