### PR TITLE
Improve handling of missing config file

### DIFF
--- a/changelog/770.bugfix.rst
+++ b/changelog/770.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message for a missing config file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,24 +7,33 @@ from twine import settings
 
 
 @pytest.fixture()
-def pypirc(tmpdir):
+def config_file(tmpdir):
     return tmpdir / ".pypirc"
 
 
+@pytest.fixture
+def write_config_file(config_file):
+    def _write(config):
+        config_file.write(textwrap.dedent(config))
+        return config_file
+
+    return _write
+
+
 @pytest.fixture()
-def make_settings(pypirc):
+def make_settings(write_config_file):
     """Return a factory function for settings.Settings with defaults."""
-    default_pypirc = """
+    default_config = """
         [pypi]
         username:foo
         password:bar
     """
 
-    def _settings(pypirc_text=default_pypirc, **settings_kwargs):
-        pypirc.write(textwrap.dedent(pypirc_text))
+    def _settings(config=default_config, **settings_kwargs):
+        config_file = write_config_file(config)
 
         settings_kwargs.setdefault("sign_with", None)
-        settings_kwargs.setdefault("config_file", str(pypirc))
+        settings_kwargs.setdefault("config_file", config_file)
 
         return settings.Settings(**settings_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,15 @@ import textwrap
 import pytest
 
 from twine import settings
+from twine import utils
 
 
 @pytest.fixture()
-def config_file(tmpdir):
-    return tmpdir / ".pypirc"
+def config_file(tmpdir, monkeypatch):
+    path = tmpdir / ".pypirc"
+    # Mimic common case of .pypirc in home directory
+    monkeypatch.setattr(utils, "DEFAULT_CONFIG_FILE", path)
+    return path
 
 
 @pytest.fixture

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -19,7 +19,7 @@ def register_settings(make_settings):
         repository: https://test.pypi.org/legacy
         username:foo
         password:bar
-    """
+        """
     )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,11 +37,11 @@ def test_settings_transforms_repository_config(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [pypi]
-            repository: https://upload.pypi.org/legacy/
-            username:username
-            password:password
-        """
+                [pypi]
+                repository: https://upload.pypi.org/legacy/
+                username:username
+                password:password
+                """
             )
         )
     s = settings.Settings(config_file=pypirc)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -203,7 +203,7 @@ def test_exception_for_http_status(verbose, upload_settings, stub_response, caps
         assert "--verbose" in captured.out
 
 
-def test_get_config_old_format(make_settings, pypirc):
+def test_get_config_old_format(make_settings, config_file):
     try:
         make_settings(
             """
@@ -218,7 +218,7 @@ def test_get_config_old_format(make_settings, pypirc):
             for text in [
                 "'pypi'",
                 "--repository-url",
-                pypirc,
+                config_file,
                 "https://docs.python.org/",
             ]
         )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -210,7 +210,7 @@ def test_get_config_old_format(make_settings, pypirc):
             [server-login]
             username:foo
             password:bar
-        """
+            """
         )
     except KeyError as err:
         assert all(
@@ -232,7 +232,7 @@ def test_deprecated_repo(make_settings):
             repository: https://pypi.python.org/pypi/
             username:foo
             password:bar
-        """
+            """
         )
 
         upload.upload(upload_settings, [helpers.WHEEL_FIXTURE])
@@ -257,7 +257,7 @@ def test_exception_for_redirect(make_settings):
         repository: https://test.pypi.org/legacy
         username:foo
         password:bar
-    """
+        """
     )
 
     stub_response = pretend.stub(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,10 +171,24 @@ def test_get_repository_config_with_invalid_url(config_file, repo_url, message):
         utils.get_repository_from_config(config_file, "pypi", repo_url)
 
 
-def test_get_repository_config_missing_config(config_file):
-    """Raise an exception when a repository isn't defined in .pypirc."""
-    with pytest.raises(exceptions.InvalidConfiguration):
-        utils.get_repository_from_config(config_file, "foobar")
+def test_get_repository_config_missing_repository(write_config_file):
+    """Raise an exception when a custom repository isn't defined in .pypirc."""
+    config_file = write_config_file("")
+    with pytest.raises(
+        exceptions.InvalidConfiguration,
+        match="Missing 'missing-repository'",
+    ):
+        utils.get_repository_from_config(config_file, "missing-repository")
+
+
+@pytest.mark.parametrize("repository", ["pypi", "missing-repository"])
+def test_get_repository_config_missing_file(repository):
+    """Raise an exception when a custom config file doesn't exist."""
+    with pytest.raises(
+        exceptions.InvalidConfiguration,
+        match=r"No such file.*missing-file",
+    ):
+        utils.get_repository_from_config("missing-file", repository)
 
 
 def test_get_config_deprecated_pypirc():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os.path
-import textwrap
 
 import pretend
 import pytest
@@ -25,24 +24,19 @@ from twine import utils
 from . import helpers
 
 
-def test_get_config(tmpdir):
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+def test_get_config(write_config_file):
+    config_file = write_config_file(
+        """
+        [distutils]
+        index-servers = pypi
 
-    with open(pypirc, "w") as fp:
-        fp.write(
-            textwrap.dedent(
-                """
-                [distutils]
-                index-servers = pypi
+        [pypi]
+        username = testuser
+        password = testpassword
+        """
+    )
 
-                [pypi]
-                username = testuser
-                password = testpassword
-                """
-            )
-        )
-
-    assert utils.get_config(pypirc) == {
+    assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
             "username": "testuser",
@@ -51,22 +45,17 @@ def test_get_config(tmpdir):
     }
 
 
