### PR TITLE
Fix the "safe_name" attribute of PackageFile for backwards compatibility

### DIFF
--- a/changelog/745.bugfix.rst
+++ b/changelog/745.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression that was causing some namespace packages with dots in them fail to upload to PyPI.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import string
+
 import pretend
 import pytest
 
@@ -108,6 +110,28 @@ def test_package_signed_name_is_correct():
 
     assert package.signed_basefilename == "deprecated-pypirc.asc"
     assert package.signed_filename == (filename + ".asc")
+
+
+@pytest.mark.parametrize(
+    "pkg_name,expected_name",
+    [
+        (string.ascii_letters, string.ascii_letters),
+        (string.digits, string.digits),
+        (string.punctuation, "-.-"),
+        ("mosaik.SimConfig", "mosaik.SimConfig"),
+        ("mosaik$$$$.SimConfig", "mosaik-.SimConfig"),
+    ],
+)
+def test_package_safe_name_is_correct(pkg_name, expected_name):
+    package = package_file.PackageFile(
+        filename="tests/fixtures/deprecated-pypirc",
+        comment=None,
+        metadata=pretend.stub(name=pkg_name),
+        python_version=None,
+        filetype=None,
+    )
+
+    assert package.safe_name == expected_name
 
 
 @pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])

--- a/twine/package.py
+++ b/twine/package.py
@@ -48,6 +48,9 @@ def _safe_name(name: str) -> str:
     """Convert an arbitrary string to a standard distribution name.
 
     Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+
+    Copied from pkg_resources.safe_name for compatibility with warehouse.
+    See https://github.com/pypa/twine/issues/743.
     """
     return re.sub("[^A-Za-z0-9.]+", "-", name)
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -14,11 +14,11 @@
 import hashlib
 import io
 import os
+import re
 import subprocess
 from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
 import importlib_metadata
-import packaging.utils
 import pkginfo
 
 from twine import exceptions
@@ -44,6 +44,14 @@ DIST_EXTENSIONS = {
 MetadataValue = Union[str, Sequence[str]]
 
 
+def _safe_name(name: str) -> str:
+    """Convert an arbitrary string to a standard distribution name.
+
+    Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+    """
+    return re.sub("[^A-Za-z0-9.]+", "-", name)
+
+
 class PackageFile:
     def __init__(
         self,
@@ -59,7 +67,7 @@ class PackageFile:
         self.metadata = metadata
         self.python_version = python_version
         self.filetype = filetype
-        self.safe_name = packaging.utils.canonicalize_name(metadata.name)
+        self.safe_name = _safe_name(metadata.name)
         self.signed_filename = self.filename + ".asc"
         self.signed_basefilename = self.basefilename + ".asc"
         self.gpg_signature: Optional[Tuple[str, bytes]] = None


### PR DESCRIPTION
Commit 0bd26af11b8f97ca97ccb9859693d7a14acf15c3 introduced a regression
that was causing some namespace packages with dots in them fail to
upload to PyPI. The reason is because
`packaging.utils.canonicalize_name()` is not equivalent to
`pkg_resources.safe_name()` as the former transforms the "." into "-",
while the later only does it for non-alphanumeric/. characters.

Closes: #743