### PR TITLE
Filter unnecessary deps from User-Agent string

### DIFF
--- a/changelog/871.bugfix.rst
+++ b/changelog/871.bugfix.rst
@@ -1,0 +1,1 @@
+Remove Twine's dependencies from the ``User-Agent`` header when uploading.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,12 +37,12 @@ packages =
 python_requires = >=3.6
 install_requires=
     pkginfo >= 1.8.1
-    readme_renderer >= 21.0
+    readme-renderer >= 21.0
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0
     urllib3 >= 1.26.0
     tqdm >= 4.14
-    importlib_metadata >= 3.6
+    importlib-metadata >= 3.6
     keyring >= 15.1
     rfc3986 >= 1.4.0
     rich

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -85,18 +85,8 @@ def test_set_certificate_authority(default_repo):
 
 
 def test_make_user_agent_string(default_repo):
-    """Add twine and its dependencies to User-Agent session header."""
-    assert "User-Agent" in default_repo.session.headers
-
-    user_agent = default_repo.session.headers["User-Agent"]
-    packages = (
-        "twine/",
-        "requests/",
-        "requests-toolbelt/",
-        "pkginfo/",
-        "importlib-metadata/",
-    )
-    assert all(p in user_agent for p in packages)
+    """Add twine to User-Agent session header."""
+    assert "twine/" in default_repo.session.headers["User-Agent"]
 
 
 def response_with(**kwattrs):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -94,7 +94,7 @@ def test_make_user_agent_string(default_repo):
         "requests/",
         "requests-toolbelt/",
         "pkginfo/",
-        "importlib_metadata/",
+        "importlib-metadata/",
     )
     assert all(p in user_agent for p in packages)
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -72,10 +72,11 @@ def configure_output() -> None:
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
     deps = (
         "importlib-metadata",
+        "keyring",
         "pkginfo",
         "requests",
         "requests-toolbelt",
-        "tqdm",
+        "urllib3",
     )
     return [(dep, importlib_metadata.version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -20,7 +20,6 @@ import rich
 import rich.highlighter
 import rich.logging
 import rich.theme
-from packaging import requirements
 
 import twine
 
@@ -71,8 +70,13 @@ def configure_output() -> None:
 
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
-    requires = importlib_metadata.requires("twine")  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
-    deps = [requirements.Requirement(r).name for r in requires]
+    deps = (
+        "importlib-metadata",
+        "pkginfo",
+        "requests",
+        "requests-toolbelt",
+        "tqdm",
+    )
     return [(dep, importlib_metadata.version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 
 

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -88,12 +88,8 @@ class Repository:
 
     @staticmethod
     def _make_user_agent_string() -> str:
-        from twine import cli
-
-        dependencies = cli.list_dependencies_and_versions()
         user_agent_string = (
             user_agent.UserAgentBuilder("twine", twine.__version__)
-            .include_extras(dependencies)
             .include_implementation()
             .build()
         )


### PR DESCRIPTION
And canonicalize them in our dependencies, so tests pass with an installed twine.

Closes: #870