### PR TITLE
Just honor types in dependencies when present

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,44 +17,6 @@ no_implicit_optional = True
 warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
-
-[mypy-colorama]
-; https://github.com/tartley/colorama/issues/206
-ignore_missing_imports = True
-
-[mypy-importlib_metadata]
-; https://gitlab.com/python-devs/importlib_metadata/-/issues/10
-ignore_missing_imports = True
-
-[mypy-keyring]
-; https://github.com/jaraco/keyring/issues/437
-ignore_missing_imports = True
-
-[mypy-pkginfo]
-; https://bugs.launchpad.net/pkginfo/+bug/1876591
-ignore_missing_imports = True
-
-[mypy-requests_toolbelt,requests_toolbelt.*]
-; https://github.com/requests/toolbelt/issues/279
-ignore_missing_imports = True
-
-[mypy-readme_renderer,readme_renderer.*]
-; https://github.com/pypa/readme_renderer/issues/166
-ignore_missing_imports = True
-
-[mypy-rfc3986]
-ignore_missing_imports = True
-
-[mypy-setuptools]
-; https://github.com/python/typeshed/issues/2171
-ignore_missing_imports = True
-
-[mypy-tqdm]
-; https://github.com/tqdm/tqdm/issues/260
-ignore_missing_imports = True
-
-[mypy-urllib3]
-; https://github.com/urllib3/urllib3/issues/867
 ignore_missing_imports = True
 
 [mypy-tests.*]

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,6 @@ commands =
     flake8 twine/ tests/
 
 [testenv:types]
-skip_install = True
 deps =
     mypy
     lxml

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -55,7 +55,7 @@ class Resolver:
 
     def get_username_from_keyring(self) -> Optional[str]:
         try:
-            creds = keyring.get_credential(self.system, None)
+            creds = keyring.get_credential(self.system, None)  # type: ignore
             if creds:
                 return cast(str, creds.username)
         except AttributeError:
@@ -67,7 +67,8 @@ class Resolver:
 
     def get_password_from_keyring(self) -> Optional[str]:
         try:
-            return cast(str, keyring.get_password(self.system, self.username))
+            password = keyring.get_password(self.system, self.username)  # type: ignore
+            return cast(str, password)
         except Exception as exc:
             warnings.warn(str(exc))
         return None

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -78,6 +78,6 @@ def dispatch(argv: List[str]) -> Any:
 
     parser.parse_args(argv, namespace=args)
 
-    main = registered_commands[args.command].load()
+    main = registered_commands[args.command].load()  # type: ignore
 
     return main(args.args)


### PR DESCRIPTION
Fixes #733.

Exposes two failing type checks in keyring usage, suppressed.