### PR TITLE
Improve redirect error message for trailing slash

### DIFF
--- a/changelog/812.bugfix.rst
+++ b/changelog/812.bugfix.rst
@@ -1,0 +1,2 @@
+Add a helpful error message when an upload fails due to missing a trailing
+slash in the URL.

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -16,7 +16,7 @@ def register_settings(make_settings):
     return make_settings(
         """
         [pypi]
-        repository: https://test.pypi.org/legacy
+        repository: https://test.pypi.org/legacy/
         username:foo
         password:bar
         """
@@ -46,7 +46,7 @@ def test_successful_register(register_settings):
 def test_exception_for_redirect(register_settings):
     """Raise an exception when repository URL results in a redirect."""
     repository_url = register_settings.repository_config["repository"]
-    redirect_url = "https://malicious.website.org/danger"
+    redirect_url = "https://malicious.website.org/danger/"
 
     stub_response = pretend.stub(
         is_redirect=True,
@@ -60,13 +60,10 @@ def test_exception_for_redirect(register_settings):
 
     register_settings.create_repository = lambda: stub_repository
 
-    err_msg = (
-        f"{repository_url} attempted to redirect to {redirect_url}.\n"
-        f"If you trust these URLs, set {redirect_url} as your repository URL.\n"
-        f"Aborting."
-    )
-
-    with pytest.raises(exceptions.RedirectDetected, match=err_msg):
+    with pytest.raises(
+        exceptions.RedirectDetected,
+        match=rf"{repository_url}.+{redirect_url}.+\nIf you trust these URLs",
+    ):
         register.register(register_settings, helpers.WHEEL_FIXTURE)
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -272,10 +272,14 @@ def test_exception_for_redirect(make_settings):
 
     upload_settings.create_repository = lambda: stub_repository
 
-    with pytest.raises(exceptions.RedirectDetected) as err:
+    with pytest.raises(
+        exceptions.RedirectDetected,
+        match=(
+            r"https://test.pypi.org/legacy.+https://test.pypi.org/legacy/"
+            r".+\nIf you trust these URLs"
+        ),
+    ):
         upload.upload(upload_settings, [helpers.WHEEL_FIXTURE])
-
-    assert "https://test.pypi.org/legacy/" in err.value.args[0]
 
 
 def test_prints_skip_message_for_uploaded_package(

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -261,9 +261,9 @@ def test_deprecated_repo(make_settings):
         ),
         (
             "https://test.pypi.org/legacy/",
-            "https://malicious.pypi.org/legacy/",
+            "https://malicious.website.org/danger/",
             (
-                r"https://test.pypi.org/legacy/.+https://malicious.pypi.org/legacy/"
+                r"https://test.pypi.org/legacy/.+https://malicious.website.org/danger/"
                 r".+\nIf you trust these URLs"
             ),
         ),

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -248,13 +248,39 @@ def test_deprecated_repo(make_settings):
     )
 
 
-def test_exception_for_redirect(make_settings):
+@pytest.mark.parametrize(
+    "repository_url, redirect_url, message_match",
+    [
+        (
+            "https://test.pypi.org/legacy",
+            "https://test.pypi.org/legacy/",
+            (
+                r"https://test.pypi.org/legacy.+https://test.pypi.org/legacy/"
+                r".+\nYour repository URL is missing a trailing slash"
+            ),
+        ),
+        (
+            "https://test.pypi.org/legacy/",
+            "https://malicious.pypi.org/legacy/",
+            (
+                r"https://test.pypi.org/legacy/.+https://malicious.pypi.org/legacy/"
+                r".+\nIf you trust these URLs"
+            ),
+        ),
+    ],
+)
+def test_exception_for_redirect(
+    repository_url,
+    redirect_url,
+    message_match,
+    make_settings,
+):
     # Not using fixtures because this setup is significantly different
 
     upload_settings = make_settings(
-        """
+        f"""
         [pypi]
-        repository: https://test.pypi.org/legacy
+        repository: {repository_url}
         username:foo
         password:bar
         """
@@ -263,7 +289,7 @@ def test_exception_for_redirect(make_settings):
     stub_response = pretend.stub(
         is_redirect=True,
         status_code=301,
-        headers={"location": "https://test.pypi.org/legacy/"},
+        headers={"location": redirect_url},
     )
 
     stub_repository = pretend.stub(
@@ -272,13 +298,7 @@ def test_exception_for_redirect(make_settings):
 
     upload_settings.create_repository = lambda: stub_repository
 
-    with pytest.raises(
-        exceptions.RedirectDetected,
-        match=(
-            r"https://test.pypi.org/legacy.+https://test.pypi.org/legacy/"
-            r".+\nIf you trust these URLs"
-        ),
-    ):
+    with pytest.raises(exceptions.RedirectDetected, match=message_match):
         upload.upload(upload_settings, [helpers.WHEEL_FIXTURE])
 
 

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -40,8 +40,8 @@ class RedirectDetected(TwineException):
 
         return cls(
             f"{repository_url} attempted to redirect to {redirect_url}.\n"
-            f"If you trust these URLs, set {redirect_url} as your repository URL.\n"
-            "Aborting.",
+            f"If you trust these URLs, set {redirect_url} as your repository URL "
+            "and try again.",
         )
 
 

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -31,6 +31,13 @@ class RedirectDetected(TwineException):
 
     @classmethod
     def from_args(cls, repository_url: str, redirect_url: str) -> "RedirectDetected":
+        if redirect_url == f"{repository_url}/":
+            return cls(
+                f"{repository_url} attempted to redirect to {redirect_url}.\n"
+                f"Your repository URL is missing a trailing slash. "
+                "Please add it and try again.",
+            )
+
         return cls(
             f"{repository_url} attempted to redirect to {redirect_url}.\n"
             f"If you trust these URLs, set {redirect_url} as your repository URL.\n"

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -31,17 +31,11 @@ class RedirectDetected(TwineException):
 
     @classmethod
     def from_args(cls, repository_url: str, redirect_url: str) -> "RedirectDetected":
-        msg = "\n".join(
-            [
-                "{} attempted to redirect to {}.".format(repository_url, redirect_url),
-                "If you trust these URLs, set {} as your repository URL.".format(
-                    redirect_url
-                ),
-                "Aborting.",
-            ]
+        return cls(
+            f"{repository_url} attempted to redirect to {redirect_url}.\n"
+            f"If you trust these URLs, set {redirect_url} as your repository URL.\n"
+            "Aborting.",
         )
-
-        return cls(msg)
 
 
 class PackageNotFound(TwineException):


### PR DESCRIPTION
Towards #310, following up on https://github.com/pypa/twine/pull/809#discussion_r707834626.

Improving Twine's existing EAFP approach feels better to me than adding more LBYL conditions. This might also cover more repositories than PyPI, though https://github.com/pypa/twine/issues/310#issuecomment-405951929 shows that devpi returns "Not Found" instead of redirecting. I'm inclined to follow up with a commit or PR to handle that case in [`utils.check_status_code`](https://github.com/pypa/twine/blob/f54311486f1a27e732fa0118ac1b2b71f1c32c10/twine/utils.py#L172), if the approach in this PR gets approval.

FYI @meowmeowmeowcat 