### PR TITLE
Avoid error from Sphinx 4.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 doc8>=0.8.0
 furo>=2021.10.09
 readme-renderer>=17.4
-Sphinx>=4.2.0
+Sphinx>=4.2.0,<4.3  # https://github.com/sphinx-doc/sphinx/issues/9844
 sphinxcontrib-programoutput>=0.17


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/9844. Using Sphinx < 4.3.0 until that's fixed.

From [a recent workflow run](https://github.com/pypa/twine/runs/4184779633?check_suite_focus=true#step:5:40):

> WARNING: error while formatting arguments for twine.utils.get_cacert: Handler <function update_defvalue at 0x7fb6e1174158> for event 'autodoc-before-process-signature' threw an exception (exception: functools.partial(<function get_userpass_value at 0x7fb6de6f2840>, key='ca_cert') is not a module, class, method, function, traceback, frame, or code object)