### PR TITLE
Use unreleased devpi to fix failing integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -119,7 +119,8 @@ commands =
 
 [testenv:devpi]
 deps =
-    devpi-server
+    # https://github.com/devpi/devpi/issues/843
+    -e git+https://github.com/devpi/devpi.git#egg=devpi-server&subdirectory=server
     devpi
 
 [testenv:pypiserver]


### PR DESCRIPTION
As noted in https://github.com/devpi/devpi/issues/843, the released version doesn't install `ruamel.yaml`, which is causing the [integration tests to fail](https://github.com/pypa/twine/runs/2871005944?check_suite_focus=true).