### PR TITLE
Use `furo` theme in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ exclude_patterns = ["_build"]
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
+# pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -100,7 +100,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,6 @@ It provides build system independent uploads of source and binary
 `distribution artifacts <distributions_>`_ for both new and existing
 `projects`_.
 
-.. contents:: Table of Contents
-    :local:
-
 Why Should I Use This?
 ----------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 doc8>=0.8.0
+furo >= 2021.7.5b38
 readme-renderer>=17.4
 Sphinx>=1.7.0
-sphinx_rtd_theme>=0.2.4


### PR DESCRIPTION
This change attempts to refresh the look of the docs by adding a better theme called Furo. I feel like it fits better than the RTD one.

Preview: https://twine--780.org.readthedocs.build/en/780/.