### PR TITLE
📝 Add a CoC link to the docs ToC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@
     :maxdepth: 3
 
     contributing
+    Code Of Conduct <https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md>
     changelog
     Python Packaging User Guide <https://packaging.python.org/tutorials/distributing-packages/>
 


### PR DESCRIPTION
It should appear in the left menu here: https://twine--789.org.readthedocs.build/en/789/.