### PR TITLE
Ignore blake2 when not available (e.g. FIPS mode)

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -214,7 +214,7 @@ def test_hash_manager():
     assert hasher.hexdigest() == TWINE_1_5_0_WHEEL_HEXDIGEST
 
 
-def test_fips_hash_manager(monkeypatch):
+def test_fips_hash_manager_md5(monkeypatch):
     """Generate hexdigest without MD5 when hashlib is using FIPS mode."""
     replaced_md5 = pretend.raiser(ValueError("fipsmode"))
     monkeypatch.setattr(package_file.hashlib, "md5", replaced_md5)
@@ -223,6 +223,18 @@ def test_fips_hash_manager(monkeypatch):
     hasher = package_file.HashManager(filename)
     hasher.hash()
     hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(md5=None)
+    assert hasher.hexdigest() == hashes
+
+
+def test_fips_hash_manager_blake2(monkeypatch):
+    """Generate hexdigest without BLAKE2 when hashlib is using FIPS mode."""
+    replaced_blake2b = pretend.raiser(ValueError("fipsmode"))
+    monkeypatch.setattr(package_file.hashlib, "blake2b", replaced_blake2b)
+
+    filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"
+    hasher = package_file.HashManager(filename)
+    hasher.hash()
+    hashes = TWINE_1_5_0_WHEEL_HEXDIGEST._replace(blake2=None)
     assert hasher.hexdigest() == hashes
 
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -220,7 +220,12 @@ class HashManager:
 
         self._sha2_hasher = hashlib.sha256()
 
-        self._blake_hasher = hashlib.blake2b(digest_size=256 // 8)
+        self._blake_hasher = None
+        try:
+            self._blake_hasher = hashlib.blake2b(digest_size=256 // 8)
+        except ValueError:
+            # FIPS mode disables blake2
+            pass
 
     def _md5_update(self, content: bytes) -> None:
         if self._md5_hasher is not None:


### PR DESCRIPTION
A recent update on a Redhat FIPS enabled system results in the following error:

`ValueError: _blake2 is not available in FIPS mode`

blake2 is not FIPS approved.

This PR adds the same handling of blake2 which already exists for md5