### PR TITLE
Having a new check to avoid redirects from PyPI

### DIFF
--- a/twine/settings.py
+++ b/twine/settings.py
@@ -347,8 +347,8 @@ class Settings:
             raise exceptions.InvalidPyPIUploadURL(
                 f"The configured repository {repository_url} is not a known "
                 f"PyPI repository.\n"
-                f"Did you mean {utils.DEFAULT_REPOSITORY} "
-                f"or {utils.TEST_REPOSITORY}?\n"
+                f"You probably want {utils.DEFAULT_REPOSITORY} "
+                f"or {utils.TEST_REPOSITORY}.\n"
                 f"Check your --repository-url value "
                 f"or the repository configuration in {self.config_file}.\n"
                 f"See https://packaging.python.org/specifications/pypirc/ "

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -324,7 +324,7 @@ class Settings:
         self.client_cert = utils.get_clientcert(client_cert, self.repository_config)
 
     def check_repository_url(self) -> None:
-        """Verify we are not using legacy PyPI and using the correct url for PyPI.
+        """Verify we are using the correct url for PyPI.
 
         :raises:
             :class:`~twine.exceptions.UploadToDeprecatedPyPIDetected`
@@ -340,19 +340,19 @@ class Settings:
                 repository_url, utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY
             )
 
-        if repository_url.startswith(
-            ("https://pypi.org/", "https://test.pypi.org/", "https://upload.pypi.org/")
-        ) and repository_url not in [utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY]:
+        if "pypi.org" in repository_url and repository_url not in [
+            utils.DEFAULT_REPOSITORY,
+            utils.TEST_REPOSITORY,
+        ]:
             raise exceptions.InvalidPyPIUploadURL(
                 f"The configured repository {repository_url} is not a known "
                 f"PyPI repository.\n"
                 f"Did you mean {utils.DEFAULT_REPOSITORY} "
-                f"or {utils.TEST_REPOSITORY} ?\n"
-                f"Check your --repository-url value or "
-                f"modify the url in {self.config_file} "
-                f"(if you are using -r or --repository),\n"
-                f"so twine can upload your distributions properly.\n"
-                f"See {utils.PYPIRC_DOCS} for more details."
+                f"or {utils.TEST_REPOSITORY}?\n"
+                f"Check your --repository-url value "
+                f"or the repository configuration in {self.config_file}.\n"
+                f"See https://packaging.python.org/specifications/pypirc/ "
+                f"for more details."
             )
 
     def create_repository(self) -> repository.Repository:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -339,7 +339,7 @@ class Settings:
             raise exceptions.UploadToDeprecatedPyPIDetected.from_args(
                 repository_url, utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY
             )
-        
+
         if repository_url.startswith(
             ("https://pypi.org/", "https://test.pypi.org/", "https://upload.pypi.org/")
         ) and repository_url not in [utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY]:
@@ -349,7 +349,8 @@ class Settings:
                 f"Did you mean {utils.DEFAULT_REPOSITORY} "
                 f"or {utils.TEST_REPOSITORY} ?\n"
                 f"Check your --repository-url value or "
-                f"modify the url in {self.config_file} (if you are using -r or --repository)"
+                f"modify the url in {self.config_file} "
+                f"(if you are using -r or --repository),\n"
                 f"so twine can upload your distributions properly.\n"
                 f"See {utils.PYPIRC_DOCS} for more details."
             )

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 import sys
 from typing import Any, ContextManager, Optional, cast
+from urllib.parse import urlparse
 
 from twine import auth
 from twine import exceptions
@@ -340,10 +341,12 @@ class Settings:
                 repository_url, utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY
             )
 
-        if "pypi.org" in repository_url and repository_url not in [
-            utils.DEFAULT_REPOSITORY,
-            utils.TEST_REPOSITORY,
-        ]:
+        repository_host = urlparse(repository_url).hostname
+        if (
+            repository_host
+            and repository_host.endswith("pypi.org")
+            and repository_url not in [utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY]
+        ):
             raise exceptions.InvalidPyPIUploadURL(
                 f"The configured repository {repository_url} is not a known "
                 f"PyPI repository.\n"

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -32,7 +32,6 @@ input_func = input
 
 DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
 TEST_REPOSITORY = "https://test.pypi.org/legacy/"
-PYPIRC_DOCS = "https://packaging.python.org/specifications/pypirc/"
 
 DEFAULT_CONFIG_FILE = "~/.pypirc"
 

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -32,6 +32,7 @@ input_func = input
 
 DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
 TEST_REPOSITORY = "https://test.pypi.org/legacy/"
+PYPIRC_DOCS = "https://packaging.python.org/specifications/pypirc/"
 
 DEFAULT_CONFIG_FILE = "~/.pypirc"
 


### PR DESCRIPTION
Fixes #310 

We should also update the redirect test as it is using `https://test.pypi.org/legacy` for the test, which is replaced by the exception `InvalidPyPIUploadURL`instead of `RedirectDetected` currently. Any suggestions? (I think we need a new URL to test.)
https://github.com/pypa/twine/blob/f54311486f1a27e732fa0118ac1b2b71f1c32c10/tests/test_upload.py#L251-L278

Old:
```
$ twine upload -r pypitest dist/*
[...]
RedirectDetected: https://test.pypi.org/legacy attempted to redirect to https://test.pypi.org/legacy/.
If you trust these URLs, set https://test.pypi.org/legacy/ as your repository URL.
Aborting.
```
New:
```
$ twine upload -r pypitest dist/*
InvalidPyPIUploadURL: The configured repository https://test.pypi.org/legacy is not a known PyPI repository.
Did you mean https://upload.pypi.org/legacy/ or https://test.pypi.org/legacy/ ?
Check your --repository-url value or modify the url in ~/.pypirc (if you are using -r or --repository),
so twine can upload your distributions properly.
See https://packaging.python.org/specifications/pypirc/ for more details.
```