### PR TITLE
Rely on importlib_metadata 3.6 for nicer protocol.

### DIFF
--- a/changelog/732.feature.rst
+++ b/changelog/732.feature.rst
@@ -1,0 +1,1 @@
+Rely on importlib_metadata 3.6 for nicer entry point processing.

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,7 +23,7 @@ strict_equality = True
 ignore_missing_imports = True
 
 [mypy-importlib_metadata]
-; https://gitlab.com/python-devs/importlib_metadata/-/issues/10
+; https://github.com/python/importlib_metadata/issues/10
 ignore_missing_imports = True
 
 [mypy-keyring]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires=
     requests-toolbelt >= 0.8.0, != 0.9.0
     setuptools >= 0.7.0
     tqdm >= 4.14
-    importlib_metadata; python_version < "3.8"
+    importlib_metadata >= 3.6
     keyring >= 15.1
     rfc3986 >= 1.4.0
     colorama >= 0.4.3

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -24,15 +24,7 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-import sys
-
-if sys.version_info[:2] >= (3, 8):
-    from importlib import metadata as importlib_metadata
-else:
-    # Using `as` to workaround "implicit reexport disabled"
-    # https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport
-    import importlib_metadata as importlib_metadata
-
+import importlib_metadata
 
 metadata = importlib_metadata.metadata("twine")
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,27 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 
 import pkginfo
 import requests
 import requests_toolbelt
 import setuptools
 import tqdm
+from importlib_metadata import entry_points
 
 import twine
 from twine import _installed
-from twine import importlib_metadata
 
 args = argparse.Namespace()
-
-
-def _registered_commands(
-    group: str = "twine.registered_commands",
-) -> Dict[str, importlib_metadata.EntryPoint]:
-    # todo: with python/importlib_metadata#278:
-    # return importlib_metadata.entry_points()[group]
-    return {ep.name: ep for ep in importlib_metadata.entry_points()[group]}
 
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
@@ -52,7 +44,7 @@ def dep_versions() -> str:
 
 
 def dispatch(argv: List[str]) -> Any:
-    registered_commands = _registered_commands()
+    registered_commands = entry_points(group="twine.registered_commands")
     parser = argparse.ArgumentParser(prog="twine")
     parser.add_argument(
         "--version",
@@ -68,7 +60,7 @@ def dispatch(argv: List[str]) -> Any:
     )
     parser.add_argument(
         "command",
-        choices=registered_commands.keys(),
+        choices=registered_commands.names,
     )
     parser.add_argument(
         "args",


### PR DESCRIPTION
Following up on #728, I've spent some time on importlib_metadata working out a new interface that's a lot more amenable to the various use-cases, including this one. As you can see, this new interface creates a much more straightforward usage for Twine.

This change does expand the scope of Python versions that require `importlib_metadata` but it's expected these changes will become available in future Python versions (likely 3.10).