### PR TITLE
Fix mypy error from `urllib.Retry` kwargs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires=
     readme_renderer >= 21.0
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0
+    urllib3 >= 1.26.0
     tqdm >= 4.14
     importlib_metadata >= 3.6
     keyring >= 15.1

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -14,8 +14,8 @@
 import argparse
 from typing import Any, List, Tuple
 
-from importlib_metadata import entry_points
-from importlib_metadata import version
+import importlib_metadata
+from packaging import requirements
 
 import twine
 
@@ -23,16 +23,9 @@ args = argparse.Namespace()
 
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
-    deps = (
-        "importlib_metadata",
-        "pkginfo",
-        "requests",
-        "requests-toolbelt",
-        "urllib3",
-        "keyring",
-        "tqdm",
-    )
-    return [(dep, version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
+    requires = importlib_metadata.requires("twine")  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
+    deps = [requirements.Requirement(r).name for r in requires]
+    return [(dep, importlib_metadata.version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 
 
 def dep_versions() -> str:
@@ -42,7 +35,9 @@ def dep_versions() -> str:
 
 
 def dispatch(argv: List[str]) -> Any:
-    registered_commands = entry_points(group="twine.registered_commands")
+    registered_commands = importlib_metadata.entry_points(
+        group="twine.registered_commands"
+    )
     parser = argparse.ArgumentParser(prog="twine")
     parser.add_argument(
         "--version",

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -28,6 +28,8 @@ def list_dependencies_and_versions() -> List[Tuple[str, str]]:
         "pkginfo",
         "requests",
         "requests-toolbelt",
+        "urllib3",
+        "keyring",
         "tqdm",
     )
     return [(dep, version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -77,22 +77,12 @@ class Repository:
 
     @staticmethod
     def _make_adapter_with_retries() -> adapters.HTTPAdapter:
-        try:
-            retry = urllib3.Retry(
-                allowed_methods=["GET"],
-                connect=5,
-                total=10,
-                status_forcelist=[500, 501, 502, 503],
-            )
-        except TypeError:  # pragma: no cover
-            # Avoiding DeprecationWarning starting in urllib3 1.26
-            # Remove when that's the mininum version
-            retry = urllib3.Retry(
-                method_whitelist=["GET"],
-                connect=5,
-                total=10,
-                status_forcelist=[500, 501, 502, 503],
-            )
+        retry = urllib3.Retry(
+            allowed_methods=["GET"],
+            connect=5,
+            total=10,
+            status_forcelist=[500, 501, 502, 503],
+        )
 
         return adapters.HTTPAdapter(max_retries=retry)
 

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -77,18 +77,22 @@ class Repository:
 
     @staticmethod
     def _make_adapter_with_retries() -> adapters.HTTPAdapter:
-        retry_kwargs = dict(
-            connect=5,
-            total=10,
-            status_forcelist=[500, 501, 502, 503],
-        )
-
         try:
-            retry = urllib3.Retry(allowed_methods=["GET"], **retry_kwargs)
+            retry = urllib3.Retry(
+                allowed_methods=["GET"],
+                connect=5,
+                total=10,
+                status_forcelist=[500, 501, 502, 503],
+            )
         except TypeError:  # pragma: no cover
             # Avoiding DeprecationWarning starting in urllib3 1.26
             # Remove when that's the mininum version
-            retry = urllib3.Retry(method_whitelist=["GET"], **retry_kwargs)
+            retry = urllib3.Retry(
+                method_whitelist=["GET"],
+                connect=5,
+                total=10,
+                status_forcelist=[500, 501, 502, 503],
+            )
 
         return adapters.HTTPAdapter(max_retries=retry)
 


### PR DESCRIPTION
Should fix failing CI: https://github.com/pypa/twine/runs/4835196152?check_suite_focus=true#step:5:18

I don't know why this just started happening, but it seemed expedient to just fix it. I was surprised to see that urllib3 wasn't in `install_requires`, even though it's directly imported. So, I added a minimum version to avoid the deprecation.

Acknowledging some scope creep, I added urllib3 and the rest of Twine's requirements to `--version`. Happy to revert if that's too much.

```
% twine --version
twine version 3.7.2.dev7+g2f05770.d20220117 (pkginfo: 1.8.2, readme_renderer:
30.0, requests: 2.26.0, requests-toolbelt: 0.9.1, urllib3: 1.26.7, tqdm:
4.62.3, importlib_metadata: 4.8.2, keyring: 23.2.1, rfc3986: 1.5.0, colorama:
0.4.4)
```