### PR TITLE
Fix the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+formats:
+  - htmlzip
+  - pdf
+  - epub
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -269,6 +269,8 @@ linkcheck_ignore = [
     # Avoid errors due to GitHub rate limit
     # https://github.com/sphinx-doc/sphinx/issues/7388
     "https://github.com/pypa/twine/issues/*",
+    # Avoid errors from channels interpreted as anchors
+    "https://web.libera.chat/#",
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,9 +4,10 @@ Contributing
 We are happy you have decided to contribute to twine.
 
 Please see `the GitHub repository`_ for code and more documentation,
-and the `official Python Packaging User Guide`_ for user documentation. You can
-also join ``#pypa`` or ``#pypa-dev`` on `IRC`_, or the `distutils-sig
-mailing list`_, to ask questions or get involved.
+and the `official Python Packaging User Guide`_ for user documentation.
+To ask questions or get involved, you can join the `Python Packaging
+Discourse forum`_, ``#pypa`` or ``#pypa-dev`` on `IRC`_, or the
+`distutils-sig mailing list`_.
 
 Getting started
 ---------------
@@ -256,6 +257,7 @@ merge into a single tool; see `ongoing discussion
 
 .. _`official Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
 .. _`the GitHub repository`: https://github.com/pypa/twine
+.. _`Python Packaging Discourse forum`: https://discuss.python.org/c/packaging/
 .. _`IRC`: https://web.libera.chat/#pypa-dev,#pypa
 .. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
 .. _`virtual environment`: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,7 +5,7 @@ We are happy you have decided to contribute to twine.
 
 Please see `the GitHub repository`_ for code and more documentation,
 and the `official Python Packaging User Guide`_ for user documentation. You can
-also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the `distutils-sig
+also join ``#pypa`` or ``#pypa-dev`` on `IRC`_, or the `distutils-sig
 mailing list`_, to ask questions or get involved.
 
 Getting started
@@ -256,7 +256,7 @@ merge into a single tool; see `ongoing discussion
 
 .. _`official Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
 .. _`the GitHub repository`: https://github.com/pypa/twine
-.. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
+.. _`IRC`: https://web.libera.chat/#pypa-dev,#pypa
 .. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
 .. _`virtual environment`: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 .. _`tox`: https://tox.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,6 +325,7 @@ discussion and background.
 Resources
 ---------
 
+* `Discourse forum <https://discuss.python.org/c/packaging/>`_
 * `IRC <https://web.libera.chat/#pypa>`_:
   ``#pypa`` on irc.libera.chat
 * `GitHub repository <https://github.com/pypa/twine>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,8 +325,8 @@ discussion and background.
 Resources
 ---------
 
-* `IRC <https://webchat.freenode.net/?channels=%23pypa>`_:
-  ``#pypa`` on irc.freenode.net
+* `IRC <https://web.libera.chat/#pypa>`_:
+  ``#pypa`` on irc.libera.chat
 * `GitHub repository <https://github.com/pypa/twine>`_
 * User and developer `documentation`_
 * `Python Packaging User Guide`_


### PR DESCRIPTION
Re: https://github.com/pypa/twine/issues/764#issuecomment-863653180

- Add Read The Docs config file to specify installing Twine with pip instead of setuptools
- Replace Freenode links with Libera.Chat
- Add links to Packaging Discourse forum

I also changed the Read The Docs web settings to use `main` instead of `master`, and to [build pull requests](https://docs.readthedocs.io/en/latest/pull-requests.html).