### PR TITLE
Specify gpg --output option explicitly

### DIFF
--- a/changelog/865.bugfix.rst
+++ b/changelog/865.bugfix.rst
@@ -1,0 +1,1 @@
+Use GPG ``--output`` option to enable using other GPG implementations.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -38,7 +38,7 @@ def test_sign_file(monkeypatch):
         package.sign("gpg2", None)
     except IOError:
         pass
-    args = ("gpg2", "--detach-sign", "-a", filename)
+    args = ("gpg2", "--detach-sign", "--output", f"{filename}.asc", "-a", filename)
     assert replaced_check_call.calls == [pretend.call(args)]
 
 
@@ -58,14 +58,30 @@ def test_sign_file_with_identity(monkeypatch):
         package.sign("gpg", "identity")
     except IOError:
         pass
-    args = ("gpg", "--detach-sign", "--local-user", "identity", "-a", filename)
+    args = (
+        "gpg",
+        "--detach-sign",
+        "--local-user",
+        "identity",
+        "--output",
+        f"{filename}.asc",
+        "-a",
+        filename,
+    )
     assert replaced_check_call.calls == [pretend.call(args)]
 
 
 def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
     replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
     monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
-    gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
+    gpg_args = (
+        "gpg",
+        "--detach-sign",
+        "--output",
+        "pypircfile.asc",
+        "-a",
+        "pypircfile",
+    )
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
         package_file.PackageFile.run_gpg(gpg_args)
@@ -76,7 +92,14 @@ def test_run_gpg_raises_exception_if_no_gpgs(monkeypatch):
 def test_run_gpg_raises_exception_if_not_using_gpg(monkeypatch):
     replaced_check_call = pretend.raiser(FileNotFoundError("not found"))
     monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
-    gpg_args = ("not_gpg", "--detach-sign", "-a", "pypircfile")
+    gpg_args = (
+        "not_gpg",
+        "--detach-sign",
+        "--output",
+        "pypircfile.asc",
+        "-a",
+        "pypircfile",
+    )
 
     with pytest.raises(exceptions.InvalidSigningExecutable) as err:
         package_file.PackageFile.run_gpg(gpg_args)
@@ -91,7 +114,14 @@ def test_run_gpg_falls_back_to_gpg2(monkeypatch):
 
     replaced_check_call = pretend.call_recorder(check_call)
     monkeypatch.setattr(package_file.subprocess, "check_call", replaced_check_call)
-    gpg_args = ("gpg", "--detach-sign", "-a", "pypircfile")
+    gpg_args = (
+        "gpg",
+        "--detach-sign",
+        "--output",
+        "pypircfile.asc",
+        "-a",
+        "pypircfile",
+    )
 
     package_file.PackageFile.run_gpg(gpg_args)
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -209,7 +209,7 @@ class PackageFile:
         gpg_args: Tuple[str, ...] = (sign_with, "--detach-sign")
         if identity:
             gpg_args += ("--local-user", identity)
-        gpg_args += ("--output", f"{self.filename}.asc")
+        gpg_args += ("--output", self.signed_filename)
         gpg_args += ("-a", self.filename)
         self.run_gpg(gpg_args)
 

--- a/twine/package.py
+++ b/twine/package.py
@@ -209,6 +209,7 @@ class PackageFile:
         gpg_args: Tuple[str, ...] = (sign_with, "--detach-sign")
         if identity:
             gpg_args += ("--local-user", identity)
+        gpg_args += ("--output", f"{self.filename}.asc")
         gpg_args += ("-a", self.filename)
         self.run_gpg(gpg_args)
 


### PR DESCRIPTION
Do not rely on obscure default behavior of gpg, which may not work with alternative implementations (like qubes-gpg-client-wrapper).

Fixes https://github.com/pypa/twine/issues/864