### PR TITLE
Use shutil for rmtree

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,14 +92,13 @@ commands =
 basepython = python3
 deps =
     build
-    path.py
 passenv =
     TWINE_PASSWORD
     TWINE_REPOSITORY
 setenv =
     TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
 commands =
-    python -c "import path; path.Path('dist').rmtree_p()"
+    python -c "import shutil; shutil.rmtree('dist', ignore_errors=True)"
     python -m build
     python -m twine upload dist/*
 


### PR DESCRIPTION
A bit of bikeshedding, but it looks like this does the same thing, without needing an extra dependency.

https://docs.python.org/3/library/shutil.html#shutil.rmtree