### PR TITLE
Reorder installation in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,8 @@ formats:
 python:
   # Mininum supported Python version
   version: "3.6"
+  # NB: install . first to avoid upgrading past docs/requirements.txt pins
   install:
-    - requirements: docs/requirements.txt
     - method: pip
       path: .
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,9 @@ formats:
 python:
   # Mininum supported Python version
   version: "3.6"
-  # NB: install . first to avoid upgrading past docs/requirements.txt pins
+  # Install twine first, because RTD uses `--upgrade-strategy eager`,
+  # which installs the latest version of docutils via readme_renderer.
+  # However, Sphinx 4.2.0 requires docutils>=0.14,<0.18.
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD installs this project with `pip install -U --upgrade-strategy eager .`
which pulls in docutils via `readme_renderer`.  Pinning `docutils` even
though we don't directly depend on it clears up the rendering errors.
