### PR TITLE
Tweak project_urls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,9 @@ description = Collection of utilities for publishing packages on PyPI
 long_description = file:README.rst
 url = https://twine.readthedocs.io/
 project_urls =
+    Source = https://github.com/pypa/twine/
+    Documentation = https://twine.readthedocs.io/en/latest/
     Packaging tutorial = https://packaging.python.org/tutorials/distributing-packages/
-    Twine documentation = https://twine.readthedocs.io/en/latest/
-    Twine source = https://github.com/pypa/twine/
 classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
"Twine" seemed redundant, and I didn't see any other PyPA projects that followed that pattern.