### PR TITLE
Don't run codecov on scheduled actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run tests
         run: python -m tox -e py -- --cov-report xml
       - uses: codecov/codecov-action@v1
+        if: github.event_name != 'schedule'
         with:
           file: ./coverage.xml
           name: ${{ matrix.python }} - ${{ matrix.platform }}


### PR DESCRIPTION
Saw this in recent scheduled runs:

```
[ErrorDetail(string='Too many uploads to this commit.', code='invalid')]
```

https://github.com/pypa/twine/runs/2310302729?check_suite_focus=true#step:6:52