### PR TITLE
Use pipx to run tox in GitHub Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run tests
-        run: python -m tox -e integration
+        run: pipx run tox -e integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run linting
-        run: python -m tox -e lint
+        run: pipx run tox -e lint
 
   test:
     strategy:
@@ -44,12 +42,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run type-checking
-        run: python -m tox -e types
+        run: pipx run tox -e types
       - name: Run tests
-        run: python -m tox -e py -- --cov-report xml
+        run: pipx run tox -e py -- --cov-report xml
       - uses: codecov/codecov-action@v1
         if: github.event_name != 'schedule'
         with:
@@ -64,10 +60,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Build docs
-        run: python -m tox -e docs
+        run: pipx run tox -e docs
 
   release:
     needs:
@@ -81,9 +75,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Release
-        run: tox -e release
+        run: pipx run tox -e release
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I saw this while poking around other repos, and it was a simple way to simplify the workflow files