### PR TITLE
Only use external importlib_metadata package when python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires=
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0
     tqdm >= 4.14
-    importlib_metadata >= 3.6
+    importlib_metadata >= 3.6; python_version < "3.8"
     keyring >= 15.1
     rfc3986 >= 1.4.0
     colorama >= 0.4.3

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import sys
 from contextlib import contextmanager
 
 import pretend
@@ -94,8 +95,10 @@ def test_make_user_agent_string(default_repo):
         "requests/",
         "requests-toolbelt/",
         "pkginfo/",
-        "importlib_metadata/",
     )
+    if sys.version_info < (3, 8):
+        packages += ("importlib_metadata/",)
+
     assert all(p in user_agent for p in packages)
 
 

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -24,9 +24,16 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-import importlib_metadata
+import sys
 
-metadata = importlib_metadata.metadata("twine")
+if sys.version_info < (3, 8):
+    import importlib_metadata
+
+    metadata = importlib_metadata.metadata("twine")
+else:
+    from importlib.metadata import metadata
+
+    metadata = metadata("twine")
 
 
 __title__ = metadata["name"]

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import sys
 from typing import Any, List, Tuple
 
-from importlib_metadata import entry_points
-from importlib_metadata import version
+if sys.version_info < (3, 8):
+    from importlib_metadata import entry_points
+    from importlib_metadata import version
+else:
+    from importlib.metadata import entry_points, version
 
 import twine
 
@@ -24,12 +28,15 @@ args = argparse.Namespace()
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
     deps = (
-        "importlib_metadata",
         "pkginfo",
         "requests",
         "requests-toolbelt",
         "tqdm",
     )
+
+    if sys.version_info < (3, 8):
+        deps += ("importlib_metadata",)
+
     return [(dep, version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -16,9 +16,14 @@ import io
 import os
 import re
 import subprocess
+import sys
 from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
-import importlib_metadata
+if sys.version_info < (3, 8):
+    from importlib_metadata import Distribution
+else:
+    from importlib.metadata import Distribution
+
 import pkginfo
 
 from twine import exceptions
@@ -111,7 +116,7 @@ class PackageFile:
 
         py_version: Optional[str]
         if dtype == "bdist_egg":
-            (dist,) = importlib_metadata.Distribution.discover(  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
+            (dist,) = Distribution.discover(  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
                 path=[filename]
             )
             py_version = dist.metadata["Version"]


### PR DESCRIPTION
importlib_metadata has been integrated into the Python standard library
in 3.8 and is thus unnecessary for any newer versions.
Let's only use the external importlib_metadata package when actually
running on a Python version that doesn't include it already

This is mostly useful for distributions where there is no need to
package importlib_metadata anymore, and it's future proofing for when
the external package stops being developed anymore