### PR TITLE
Show asterisks for password with `--verbose`

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -352,7 +352,9 @@ def test_package_is_uploaded_incorrect_repo_url():
     [
         (None, None, ["username: <empty>", "password: <empty>"]),
         ("", "", ["username: <empty>", "password: <empty>"]),
-        ("username", "password", ["username: username", "password: <hidden>"]),
+        ("username", "password", ["username: username", "password: ********"]),
+        # Ctrl-V in Windows Command Prompt; see https://bugs.python.org/issue37426
+        ("username", "\x16", ["username: username", "password: *"]),
     ],
 )
 def test_logs_username_and_password(username, password, messages, caplog):

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -65,7 +65,7 @@ class Repository:
             (username or "", password or "") if username or password else None
         )
         logger.info(f"username: {username if username else '<empty>'}")
-        logger.info(f"password: <{'hidden' if password else 'empty'}>")
+        logger.info(f"password: {'*' * len(password) if password else '<empty>'}")
 
         self.session.headers["User-Agent"] = self._make_user_agent_string()
         for scheme in ("http://", "https://"):


### PR DESCRIPTION
As noted in https://github.com/pypa/twine/issues/671#issuecomment-910140288, when Windows users use `Ctrl+V` to paste their password, the resulting value is a control character, as documented in https://bugs.python.org/issue37426. The current behavior via https://github.com/pypa/twine/pull/685 is to show `<hidden>` in that case, but that's not useful information. The intention of that PR was to show `<empty>`, which would have indicated that pasting didn't work as expected.

This is a lightweight attempt to give the user better feedback, and aid troubleshooting. In https://github.com/pypa/twine/pull/685#discussion_r473097957, @sigmavirus24 said:

> I am strongly against revealing the length of a password. That's more metadata than is necessary.

However, given that this would be opt-in via `--verbose`, and the prevalence of this issue, I think the benefit outweighs the risk.

A further step could be to detect this case, and display a helpful warning message (possibly as a link to a new section in Twine's docs).