### PR TITLE
Add verbose logging for querying keyring credentials

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -86,7 +86,9 @@ def test_get_username_and_password_keyring_overrides_prompt(
     assert res.password == "real_user@system sekure pa55word"
 
     assert caplog.messages == [
+        "Querying keyring for username",
         "username set from keyring",
+        "Querying keyring for password",
         "password set from keyring",
     ]
 

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -56,6 +56,7 @@ class Resolver:
     def get_username_from_keyring(self) -> Optional[str]:
         try:
             system = cast(str, self.system)
+            logger.info("Querying keyring for username")
             creds = keyring.get_credential(system, None)
             if creds:
                 return cast(str, creds.username)
@@ -70,6 +71,7 @@ class Resolver:
         try:
             system = cast(str, self.system)
             username = cast(str, self.username)
+            logger.info("Querying keyring for password")
             return cast(str, keyring.get_password(system, username))
         except Exception as exc:
             warnings.warn(str(exc))


### PR DESCRIPTION
Following up on #847, I think this would have been helpful in troubleshooting, by showing that keyring was blocked.