### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,17 +4,16 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 0 * * *'  # daily
+    - cron: "0 0 * * *" # daily
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run linting
@@ -23,8 +22,16 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -51,21 +58,24 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           # Mininum supported Python version
-          python-version: '3.6'
+          python-version: "3.6"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Build docs
         run: python -m tox -e docs
 
   release:
-    needs: [lint, test, docs]
+    needs:
+      - lint
+      - test
+      - docs
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run linting
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           # Mininum supported Python version
-          python-version: 3.6
+          python-version: '3.6'
       - name: Install dependencies
         run: python -m pip install tox
       - name: Build docs
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - name: Install dependencies
         run: python -m pip install tox
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,21 +20,6 @@ jobs:
       - name: Run linting
         run: python -m tox -e lint
 
-  types:
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run type-checking
-        run: python -m tox -e types
-
   test:
     strategy:
       matrix:
@@ -48,6 +33,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: python -m pip install tox
+      - name: Run type-checking
+        run: python -m tox -e types
       - name: Run tests
         run: python -m tox -e py -- --cov-report xml
       - uses: codecov/codecov-action@v1
@@ -71,7 +58,7 @@ jobs:
         run: python -m tox -e docs
 
   release:
-    needs: [lint, types, test, docs]
+    needs: [lint, test, docs]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9, 3.10]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/changelog/827.feature.rst
+++ b/changelog/827.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.10.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,13 +112,13 @@ To pass options to ``pytest``, e.g. the name of a test, run:
 
    tox -e py -- tests/test_upload.py::test_exception_for_http_status
 
-Twine is continuously tested against Python 3.6, 3.7, 3.8, and 3.9 using
+Twine is continuously tested against supported versions of Python using
 `GitHub Actions`_. To run the tests against a specific version, e.g. Python
-3.6, you will need it installed on your machine. Then, run:
+3.8, you will need it installed on your machine. Then, run:
 
 .. code-block:: bash
 
-   tox -e py36
+   tox -e py38
 
 To run the "integration" tests of uploading to real package indexes, run:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3
-envlist = lint,types,py{36,37,38,39},integration,docs
+envlist = lint,types,py{36,37,38,39,310},integration,docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Closes #826 

This also combines the `types` and `test` job, to reduce the overall size of the workflow matrix. That also means that `types` will be run on all platforms, instead of just `ubuntu`.