### PR TITLE
Use Rich for log messages

### DIFF
--- a/changelog/818.feature.rst
+++ b/changelog/818.feature.rst
@@ -1,0 +1,1 @@
+Use Rich to add color to ``upload`` logging output.

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,10 +18,6 @@ warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
 
-[mypy-colorama]
-; https://github.com/tartley/colorama/issues/206
-ignore_missing_imports = True
-
 [mypy-pkginfo]
 ; https://bugs.launchpad.net/pkginfo/+bug/1876591
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires=
     keyring >= 15.1
     rfc3986 >= 1.4.0
     colorama >= 0.4.3
+    rich
 include_package_data = True
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ install_requires=
     importlib_metadata >= 3.6
     keyring >= 15.1
     rfc3986 >= 1.4.0
-    colorama >= 0.4.3
     rich
 include_package_data = True
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -149,21 +149,17 @@ def keyring_no_backends_get_credential(monkeypatch):
 
 
 def test_get_username_runtime_error_suppressed(
-    entered_username, keyring_no_backends_get_credential, recwarn, config
+    entered_username, keyring_no_backends_get_credential, caplog, config
 ):
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
-    assert len(recwarn) == 1
-    warning = recwarn.pop(UserWarning)
-    assert "fail!" in str(warning)
+    assert caplog.messages == ["fail!"]
 
 
 def test_get_password_runtime_error_suppressed(
-    entered_password, keyring_no_backends, recwarn, config
+    entered_password, keyring_no_backends, caplog, config
 ):
     assert auth.Resolver(config, auth.CredentialInput("user")).password == "entered pw"
-    assert len(recwarn) == 1
-    warning = recwarn.pop(UserWarning)
-    assert "fail!" in str(warning)
+    assert caplog.messages == ["fail!"]
 
 
 def test_get_username_return_none(entered_username, monkeypatch, config):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -219,6 +219,9 @@ def test_warns_for_empty_password(
     config,
     caplog,
 ):
+    # Avoiding additional warning "No recommended backend was available"
+    monkeypatch.setattr(auth.keyring, "get_password", lambda system, user: None)
+
     monkeypatch.setattr(getpass, "getpass", lambda prompt: password)
 
     assert auth.Resolver(config, auth.CredentialInput()).password == password

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -223,4 +223,4 @@ def test_warns_for_empty_password(
 
     assert auth.Resolver(config, auth.CredentialInput()).password == password
 
-    assert caplog.messages[0].startswith(f"  {warning}")
+    assert caplog.messages[0].startswith(warning)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,6 @@
 
 import sys
 
-import pytest
-
 from twine import __main__ as dunder_main
 
 
@@ -34,7 +32,6 @@ def test_exception_handling(monkeypatch, capsys):
     ]
 
 
-@pytest.mark.xfail(reason="capsys isn't reset, resulting in duplicate lines")
 def test_no_color_exception(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["twine", "--no-color", "upload", "missing.whl"])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,18 +12,42 @@
 
 import sys
 
-import colorama
+import pytest
 
 from twine import __main__ as dunder_main
 
 
-def test_exception_handling(monkeypatch):
+def test_exception_handling(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["twine", "upload", "missing.whl"])
-    message = "InvalidDistribution: Cannot find file (or expand pattern): 'missing.whl'"
-    assert dunder_main.main() == colorama.Fore.RED + message + colorama.Style.RESET_ALL
+
+    error = dunder_main.main()
+    assert error
+
+    captured = capsys.readouterr()
+
+    # Removing trailing whitespace on lines wrapped by Rich; trying to test it was ugly.
+    # TODO: Assert color
+    assert [line.rstrip() for line in captured.out.splitlines()] == [
+        "ERROR    InvalidDistribution: Cannot find file (or expand pattern):",
+        "         'missing.whl'",
+    ]
 
 
-def test_no_color_exception(monkeypatch):
+@pytest.mark.xfail(reason="capsys isn't reset, resulting in duplicate lines")
+def test_no_color_exception(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["twine", "--no-color", "upload", "missing.whl"])
-    message = "InvalidDistribution: Cannot find file (or expand pattern): 'missing.whl'"
-    assert dunder_main.main() == message
+
+    error = dunder_main.main()
+    assert error
+
+    captured = capsys.readouterr()
+
+    # Removing trailing whitespace on lines wrapped by Rich; trying to test it was ugly.
+    # TODO: Assert no color
+    assert [line.rstrip() for line in captured.out.splitlines()] == [
+        "ERROR    InvalidDistribution: Cannot find file (or expand pattern):",
+        "         'missing.whl'",
+    ]
+
+
+# TODO: Test verbose output formatting

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,8 +43,7 @@ def test_no_color_exception(monkeypatch, capsys):
 
     captured = capsys.readouterr()
 
