### PR TITLE
Log all upload responses with `--verbose`

### DIFF
--- a/changelog/859.feature.rst
+++ b/changelog/859.feature.rst
@@ -1,0 +1,1 @@
+Log all upload responses with ``--verbose``.

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -143,6 +143,25 @@ def test_print_packages_if_verbose(upload_settings, capsys):
         assert captured.out.count(f"{filename} ({size})") == 1
 
 
+def test_print_response_if_verbose(upload_settings, stub_response, capsys):
+    """Print details about the response from the repostiry."""
+    upload_settings.verbose = True
+
+    result = upload.upload(
+        upload_settings,
+        [helpers.WHEEL_FIXTURE, helpers.SDIST_FIXTURE],
+    )
+    assert result is None
+
+    captured = capsys.readouterr()
+    response_log = (
+        f"Response from {stub_response.url}:\n"
+        f"{stub_response.status_code} {stub_response.reason}"
+    )
+
+    assert captured.out.count(response_log) == 2
+
+
 def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
     """Add GPG signature provided by user to uploaded package."""
     # Upload a pre-signed distribution

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,10 +282,7 @@ def test_check_status_code_for_missing_status_code(
 
     captured = capsys.readouterr()
 
-    if verbose:
-        assert captured.out.count("Content received from server:\nForbidden\n") == 1
-    else:
-        assert captured.out.count("--verbose option") == 1
+    assert captured.out.count("--verbose option") == 0 if verbose else 1
 
 
 @pytest.mark.parametrize(

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -18,7 +18,6 @@ import os.path
 from typing import Dict, List, cast
 
 import requests
-from requests_toolbelt.utils import dump
 
 from twine import commands
 from twine import exceptions
@@ -142,7 +141,11 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         resp = repository.upload(package)
 
         if upload_settings.verbose:
-            logger.info(dump.dump_all(resp).decode("utf-8"))
+            logger.info(
+                f"Received {resp.status_code} response from {resp.url}: {resp.reason}"
+            )
+            if resp.text:
+                logger.info(f"Response text:\n{resp.text}")
 
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -139,12 +139,9 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
             continue
 
         resp = repository.upload(package)
-
-        if upload_settings.verbose:
-            logger.info(f"Request: {resp.request.method} {resp.request.url}")
-            logger.info(f"Response from {resp.url}:\n{resp.status_code} {resp.reason}")
-            if resp.text:
-                logger.info(f"Response text:\n{resp.text}")
+        logger.info(f"Response from {resp.url}:\n{resp.status_code} {resp.reason}")
+        if resp.text:
+            logger.info(resp.text)
 
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -141,9 +141,8 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         resp = repository.upload(package)
 
         if upload_settings.verbose:
-            logger.info(
-                f"Received {resp.status_code} response from {resp.url}: {resp.reason}"
-            )
+            logger.info(f"Request: {resp.request.method} {resp.request.url}")
+            logger.info(f"Response from {resp.url}:\n{resp.status_code} {resp.reason}")
             if resp.text:
                 logger.info(f"Response text:\n{resp.text}")
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -140,6 +140,13 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
 
         resp = repository.upload(package)
 
+        if upload_settings.verbose:
+            logger.info(
+                f"Received {resp.status_code} response from {resp.url}: {resp.reason}"
+            )
+            if resp.text:
+                logger.info(f"Response text:\n{resp.text}")
+
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued
         # by PyPI should never happen in reality. This should catch malicious

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -18,6 +18,7 @@ import os.path
 from typing import Dict, List, cast
 
 import requests
+from requests_toolbelt.utils import dump
 
 from twine import commands
 from twine import exceptions
@@ -141,11 +142,7 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         resp = repository.upload(package)
 
         if upload_settings.verbose:
-            logger.info(
-                f"Received {resp.status_code} response from {resp.url}: {resp.reason}"
-            )
-            if resp.text:
-                logger.info(f"Response text:\n{resp.text}")
+            logger.info(dump.dump_all(resp).decode("utf-8"))
 
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -204,9 +204,6 @@ def check_status_code(response: requests.Response, verbose: bool) -> None:
                 "Retry with the --verbose option for more details."
             )
 
-        if response.text:
-            logger.info("Content received from server:\n{}".format(response.text))
-
         raise err
 
 


### PR DESCRIPTION
Towards #856. This is a quick hack to log all HTTP responses, not just `--verbose`, in the hopes of assisting debugging uploads that should fail, but don't.

@usinelogicielle, can you try this out in your environment? You should be able to install it with:

```sh
python3 -m pip install -e git+https://github.com/bhrutledge/twine.git@856-verbose-response#egg=twine
```

I'm very open to feedback on the approach, which I'd like before I add/update tests.