-def test_get_config_no_distutils(tmpdir):
+def test_get_config_no_distutils(write_config_file):
     """Upload by default to PyPI if an index server is not set in .pypirc."""
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+    config_file = write_config_file(
+        """
+        [pypi]
+        username = testuser
+        password = testpassword
+        """
+    )
 
-    with open(pypirc, "w") as fp:
-        fp.write(
-            textwrap.dedent(
-                """
-                [pypi]
-                username = testuser
-                password = testpassword
-                """
-            )
-        )
-
-    assert utils.get_config(pypirc) == {
+    assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
             "username": "testuser",
@@ -80,24 +69,19 @@ def test_get_config_no_distutils(tmpdir):
     }
 
 
-def test_get_config_no_section(tmpdir):
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+def test_get_config_no_section(write_config_file):
+    config_file = write_config_file(
+        """
+        [distutils]
+        index-servers = pypi foo
 
-    with open(pypirc, "w") as fp:
-        fp.write(
-            textwrap.dedent(
-                """
-                [distutils]
-                index-servers = pypi foo
+        [pypi]
+        username = testuser
+        password = testpassword
+        """
+    )
 
-                [pypi]
-                username = testuser
-                password = testpassword
-                """
-            )
-        )
-
-    assert utils.get_config(pypirc) == {
+    assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
             "username": "testuser",
@@ -106,26 +90,19 @@ def test_get_config_no_section(tmpdir):
     }
 
 
-def test_get_config_override_pypi_url(tmpdir):
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+def test_get_config_override_pypi_url(write_config_file):
+    config_file = write_config_file(
+        """
+        [pypi]
+        repository = http://pypiproxy
+        """
+    )
 
-    with open(pypirc, "w") as fp:
-        fp.write(
-            textwrap.dedent(
-                """
-                [pypi]
-                repository = http://pypiproxy
-                """
-            )
-        )
-
-    assert utils.get_config(pypirc)["pypi"]["repository"] == "http://pypiproxy"
+    assert utils.get_config(config_file)["pypi"]["repository"] == "http://pypiproxy"
 
 
-def test_get_config_missing(tmpdir):
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
-
-    assert utils.get_config(pypirc) == {
+def test_get_config_missing(config_file):
+    assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
             "username": None,
@@ -139,44 +116,38 @@ def test_get_config_missing(tmpdir):
     }
 
 
-def test_empty_userpass(tmpdir):
+def test_empty_userpass(write_config_file):
     """Suppress prompts if empty username and password are provided in .pypirc."""
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
+    config_file = write_config_file(
+        """
+        [pypi]
+        username=
+        password=
+        """
+    )
 
-    with open(pypirc, "w") as fp:
-        fp.write(
-            textwrap.dedent(
-                """
-                [pypi]
-                username=
-                password=
-                """
-            )
-        )
-
-    config = utils.get_config(pypirc)
+    config = utils.get_config(config_file)
     pypi = config["pypi"]
 
     assert pypi["username"] == pypi["password"] == ""
 
 
-def test_get_repository_config_missing(tmpdir):
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
-
+def test_get_repository_config_missing(config_file):
     repository_url = "https://notexisting.python.org/pypi"
     exp = {
         "repository": repository_url,
         "username": None,
         "password": None,
     }
-    assert utils.get_repository_from_config(pypirc, "foo", repository_url) == exp
-    assert utils.get_repository_from_config(pypirc, "pypi", repository_url) == exp
+    assert utils.get_repository_from_config(config_file, "foo", repository_url) == exp
+    assert utils.get_repository_from_config(config_file, "pypi", repository_url) == exp
+
     exp = {
         "repository": utils.DEFAULT_REPOSITORY,
         "username": None,
         "password": None,
     }