-    # Removing trailing whitespace on lines wrapped by Rich; trying to test it was ugly.
-    # TODO: Assert no color
+    # Removing trailing whitespace on wrapped lines; trying to test it was ugly.
     assert [line.rstrip() for line in captured.out.splitlines()] == [
         "ERROR    InvalidDistribution: Cannot find file (or expand pattern):",
         "         'missing.whl'",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,10 +25,11 @@ def test_exception_handling(monkeypatch, capsys):
 
     captured = capsys.readouterr()
 
-    # Removing trailing whitespace on lines wrapped by Rich; trying to test it was ugly.
-    # TODO: Assert color
+    # Hard-coding control characters for red text; couldn't find a succint alternative.
+    # Removing trailing whitespace on wrapped lines; trying to test it was ugly.
+    level = "\x1b[31mERROR   \x1b[0m"
     assert [line.rstrip() for line in captured.out.splitlines()] == [
-        "ERROR    InvalidDistribution: Cannot find file (or expand pattern):",
+        f"{level} InvalidDistribution: Cannot find file (or expand pattern):",
         "         'missing.whl'",
     ]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,7 +17,6 @@ import logging
 
 import pytest
 
-from twine import __main__ as dunder_main
 from twine import exceptions
 from twine import settings
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,6 +17,7 @@ import logging
 
 import pytest
 
+from twine import __main__ as dunder_main
 from twine import exceptions
 from twine import settings
 
@@ -66,16 +67,14 @@ def test_setup_logging(verbose, log_level):
     "verbose",
     [True, False],
 )
-def test_print_config_path_if_verbose(config_file, capsys, make_settings, verbose):
+def test_print_config_path_if_verbose(config_file, caplog, make_settings, verbose):
     """Print the location of the .pypirc config used by the user."""
     make_settings(verbose=verbose)
 
-    captured = capsys.readouterr()
-
     if verbose:
-        assert captured.out == f"Using configuration from {config_file}\n"
+        assert caplog.messages == [f"Using configuration from {config_file}"]
     else:
-        assert captured.out == ""
+        assert caplog.messages == []
 
 
 def test_identity_requires_sign():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -54,7 +54,7 @@ def upload_settings(make_settings, stub_repository):
     return upload_settings
 
 
-def test_make_package_pre_signed_dist(upload_settings, capsys):
+def test_make_package_pre_signed_dist(upload_settings, caplog):
     """Create a PackageFile and print path, size, and user-provided signature."""
     filename = helpers.WHEEL_FIXTURE
     expected_size = "15.4 KB"
@@ -69,12 +69,13 @@ def test_make_package_pre_signed_dist(upload_settings, capsys):
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = capsys.readouterr()
-    assert captured.out.count(f"{filename} ({expected_size})") == 1
-    assert captured.out.count(f"Signed with {signed_filename}") == 1
+    assert caplog.messages == [
+        f"{filename} ({expected_size})",
+        f"Signed with {signed_filename}",
+    ]
 
 
-def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
+def test_make_package_unsigned_dist(upload_settings, monkeypatch, caplog):
     """Create a PackageFile and print path, size, and Twine-generated signature."""
     filename = helpers.NEW_WHEEL_FIXTURE
     expected_size = "21.9 KB"
@@ -93,9 +94,10 @@ def test_make_package_unsigned_dist(upload_settings, monkeypatch, capsys):
     assert package.filename == filename
     assert package.gpg_signature is not None
 
-    captured = capsys.readouterr()
-    assert captured.out.count(f"{filename} ({expected_size})") == 1
-    assert captured.out.count(f"Signed with {package.signed_filename}") == 1
+    assert caplog.messages == [
+        f"{filename} ({expected_size})",
+        f"Signed with {package.signed_filename}",
+    ]
 
 
 def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
@@ -118,13 +120,13 @@ def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
     assert captured.out.count(NEW_RELEASE_URL) == 1
 
 
