### PR TITLE
Use importlib.metadata from the standard library on Python 3.10

### DIFF
--- a/changelog/772.mics.rst
+++ b/changelog/772.mics.rst
@@ -1,0 +1,1 @@
+Remove dependency on external importlib_metadata on Python 3.10.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires=
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0
     tqdm >= 4.14
-    importlib_metadata >= 3.6
+    importlib_metadata >= 3.6; python_version<"3.10"
     keyring >= 15.1
     rfc3986 >= 1.4.0
     colorama >= 0.4.3

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -27,11 +27,11 @@ __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 import sys
 
 if sys.version_info[:2] >= (3, 10):
-    from importlib import metadata as importlib_metadata
+    from importlib.metadata import metadata as _metadata
 else:
-    import importlib_metadata
+    from importlib_metadata import metadata as _metadata
 
-metadata = importlib_metadata.metadata("twine")
+metadata = _metadata("twine")
 
 
 __title__ = metadata["name"]

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -24,7 +24,12 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
-import importlib_metadata
+import sys
+
+if sys.version_info[:2] >= (3, 10):
+    from importlib import metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 metadata = importlib_metadata.metadata("twine")
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import sys
 from typing import Any, List, Tuple
 
-from importlib_metadata import entry_points
-from importlib_metadata import version
+if sys.version_info[:2] >= (3, 10):
+    from importlib.metadata import entry_points
+    from importlib.metadata import version
+else:
+    from importlib_metadata import entry_points
+    from importlib_metadata import version
 
 import twine
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -16,9 +16,14 @@ import io
 import os
 import re
 import subprocess
+import sys
 from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
-import importlib_metadata
+if sys.version_info[:2] >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
 import pkginfo
 
 from twine import exceptions


### PR DESCRIPTION
According to the [importlib_metadata readme], all features from 4.4
were merged to Python 3.10. So, twine can have one less external
dependency on the upcoming Python release.

[importlib_metadata readme]: https://pypi.org/project/importlib-metadata/