### PR TITLE
Tweak resource list for users

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,12 +325,12 @@ discussion and background.
 Resources
 ---------
 
-* `Discourse forum <https://discuss.python.org/c/packaging/>`_
-* `IRC <https://web.libera.chat/#pypa>`_:
-  ``#pypa`` on irc.libera.chat
 * `GitHub repository <https://github.com/pypa/twine>`_
 * User and developer `documentation`_
 * `Python Packaging User Guide`_
+* `Python packaging issue tracker <https://github.com/pypa/packaging-problems>`_
+* `IRC <https://web.libera.chat/#pypa>`_:
+  ``#pypa`` on irc.libera.chat
 
 Contributing
 ------------


### PR DESCRIPTION
In https://github.com/pypa/packaging.python.org/pull/916, I was discouraged from using the Packaging Discourse forum as a general support resource. I ended up linking to https://github.com/pypa/packaging-problems. This mirrors that change.