### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,10 @@ jobs:
       - name: Run linting
         run: python -m tox -e lint
 
-  # TODO: Add 3.9 when lxml wheels are available:
-  # https://bugs.launchpad.net/lxml/+bug/1899830
   types:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Run linting
         run: python -m tox -e lint
 
+  # TODO: Add 3.9 when lxml wheels are available:
+  # https://bugs.launchpad.net/lxml/+bug/1899830
   types:
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Devesh Kumar Singh <deveshkusingh@gmail.com>
 Yesha Maggi <yesha.maggic@gmail.com>
 Cyril de Catheu <cdecatheu@gmail.com> (https://catheu.tech/)
 Thomas Miedema <thomasmiedema@gmail.com>
+Hugo van Kemenade (https://github.com/hugovk)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -107,9 +107,9 @@ To pass options to ``pytest``, e.g. the name of a test, run:
 
     tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
-Twine is continuously tested against Python 3.6, 3.7, and 3.8 using `GitHub
-Actions`_. To run the tests against a specific version, e.g. Python 3.6, you
-will need it installed on your machine. Then, run:
+Twine is continuously tested against Python 3.6, 3.7, 3.8, and 3.9 using
+`GitHub Actions`_. To run the tests against a specific version, e.g. Python
+3.6, you will need it installed on your machine. Then, run:
 
 .. code-block:: console
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = lint,types,py{36,37,38},integration,docs
+envlist = lint,types,py{36,37,38,39},integration,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Add to tests, Trove classifiers and `docs/contributing.rst`.

Omitted from the `types` test because the lxml dependency isn't yet ready for 3.9.