### PR TITLE
Add support for Metadata 2.2

### DIFF
--- a/changelog/833.feature.rst
+++ b/changelog/833.feature.rst
@@ -1,0 +1,1 @@
+Add support for core metadata version 2.2, defined in PEP 643.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages =
     twine.commands
 python_requires = >=3.6
 install_requires=
-    pkginfo >= 1.4.2
+    pkginfo >= 1.8.1
     readme_renderer >= 21.0
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -164,6 +164,7 @@ def test_metadata_dictionary(gpg_signature):
         requires_python=pretend.stub(),
         provides_extras=pretend.stub(),
         description_content_type=pretend.stub(),
+        dynamic=pretend.stub(),
     )
 
     package = package_file.PackageFile(
@@ -218,6 +219,9 @@ def test_metadata_dictionary(gpg_signature):
     # Metadata 2.1
     assert result["provides_extras"] == meta.provides_extras
     assert result["description_content_type"] == meta.description_content_type
+
+    # Metadata 2.2
+    assert result["dynamic"] == meta.dynamic
 
     # GPG signature
     assert result.get("gpg_signature") == gpg_signature

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -19,6 +19,8 @@ import pytest
 from twine import exceptions
 from twine import package as package_file
 
+from . import helpers
+
 
 def test_sign_file(monkeypatch):
     replaced_check_call = pretend.call_recorder(lambda args: None)
@@ -134,8 +136,59 @@ def test_package_safe_name_is_correct(pkg_name, expected_name):
     assert package.safe_name == expected_name
 
 
+def test_metadata_dictionary_keys():
+    """Merge multiple sources of metadata into a single dictionary."""
+    package = package_file.PackageFile.from_filename(helpers.SDIST_FIXTURE, None)
+    assert set(package.metadata_dictionary()) == set(
+        [
+            # identify release
+            "name",
+            "version",
+            # file content
+            "filetype",
+            "pyversion",
+            # additional meta-data
+            "metadata_version",
+            "summary",
+            "home_page",
+            "author",
+            "author_email",
+            "maintainer",
+            "maintainer_email",
+            "license",
+            "description",
+            "keywords",
+            "platform",
+            "classifiers",
+            "download_url",
+            "supported_platform",
+            "comment",
+            "md5_digest",
+            "sha256_digest",
+            "blake2_256_digest",
+            # PEP 314
+            "provides",
+            "requires",
+            "obsoletes",
+            # Metadata 1.2
+            "project_urls",
+            "provides_dist",
+            "obsoletes_dist",
+            "requires_dist",
+            "requires_external",
+            "requires_python",
+            # Metadata 2.1
+            "provides_extras",
+            "description_content_type",
+            # Metadata 2.2
+            "dynamic",
+        ]
+    )
+
+
 @pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])
-def test_metadata_dictionary(gpg_signature):
+def test_metadata_dictionary_values(gpg_signature):
+    """Pass values from pkginfo.Distribution through to dictionary."""
     meta = pretend.stub(
         name="whatever",
         version=pretend.stub(),

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -296,7 +296,7 @@ def test_pkginfo_returns_no_metadata(monkeypatch):
         package_file.PackageFile.from_filename(filename, comment=None)
 
     assert "Invalid distribution metadata" in err.value.args[0]
-    assert "1.0, 1.1, 1.2, 2.0, and 2.1" in err.value.args[0]
+    assert "1.0, 1.1, 1.2, 2.0, 2.1, and 2.2" in err.value.args[0]
 
 
 def test_malformed_from_file(monkeypatch):

--- a/twine/package.py
+++ b/twine/package.py
@@ -128,6 +128,10 @@ class PackageFile:
         return cls(filename, comment, meta, py_version, dtype)
 
     def metadata_dictionary(self) -> Dict[str, MetadataValue]:
+        """Merge multiple sources of metadata into a single dictionary.
+
+        Includes values from filename, PKG-INFO, hashers, and signature.
+        """
         meta = self.metadata
         data = {
             # identify release

--- a/twine/package.py
+++ b/twine/package.py
@@ -167,6 +167,8 @@ class PackageFile:
             # Metadata 2.1
             "provides_extras": meta.provides_extras,
             "description_content_type": meta.description_content_type,
+            # Metadata 2.2
+            "dynamic": meta.dynamic,
         }
 
         if self.gpg_signature is not None:


### PR DESCRIPTION
Closes #753, though I'm starting this as a draft PR because I'm not sure there's enough here.

Changes so far:

- Require the [latest version of `pkginfo`](https://pypi.org/project/pkginfo/1.8.1/), which now has support for 2.2
- Update `PackageFile` and related tests to recognize new version and the `dynamic` field

Questions:

- The [PyPUG](https://packaging.python.org/specifications/core-metadata/#dynamic-multiple-use) defines some rules for `Dynamic`, and says `Name` and `Version` may not be specified as `Dynamic`. Looking over the relevant [`pkginfo` changes](https://bazaar.launchpad.net/~tseaver/pkginfo/trunk/revision/185), I don't see any validation of those rules. Where should that happen? Maybe @pfmoore and @tseaver have thoughts?

- @FFY00 Does this meet your needs for #753?