### PR TITLE
Fix link to packaging tutorial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Everyone interacting in the Twine project's codebases, issue
 trackers, chat rooms, and mailing lists is expected to follow the
 `PSF Code of Conduct`_.
 
-.. _`publishing`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`publishing`: https://packaging.python.org/tutorials/packaging-projects/
 .. _`PyPI`: https://pypi.org
 .. _`distributions`:
    https://packaging.python.org/glossary/#term-Distribution-Package

--- a/changelog/844.doc.rst
+++ b/changelog/844.doc.rst
@@ -1,0 +1,1 @@
+Fix broken link to packaging tutorial.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -291,7 +291,7 @@ In the future, ``pip`` and ``twine`` may
 merge into a single tool; see `ongoing discussion
 <https://github.com/pypa/packaging-problems/issues/60>`_.
 
-.. _`official Python Packaging User Guide`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`official Python Packaging User Guide`: https://packaging.python.org/tutorials/packaging-projects/
 .. _`the GitHub repository`: https://github.com/pypa/twine
 .. _`Python Packaging Discourse forum`: https://discuss.python.org/c/packaging/
 .. _`IRC`: https://web.libera.chat/#pypa-dev,#pypa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@
    Code of Conduct <https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md>
    PyPI Project <https://pypi.org/project/twine/>
    GitHub Repository <https://github.com/pypa/twine>
-   Python Packaging Tutorial <https://packaging.python.org/tutorials/distributing-packages/>
+   Python Packaging Tutorial <https://packaging.python.org/tutorials/packaging-projects/>
 
 Twine
 =====
@@ -229,12 +229,12 @@ Keyring, run:
 See `Twine issue #338`_ for discussion and background.
 
 
-.. _`publishing`: https://packaging.python.org/tutorials/distributing-packages/
+.. _`publishing`: https://packaging.python.org/tutorials/packaging-projects/
 .. _`PyPI`: https://pypi.org
 .. _`Test PyPI`: https://packaging.python.org/guides/using-testpypi/
 .. _`pypirc`: https://packaging.python.org/specifications/pypirc/
 .. _`Python Packaging User Guide`:
-   https://packaging.python.org/tutorials/distributing-packages/
+   https://packaging.python.org/tutorials/packaging-projects/
 .. _`keyring`: https://pypi.org/project/keyring/
 .. _`Using Keyring on headless systems`:
    https://keyring.readthedocs.io/en/latest/#using-keyring-on-headless-linux-systems

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://twine.readthedocs.io/
 project_urls =
     Source = https://github.com/pypa/twine/
     Documentation = https://twine.readthedocs.io/en/latest/
-    Packaging tutorial = https://packaging.python.org/tutorials/distributing-packages/
+    Packaging tutorial = https://packaging.python.org/tutorials/packaging-projects/
 classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
It was relying on a redirect that's been lost; see https://github.com/pypa/packaging.python.org/issues/1026#issuecomment-987509961.