### PR TITLE
Fix integration test of PyPI error message

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,6 @@ import secrets
 import subprocess
 import sys
 
-import colorama
 import jaraco.envs
 import munch
 import portend
@@ -64,7 +63,7 @@ def test_pypi_upload(sampleproject_dist):
     cli.dispatch(command)
 
 
-def test_pypi_error(sampleproject_dist, monkeypatch):
+def test_pypi_error(sampleproject_dist, monkeypatch, capsys):
     command = [
         "twine",
         "upload",
@@ -79,14 +78,16 @@ def test_pypi_error(sampleproject_dist, monkeypatch):
     monkeypatch.setattr(sys, "argv", command)
 
     message = (
-        re.escape(colorama.Fore.RED)
-        + r"HTTPError: 403 Forbidden from https://test\.pypi\.org/legacy/\n"
-        + r".+?authentication"
+        r"HTTPError: 403 Forbidden from https://test\.pypi\.org/legacy/"
+        + r".+authentication information"
     )
 
-    result = dunder_main.main()
+    error = dunder_main.main()
+    assert error
 
-    assert re.match(message, result)
+    captured = capsys.readouterr()
+
+    assert re.search(message, captured.out, re.DOTALL)
 
 
 @pytest.fixture(


### PR DESCRIPTION
We're not running integration tests on pull requests, because they can be flaky (see https://github.com/pypa/twine/issues/684#issuecomment-703150619):

https://github.com/pypa/twine/blob/133f8ae254fe51b4f75a59b101efa413adc4cc8d/.github/workflows/integration.yml#L5-L10

I wonder if a better approach would be to run them, but not require them for merge.

With this change, the tests pass locally. 🤞 that they pass on merge.