-def test_print_packages_if_verbose(upload_settings, capsys):
+def test_print_packages_if_verbose(upload_settings, caplog):
     """Print the path and file size of each distribution attempting to be uploaded."""
     dists_to_upload = {
         helpers.WHEEL_FIXTURE: "15.4 KB",
+        helpers.NEW_WHEEL_FIXTURE: "21.9 KB",
         helpers.SDIST_FIXTURE: "20.8 KB",
         helpers.NEW_SDIST_FIXTURE: "26.1 KB",
-        helpers.NEW_WHEEL_FIXTURE: "21.9 KB",
     }
 
     upload_settings.verbose = True
@@ -132,10 +134,9 @@ def test_print_packages_if_verbose(upload_settings, capsys):
     result = upload.upload(upload_settings, dists_to_upload.keys())
     assert result is None
 
-    captured = capsys.readouterr()
-
-    for filename, size in dists_to_upload.items():
-        assert captured.out.count(f"{filename} ({size})") == 1
+    assert caplog.messages == [
+        f"{filename} ({size})" for filename, size in dists_to_upload.items()
+    ]
 
 
 def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
@@ -181,7 +182,9 @@ def test_success_when_gpg_is_run(upload_settings, stub_repository, monkeypatch):
 
 
 @pytest.mark.parametrize("verbose", [False, True])
-def test_exception_for_http_status(verbose, upload_settings, stub_response, capsys):
+def test_exception_for_http_status(
+    verbose, upload_settings, stub_response, capsys, caplog
+):
     upload_settings.verbose = verbose
 
     stub_response.is_redirect = False
