### PR TITLE
Allow pip install -e . to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+# this is necessary to allow 
+# pip install -e . 
+# to work
+from setuptools import setup
+setup()


### PR DESCRIPTION
When I tried _pip install -e ._ I received the error message
ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /git/twine
(A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)

A stackoverflow post suggested creating this file, which seems to work.