### PR TITLE
Install missing stubs for mypy 0.900

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,8 @@ deps =
     lxml
     # required for more thorough type declarations
     keyring >= 22.3
-    # consider replacing with `mypy --install-types` if
-    # https://github.com/python/mypy/issues/10598 is resolved
+    # consider replacing with `mypy --install-types` when
+    # https://github.com/python/mypy/issues/10600 is resolved
     types-requests
 commands =
     mypy --html-report mypy --txt-report mypy {posargs:twine}

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,9 @@ deps =
     lxml
     # required for more thorough type declarations
     keyring >= 22.3
+    # consider replacing with `mypy --install-types` if
+    # https://github.com/python/mypy/issues/10598 is resolved
+    types-requests
 commands =
     mypy --html-report mypy --txt-report mypy {posargs:twine}
     python -c 'with open("mypy/index.txt") as f: print(f.read())'


### PR DESCRIPTION
Prompted by the [output from a failed test run](https://github.com/pypa/twine/runs/2779259854?check_suite_focus=true#step:5:13):

```
types run-test: commands[0] | mypy --html-report mypy --txt-report mypy twine
twine/utils.py:25: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
twine/__main__.py:20: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
twine/repository.py:18: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
twine/commands/upload.py:19: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)
twine/commands/upload.py:19: note: Hint: "python3 -m pip install types-requests"
twine/commands/upload.py:19: note: (or run "mypy --install-types" to install all missing stub packages)
twine/commands/upload.py:19: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

The [suggested docs](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports) and [relevant blog post](https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html) seemed clear enough. I tried `mypy --install-types`, but it's interactive ([for now](https://github.com/python/mypy/issues/10598)):

```
% mypy --install-types
Installing missing stub packages:
/Users/bhrutledge/Dev/twine/.tox/types/bin/python -m pip install types-requests

Install? [yN] 
```