@@ -196,11 +199,14 @@ def test_exception_for_http_status(verbose, upload_settings, stub_response, caps
     assert RELEASE_URL not in captured.out
 
     if verbose:
-        assert stub_response.text in captured.out
-        assert "--verbose" not in captured.out
+        assert caplog.messages == [
+            f"{helpers.WHEEL_FIXTURE} (15.4 KB)",
+            f"Content received from server:\n{stub_response.text}",
+        ]
     else:
-        assert stub_response.text not in captured.out
-        assert "--verbose" in captured.out
+        assert caplog.messages == [
+            "Error during upload. Retry with the --verbose option for more details."
+        ]
 
 
 def test_get_config_old_format(make_settings, config_file):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,7 +265,7 @@ def test_check_status_code_for_deprecated_pypi_url(repo_url):
     [True, False],
 )
 def test_check_status_code_for_missing_status_code(
-    capsys, repo_url, verbose, make_settings
+    caplog, repo_url, verbose, make_settings, config_file
 ):
     """Print HTTP errors based on verbosity level."""
     response = pretend.stub(
@@ -280,12 +280,15 @@ def test_check_status_code_for_missing_status_code(
     with pytest.raises(requests.HTTPError):
         utils.check_status_code(response, verbose)
 
-    captured = capsys.readouterr()
-
     if verbose:
-        assert captured.out.count("Content received from server:\nForbidden\n") == 1
+        assert caplog.messages == [
+            f"Using configuration from {config_file}",
+            f"Content received from server:\n{response.text}",
+        ]
     else:
-        assert captured.out.count("--verbose option") == 1
+        assert caplog.messages == [
+            "Error during upload. Retry with the --verbose option for more details."
+        ]
 
 
 @pytest.mark.parametrize(

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -18,8 +18,10 @@ import sys
 from typing import Any
 
 import requests
+import rich.console
 import rich.highlighter
 import rich.logging
+import rich.theme
 
 from twine import cli
 from twine import exceptions
@@ -29,6 +31,17 @@ def main() -> Any:
     root_logger = logging.getLogger("twine")
     root_logger.addHandler(
         rich.logging.RichHandler(
+            console=rich.console.Console(
+                theme=rich.theme.Theme(
+                    {
+                        "logging.level.debug": "green",
+                        "logging.level.info": "blue",
+                        "logging.level.warning": "yellow",
+                        "logging.level.error": "red",
+                        "logging.level.critical": "reverse red",
+                    }
+                )
+            ),
             show_time=False,
             show_path=False,
             highlighter=rich.highlighter.NullHighlighter(),

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -13,40 +13,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import http
+import logging
 import sys
 from typing import Any
 
-import colorama
 import requests
+import rich.highlighter
+import rich.logging
 
 from twine import cli
 from twine import exceptions
 
 
 def main() -> Any:
+    root_logger = logging.getLogger("twine")
+    root_logger.addHandler(
+        rich.logging.RichHandler(
+            show_time=False,
+            show_path=False,
+            highlighter=rich.highlighter.NullHighlighter(),
+        )
+    )
+
     try:
-        result = cli.dispatch(sys.argv[1:])
+        error = cli.dispatch(sys.argv[1:])
     except requests.HTTPError as exc:
+        error = True
         status_code = exc.response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase
-        result = (
+        root_logger.error(
             f"{exc.__class__.__name__}: {status_code} {status_phrase} "
             f"from {exc.response.url}\n"
             f"{exc.response.reason}"
         )
     except exceptions.TwineException as exc:
-        result = f"{exc.__class__.__name__}: {exc.args[0]}"
+        error = True
+        root_logger.error(f"{exc.__class__.__name__}: {exc.args[0]}")
 
-    return _format_error(result) if isinstance(result, str) else result
-
-
-def _format_error(message: str) -> str:
-    pre_style, post_style = "", ""
-    if not cli.args.no_color:
-        colorama.init()
-        pre_style, post_style = colorama.Fore.RED, colorama.Style.RESET_ALL
-
-    return f"{pre_style}{message}{post_style}"
+    return error
 
 
 if __name__ == "__main__":

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -18,36 +18,16 @@ import sys
 from typing import Any
 
 import requests
-import rich.console
-import rich.highlighter
-import rich.logging
-import rich.theme
 
 from twine import cli
 from twine import exceptions
 
 
 def main() -> Any:
+    # Ensure that all log messages are displayed.
+    # Color will be configured during cli.dispatch() after argparse.
     root_logger = logging.getLogger("twine")
-    root_logger.addHandler(
-        rich.logging.RichHandler(
-            console=rich.console.Console(
-                theme=rich.theme.Theme(
-                    {
-                        "logging.level.debug": "green",
-                        "logging.level.info": "blue",
-                        "logging.level.warning": "yellow",
-                        "logging.level.error": "red",
-                        "logging.level.critical": "reverse red",
-                    }
-                ),
-                force_terminal=True,
-            ),
-            show_time=False,
-            show_path=False,
-            highlighter=rich.highlighter.NullHighlighter(),
-        )
-    )
+    root_logger.addHandler(logging.StreamHandler(sys.stdout))
 
     try:
         error = cli.dispatch(sys.argv[1:])

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def main() -> Any:
     # Ensure that all errors are logged, even before argparse
-    cli.configure_logging()
+    cli.configure_output()
 
     try:
         error = cli.dispatch(sys.argv[1:])

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -40,7 +40,8 @@ def main() -> Any:
                         "logging.level.error": "red",
                         "logging.level.critical": "reverse red",
                     }
-                )
+                ),
+                force_terminal=True,
             ),
             show_time=False,
             show_path=False,

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -22,12 +22,12 @@ import requests
 from twine import cli
 from twine import exceptions
 
+logger = logging.getLogger(__name__)
+
 
 def main() -> Any:
-    # Ensure that all log messages are displayed.
-    # Color will be configured during cli.dispatch() after argparse.
-    root_logger = logging.getLogger("twine")
-    root_logger.addHandler(logging.StreamHandler(sys.stdout))
+    # Ensure that all errors are logged, even before argparse
+    cli.configure_logging()
 
     try:
         error = cli.dispatch(sys.argv[1:])
@@ -35,14 +35,14 @@ def main() -> Any:
         error = True
         status_code = exc.response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase
-        root_logger.error(
+        logger.error(
             f"{exc.__class__.__name__}: {status_code} {status_phrase} "
             f"from {exc.response.url}\n"
             f"{exc.response.reason}"
         )
     except exceptions.TwineException as exc:
         error = True
-        root_logger.error(f"{exc.__class__.__name__}: {exc.args[0]}")
+        logger.error(f"{exc.__class__.__name__}: {exc.args[0]}")
 
     return error
 

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -1,7 +1,6 @@
 import functools
 import getpass
 import logging
-import warnings
 from typing import Callable, Optional, Type, cast
 
 import keyring
@@ -64,7 +63,7 @@ class Resolver:
             # To support keyring prior to 15.2
             pass
         except Exception as exc:
-            warnings.warn(str(exc))
+            logger.warning(str(exc))
         return None
 
     def get_password_from_keyring(self) -> Optional[str]:
@@ -74,7 +73,7 @@ class Resolver:
             logger.info("Querying keyring for password")
             return cast(str, keyring.get_password(system, username))
         except Exception as exc:
-            warnings.warn(str(exc))
+            logger.warning(str(exc))
         return None
 
     def username_from_keyring_or_prompt(self) -> str:

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import logging
+import logging.config
 from typing import Any, List, Tuple
 
 import importlib_metadata
@@ -48,20 +48,26 @@ console = rich.console.Console(
 
 
 def configure_logging() -> None:
-    root_logger = logging.getLogger("twine")
-
-    # This prevents failures test_main.py due to capsys not being cleared.
-    # TODO: Use dictConfig() instead?
-    for handler in root_logger.handlers:
-        root_logger.removeHandler(handler)
-
-    root_logger.addHandler(
-        rich.logging.RichHandler(
-            console=console,
-            show_time=False,
-            show_path=False,
-            highlighter=rich.highlighter.NullHighlighter(),
-        )
+    # Using dictConfig to override existing loggers, which prevents failures in
+    # test_main.py due to capsys not being cleared.
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "handlers": {
+                "console": {
+                    "class": "rich.logging.RichHandler",
+                    "console": console,
+                    "show_time": False,
+                    "show_path": False,
+                    "highlighter": rich.highlighter.NullHighlighter(),
+                }
+            },
+            "loggers": {
+                "twine": {
+                    "handlers": ["console"],
+                },
+            },
+        }
     )
 
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -82,9 +82,9 @@ def _make_package(
         package.sign(upload_settings.sign_with, upload_settings.identity)
 
     file_size = utils.get_file_size(package.filename)
-    logger.info(f"  {package.filename} ({file_size})")
+    logger.info(f"{package.filename} ({file_size})")
     if package.gpg_signature:
-        logger.info(f"  Signed with {package.signed_filename}")
+        logger.info(f"Signed with {package.signed_filename}")
 
     return package
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -149,8 +149,8 @@ class Settings:
     def verbose(self, verbose: bool) -> None:
         """Initialize a logger based on the --verbose option."""
         self._verbose = verbose
-        root_logger = logging.getLogger("twine")
-        root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
+        twine_logger = logging.getLogger("twine")
+        twine_logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     @staticmethod
     def register_argparse_arguments(parser: argparse.ArgumentParser) -> None:

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -15,8 +15,10 @@
 import argparse
 import contextlib
 import logging
-import sys
 from typing import Any, ContextManager, Optional, cast
+
+import rich.highlighter
+import rich.logging
 
 from twine import auth
 from twine import exceptions
@@ -151,7 +153,13 @@ class Settings:
         """Initialize a logger based on the --verbose option."""
         self._verbose = verbose
         root_logger = logging.getLogger("twine")
-        root_logger.addHandler(logging.StreamHandler(sys.stdout))
+        root_logger.addHandler(
+            rich.logging.RichHandler(
+                show_time=False,
+                show_path=False,
+                highlighter=rich.highlighter.NullHighlighter(),
+            )
+        )
         root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     @staticmethod

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -17,9 +17,6 @@ import contextlib
 import logging
 from typing import Any, ContextManager, Optional, cast
 
-import rich.highlighter
-import rich.logging
-
 from twine import auth
 from twine import exceptions
 from twine import repository
@@ -153,13 +150,6 @@ class Settings:
         """Initialize a logger based on the --verbose option."""
         self._verbose = verbose
         root_logger = logging.getLogger("twine")
-        root_logger.addHandler(
-            rich.logging.RichHandler(
-                show_time=False,
-                show_path=False,
-                highlighter=rich.highlighter.NullHighlighter(),
-            )
-        )
         root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     @staticmethod

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -258,9 +258,9 @@ def get_userpass_value(
             warning = f"Your {key} contains control characters"
 
         if warning:
-            logger.warning(f"  {warning}. Did you enter it correctly?")
+            logger.warning(f"{warning}. Did you enter it correctly?")
             logger.warning(
-                "  See https://twine.readthedocs.io/#entering-credentials "
+                "See https://twine.readthedocs.io/#entering-credentials "
                 "for more information."
             )
 


### PR DESCRIPTION
Towards #818. I'm opening this up early for feedback on the rendered log messages. I started with the easy thing of using [Rich's logging handler](https://rich.readthedocs.io/en/latest/logging.html). Out of the box, it feels like its intended audience is devs reading log messages, so I tweaked it a bit to be friendlier to everyday CLI users. 

<img width="675" alt="Screen Shot 2022-01-02 at 6 32 30 AM" src="https://user-images.githubusercontent.com/1326704/147874477-03908860-8942-4574-b22a-b77ad07f9af2.png">

vs. the current behavior:

<img width="673" alt="Screen Shot 2022-01-01 at 5 00 32 PM" src="https://user-images.githubusercontent.com/1326704/147861139-7fb92d62-2048-4847-b243-3bc93e9b2fa7.png">
