### PR TITLE
Improve legibility of command line examples

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,13 +15,13 @@ Getting started
 We use `tox`_ to run tests, check code style, and build the documentation.
 To install ``tox``, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     python3 -m pip install tox
 
 Clone the twine repository from GitHub, then run:
 
-.. code-block:: console
+.. code-block:: bash
 
     cd /path/to/your/local/twine
     tox -e dev
@@ -38,7 +38,7 @@ below on the whole codebase.
 
 To use the virtual environment, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     source venv/bin/activate
 
@@ -50,7 +50,7 @@ appreciated.
 
 To preview the docs while you're making changes, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e watch-docs
 
@@ -59,7 +59,7 @@ Then open a web browser to `<http://127.0.0.1:8000>`_.
 When you're done making changes, lint and build the docs locally before making
 a pull request. In your active virtual environment, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e docs
 
@@ -70,19 +70,19 @@ Code style
 
 To automatically reformat your changes with `isort`_ and `black`_, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e format
 
 To detect any remaining code smells with `flake8`_, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e lint
 
 To perform strict type-checking using `mypy`_, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e types
 
@@ -98,13 +98,13 @@ We use `pytest`_ for writing and running tests.
 
 To run the tests in your virtual environment, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e py
 
 To pass options to ``pytest``, e.g. the name of a test, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
@@ -112,20 +112,20 @@ Twine is continuously tested against Python 3.6, 3.7, 3.8, and 3.9 using
 `GitHub Actions`_. To run the tests against a specific version, e.g. Python
 3.6, you will need it installed on your machine. Then, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e py36
 
 To run the "integration" tests of uploading to real package indexes, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox -e integration
 
 To run the tests against all supported Python versions, check code style,
 and build the documentation, run:
 
-.. code-block:: console
+.. code-block:: bash
 
     tox
 
@@ -235,7 +235,7 @@ A checklist for creating, testing, and distributing a new version.
 
 #. Choose a version number, and create a new branch
 
-   .. code-block:: console
+   .. code-block:: bash
 
       VERSION=3.4.2
 
@@ -243,7 +243,7 @@ A checklist for creating, testing, and distributing a new version.
 
 #. Update :file:`docs/changelog.rst`
 
-   .. code-block:: console
+   .. code-block:: bash
 
       tox -e changelog -- --version $VERSION
 
@@ -255,7 +255,7 @@ A checklist for creating, testing, and distributing a new version.
 
 #. Create a new git tag for the version
 
-   .. code-block:: console
+   .. code-block:: bash
 
       git switch main
 
@@ -265,7 +265,7 @@ A checklist for creating, testing, and distributing a new version.
 
 #. Push to start the release, and watch it in `GitHub Actions`_
 
-   .. code-block:: console
+   .. code-block:: bash
 
       git push upstream $VERSION
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,14 +67,14 @@ Using Twine
 
 1. Create some distributions in the normal way:
 
-    .. code-block:: console
+   .. code-block:: console
 
        $ python setup.py sdist bdist_wheel
 
 2. Upload with ``twine`` to `Test PyPI`_ and verify things look right.
    Twine will automatically prompt for your username and password:
 
-    .. code-block:: console
+   .. code-block:: console
 
        $ twine upload -r testpypi dist/*
        username: ...
@@ -83,7 +83,7 @@ Using Twine
 
 3. Upload to `PyPI`_:
 
-    .. code-block:: console
+   .. code-block:: console
 
        $ twine upload dist/*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,9 +100,8 @@ Commands
 
 Uploads one or more distributions to a repository.
 
-.. code-block:: console
+.. code-block:: text
 
-    $ twine upload -h
     usage: twine upload [-h] [-r REPOSITORY] [--repository-url REPOSITORY_URL]
                         [-s] [--sign-with SIGN_WITH] [-i IDENTITY] [-u USERNAME]
                         [-p PASSWORD] [-c COMMENT] [--config-file CONFIG_FILE]
@@ -166,9 +165,8 @@ Uploads one or more distributions to a repository.
 Checks whether your distribution's long description will render correctly on
 PyPI.
 
-.. code-block:: console
+.. code-block:: text
 
-    $ twine check -h
     usage: twine check [-h] [--strict] dist [dist ...]
 
     positional arguments:
@@ -188,9 +186,7 @@ are using a different package index.
 
 For completeness, its usage:
 
-.. code-block:: console
-
-    $ twine register -h
+.. code-block:: text
 
     usage: twine register [-h] -r REPOSITORY [--repository-url REPOSITORY_URL]
                           [-u USERNAME] [-p PASSWORD] [-c COMMENT]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,9 +58,9 @@ Features
 Installation
 ------------
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ pip install twine
+    pip install twine
 
 Using Twine
 -----------
@@ -276,15 +276,15 @@ which you may upload.
 
 For example, to set a username and password for PyPI:
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ keyring set https://upload.pypi.org/legacy/ your-username
+    keyring set https://upload.pypi.org/legacy/ your-username
 
 or
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ python3 -m keyring set https://upload.pypi.org/legacy/ your-username
+    python3 -m keyring set https://upload.pypi.org/legacy/ your-username
 
 and enter the password when prompted.
 
@@ -307,15 +307,15 @@ Keyring will cause unexpected or undesirable prompts from the backing system.
 In these cases, it may be desirable to disable Keyring altogether. To disable
 Keyring, simply invoke:
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ keyring --disable
+    keyring --disable
 
 or
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ python -m keyring --disable
+    python -m keyring --disable
 
 That command will configure for the current user the "null" keyring,
 effectively disabling the functionality, and allowing Twine to prompt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,25 +67,23 @@ Using Twine
 
 1. Create some distributions in the normal way:
 
-   .. code-block:: console
+   .. code-block:: bash
 
-       $ python setup.py sdist bdist_wheel
+       python setup.py sdist bdist_wheel
 
-2. Upload with ``twine`` to `Test PyPI`_ and verify things look right.
-   Twine will automatically prompt for your username and password:
+2. Upload to `Test PyPI`_ and verify things look right:
 
-   .. code-block:: console
+   .. code-block:: bash
 
-       $ twine upload -r testpypi dist/*
-       username: ...
-       password:
-       ...
+       twine upload -r testpypi dist/*
+
+   Twine will prompt for your username and password.
 
 3. Upload to `PyPI`_:
 
-   .. code-block:: console
+   .. code-block:: bash
 
-       $ twine upload dist/*
+       twine upload dist/*
 
 4. Done!
 


### PR DESCRIPTION
Closes #783

This follows the convention that's recently been adopted in the Python Packaging User Guide. According to the Pygments docs, the [`console` lexer](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) is "for Bash shell sessions, i.e. command lines, including a prompt, interspersed with output". However, it seems increasingly common to use single command lines without a prompt, perhaps because they are more legible and easily copied.