-    assert utils.get_repository_from_config(pypirc, "pypi") == exp
+    assert utils.get_repository_from_config(config_file, "pypi") == exp
 
 
 @pytest.mark.parametrize(
@@ -191,22 +162,19 @@ def test_get_repository_config_missing(tmpdir):
         ("foo.bar", "host, scheme were required but missing."),
     ],
 )
-def test_get_repository_config_with_invalid_url(tmpdir, repo_url, message):
+def test_get_repository_config_with_invalid_url(config_file, repo_url, message):
     """Raise an exception for a URL with an invalid/missing scheme and/or host."""
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
-
     with pytest.raises(
         exceptions.UnreachableRepositoryURLDetected,
         match=message,
     ):
-        utils.get_repository_from_config(pypirc, "pypi", repo_url)
+        utils.get_repository_from_config(config_file, "pypi", repo_url)
 
 
-def test_get_repository_config_missing_config(tmpdir):
+def test_get_repository_config_missing_config(config_file):
     """Raise an exception when a repository isn't defined in .pypirc."""
-    pypirc = os.path.join(str(tmpdir), ".pypirc")
     with pytest.raises(exceptions.InvalidConfiguration):
-        utils.get_repository_from_config(pypirc, "foobar")
+        utils.get_repository_from_config(config_file, "foobar")
 
 
 def test_get_config_deprecated_pypirc():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,13 +32,13 @@ def test_get_config(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [distutils]
-            index-servers = pypi
+                [distutils]
+                index-servers = pypi
 
-            [pypi]
-            username = testuser
-            password = testpassword
-        """
+                [pypi]
+                username = testuser
+                password = testpassword
+                """
             )
         )
 
@@ -59,10 +59,10 @@ def test_get_config_no_distutils(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [pypi]
-            username = testuser
-            password = testpassword
-        """
+                [pypi]
+                username = testuser
+                password = testpassword
+                """
             )
         )
 
@@ -87,13 +87,13 @@ def test_get_config_no_section(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [distutils]
-            index-servers = pypi foo
+                [distutils]
+                index-servers = pypi foo
 
-            [pypi]
-            username = testuser
-            password = testpassword
-        """
+                [pypi]
+                username = testuser
+                password = testpassword
+                """
             )
         )
 
@@ -113,9 +113,9 @@ def test_get_config_override_pypi_url(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [pypi]
-            repository = http://pypiproxy
-        """
+                [pypi]
+                repository = http://pypiproxy
+                """
             )
         )
 
