### PR TITLE
Support --skip-existing with GCP Artifact Registry

### DIFF
--- a/changelog/816.feature.rst
+++ b/changelog/816.feature.rst
@@ -1,0 +1,1 @@
+Allow the ``--skip-existing`` option to work with GCP Artifact Registry.

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -58,8 +58,8 @@ def skip_upload(
     return (
         # pypiserver (https://pypi.org/project/pypiserver)
         status == 409
-        # PyPI / TestPyPI
-        or (status == 400 and "already exist" in reason)
+        # PyPI / TestPyPI / GCP Artifact Registry
+        or (status == 400 and any("already exist" in x for x in [reason, text]))
         # Nexus Repository OSS (https://www.sonatype.com/nexus-repository-oss)
         or (status == 400 and any("updating asset" in x for x in [reason, text]))
         # Artifactory (https://jfrog.com/artifactory/)


### PR DESCRIPTION
GCP includes the same "already exist" note as PyPI in a 400 response,
but in `text` rather than `reason`.

Fixes #816.