@@ -147,10 +147,10 @@ def test_empty_userpass(tmpdir):
         fp.write(
             textwrap.dedent(
                 """
-            [pypi]
-            username=
-            password=
-        """
+                [pypi]
+                username=
+                password=
+                """
             )
         )
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -52,7 +52,7 @@ class Settings:
         password: Optional[str] = None,
         non_interactive: bool = False,
         comment: Optional[str] = None,
-        config_file: str = "~/.pypirc",
+        config_file: str = utils.DEFAULT_CONFIG_FILE,
         skip_existing: bool = False,
         cacert: Optional[str] = None,
         client_cert: Optional[str] = None,
@@ -244,7 +244,7 @@ class Settings:
         )
         parser.add_argument(
             "--config-file",
-            default="~/.pypirc",
+            default=utils.DEFAULT_CONFIG_FILE,
             help="The .pypirc config file to use.",
         )
         parser.add_argument(

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -43,46 +43,38 @@ RepositoryConfig = Dict[str, Optional[str]]
 logger = logging.getLogger(__name__)
 
 
-def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
-    # even if the config file does not exist, set up the parser
-    # variable to reduce the number of if/else statements
+def get_config(path: str) -> Dict[str, RepositoryConfig]:
+    """Read repository configuration from a file (i.e. ~/.pypirc).
+
+    Format: https://packaging.python.org/specifications/pypirc/
+
+    If the file doesn't exist, return a default configuration for pypyi and testpypi.
+    """
     parser = configparser.RawConfigParser()
 
-    # this list will only be used if index-servers
-    # is not defined in the config file
-    index_servers = ["pypi", "testpypi"]
-
-    # default configuration for each repository
-    defaults: RepositoryConfig = {"username": None, "password": None}
-
-    # Expand user strings in the path
     path = os.path.expanduser(path)
+    if parser.read(path):
+        logger.info(f"Using configuration from {path}")
 
-    logger.info(f"Using configuration from {path}")
+    # server-login is obsolete, but retained for backwards compatibility
+    defaults: RepositoryConfig = {
+        "username": parser.get("server-login", "username", fallback=None),
+        "password": parser.get("server-login", "password", fallback=None),
+    }
 
-    # Parse the rc file
-    if os.path.isfile(path):
-        parser.read(path)
+    config: DefaultDict[str, RepositoryConfig]
+    config = collections.defaultdict(lambda: defaults.copy())
 
-        # Get a list of index_servers from the config file
-        # format: https://packaging.python.org/specifications/pypirc/
-        if parser.has_option("distutils", "index-servers"):
-            index_servers = parser.get("distutils", "index-servers").split()
+    index_servers = parser.get(
+        "distutils", "index-servers", fallback="pypi testpypi"
+    ).split()
 
-        for key in ["username", "password"]:
-            if parser.has_option("server-login", key):
-                defaults[key] = parser.get("server-login", key)
-
-    config: DefaultDict[str, RepositoryConfig] = collections.defaultdict(
-        lambda: defaults.copy()
-    )
-
-    # don't require users to manually configure URLs for these repositories
+    # Don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY
     if "testpypi" in index_servers:
         config["testpypi"]["repository"] = TEST_REPOSITORY
 
-    # optional configuration values for individual repositories
+    # Optional configuration values for individual repositories
     for repository in index_servers:
         for key in [
             "username",
@@ -94,8 +86,7 @@ def get_config(path: str = "~/.pypirc") -> Dict[str, RepositoryConfig]:
             if parser.has_option(repository, key):
                 config[repository][key] = parser.get(repository, key)
 
-    # convert the defaultdict to a regular dict at this point
-    # to prevent surprising behavior later on
+    # Convert the defaultdict to a regular dict to prevent surprising behavior later on
     return dict(config)
 
 
@@ -117,14 +108,14 @@ def _validate_repository_url(repository_url: str) -> None:
 
 
 def get_repository_from_config(
-    config_file: str, repository: str, repository_url: Optional[str] = None
+    config_file: str,
+    repository: str,
+    repository_url: Optional[str] = None,
 ) -> RepositoryConfig:
-    # Get our config from, if provided, command-line values for the
-    # repository name and URL, or the .pypirc file
-
+    """Get repository config command-line values or the .pypirc file."""
+    # Prefer CLI `repository_url` over `repository` or .pypirc
     if repository_url:
         _validate_repository_url(repository_url)
-        # prefer CLI `repository_url` over `repository` or .pypirc
         return {
             "repository": repository_url,
             "username": None,
@@ -133,14 +124,10 @@ def get_repository_from_config(
     try:
         return get_config(config_file)[repository]
     except KeyError:
-        msg = (
-            "Missing '{repo}' section from the configuration file\n"
-            "or not a complete URL in --repository-url.\n"
-            "Maybe you have an out-dated '{cfg}' format?\n"
-            "more info: "
-            "https://packaging.python.org/specifications/pypirc/\n"
-        ).format(repo=repository, cfg=config_file)
-        raise exceptions.InvalidConfiguration(msg)
+        raise exceptions.InvalidConfiguration(
+            f"Missing '{repository}' section from {config_file}.\n"
+            f"More info: https://packaging.python.org/specifications/pypirc/ "
+        )
 
 
 _HOSTNAMES = {


### PR DESCRIPTION
Fixes #564 

There's a lot here, but my hope is that it makes things clearer for users and contributors. I tried to organize the commits so that they could be reviewed individually; for example, the change that addresses @angerson's suggestion in https://github.com/pypa/twine/issues/564#issuecomment-863504013 is https://github.com/pypa/twine/commit/fd51ed19191f02de6ab17149926cb5f387daf2ca.

New output:

```
% twine upload --config-file /path/to/missing/file --repository undefined-repository dist/* 
InvalidConfiguration: [Errno 2] No such file or directory: '/path/to/missing/file'

% twine upload --config-file /path/to/missing/file dist/*
InvalidConfiguration: [Errno 2] No such file or directory: '/path/to/missing/file'

% twine upload --repository undefined-repository dist/*                      
InvalidConfiguration: Missing 'undefined-repository' section from ~/.pypirc.
More info: https://packaging.python.org/specifications/pypirc/ 
```

The second example is new behavior. Currently, Twine silently ignores the missing file, and returns a default configuration for PyPI and TestPyPI. However, if a user takes the time to specify `--config-file` on the command line, and the file doesn't exist, that feels like it should be an error.  These changes include a special case to continue to provide a default configuration if `--config-file` isn't used.