### PR TITLE
Use Rich for `print()` output

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -257,8 +257,8 @@ def test_upload_retry(tmpdir, default_repo, capsys):
     msg = [
         (
             "Uploading fake.whl\n"
-            'Received "500: Internal server error" '
-            f"Package upload appears to have failed.  Retry {i} of 5"
+            'Received "500: Internal server error"\n'
+            f"Package upload appears to have failed. Retry {i} of 5."
         )
         for i in range(1, 6)
     ]
@@ -272,8 +272,8 @@ def test_upload_retry(tmpdir, default_repo, capsys):
     msg = [
         (
             "Uploading fake.whl\n"
-            'Received "500: Internal server error" '
-            f"Package upload appears to have failed.  Retry {i} of 3"
+            'Received "500: Internal server error"\n'
+            f"Package upload appears to have failed. Retry {i} of 3."
         )
         for i in range(1, 4)
     ]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -230,7 +230,7 @@ def test_disable_progress_bar_is_forwarded_to_tqdm(
     default_repo.upload(package)
 
 
-def test_upload_retry(tmpdir, default_repo, capsys):
+def test_upload_retry(tmpdir, default_repo, caplog):
     """Print retry messages when the upload response indicates a server error."""
     default_repo.disable_progress_bar = True
 
@@ -254,32 +254,26 @@ def test_upload_retry(tmpdir, default_repo, capsys):
     # Upload with default max_redirects of 5
     default_repo.upload(package)
 
-    msg = [
+    assert caplog.messages == [
         (
-            "Uploading fake.whl\n"
             'Received "500: Internal server error"\n'
             f"Package upload appears to have failed. Retry {i} of 5."
         )
         for i in range(1, 6)
     ]
 
-    captured = capsys.readouterr()
-    assert captured.out == "\n".join(msg) + "\n"
+    caplog.clear()
 
     # Upload with custom max_redirects of 3
     default_repo.upload(package, 3)
 
-    msg = [
+    assert caplog.messages == [
         (
-            "Uploading fake.whl\n"
             'Received "500: Internal server error"\n'
             f"Package upload appears to have failed. Retry {i} of 3."
         )
         for i in range(1, 4)
     ]
-
-    captured = capsys.readouterr()
-    assert captured.out == "\n".join(msg) + "\n"
 
 
 @pytest.mark.parametrize(

--- a/twine/commands/register.py
+++ b/twine/commands/register.py
@@ -16,6 +16,8 @@ import argparse
 import os.path
 from typing import List, cast
 
+from rich import print
+
 from twine import exceptions
 from twine import package as package_file
 from twine import settings

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -18,6 +18,7 @@ import os.path
 from typing import Dict, List, cast
 
 import requests
+from rich import print
 
 from twine import commands
 from twine import exceptions
@@ -127,8 +128,9 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
     uploaded_packages = []
 
     for package in packages_to_upload:
-        skip_message = "  Skipping {} because it appears to already exist".format(
-            package.basefilename
+        skip_message = (
+            f"[yellow]Skipping {package.basefilename}"
+            " because it appears to already exist"
         )
 
         # Note: The skip_existing check *needs* to be first, because otherwise
@@ -163,7 +165,7 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
 
     release_urls = repository.release_urls(uploaded_packages)
     if release_urls:
-        print("\nView at:")
+        print("\n[green]View at:")
         for url in release_urls:
             print(url)
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -129,15 +129,14 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
 
     for package in packages_to_upload:
         skip_message = (
-            f"[yellow]Skipping {package.basefilename}"
-            " because it appears to already exist"
+            f"Skipping {package.basefilename} because it appears to already exist"
         )
 
         # Note: The skip_existing check *needs* to be first, because otherwise
         #       we're going to generate extra HTTP requests against a hardcoded
         #       URL for no reason.
         if upload_settings.skip_existing and repository.package_is_uploaded(package):
-            print(skip_message)
+            logger.warning(skip_message)
             continue
 
         resp = repository.upload(package)
@@ -156,7 +155,7 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
             )
 
         if skip_upload(resp, upload_settings.skip_existing, package):
-            print(skip_message)
+            logger.warning(skip_message)
             continue
 
         utils.check_status_code(resp, upload_settings.verbose)

--- a/twine/package.py
+++ b/twine/package.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import hashlib
 import io
+import logging
 import os
 import re
 import subprocess
@@ -43,6 +44,8 @@ DIST_EXTENSIONS = {
 }
 
 MetadataValue = Union[str, Sequence[str]]
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_name(name: str) -> str:
@@ -226,12 +229,12 @@ class PackageFile:
                     f"{gpg_args[0]} executable not available."
                 )
 
-        print("[yellow]gpg executable not available. Attempting fallback to gpg2.")
+        logger.warning("gpg executable not available. Attempting fallback to gpg2.")
         try:
             subprocess.check_call(("gpg2",) + gpg_args[1:])
         except FileNotFoundError:
             raise exceptions.InvalidSigningExecutable(
-                "'gpg' or 'gpg2' executables not available. "
+                "'gpg' or 'gpg2' executables not available.\n"
                 "Try installing one of these or specifying an executable "
                 "with the --sign-with flag."
             )

--- a/twine/package.py
+++ b/twine/package.py
@@ -20,6 +20,7 @@ from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union
 
 import importlib_metadata
 import pkginfo
+from rich import print
 
 from twine import exceptions
 from twine import wheel
@@ -222,14 +223,13 @@ class PackageFile:
         except FileNotFoundError:
             if gpg_args[0] != "gpg":
                 raise exceptions.InvalidSigningExecutable(
-                    "{} executable not available.".format(gpg_args[0])
+                    f"{gpg_args[0]} executable not available."
                 )
 
-        print("gpg executable not available. Attempting fallback to gpg2.")
+        print("[yellow]gpg executable not available. Attempting fallback to gpg2.")
         try:
             subprocess.check_call(("gpg2",) + gpg_args[1:])
         except FileNotFoundError:
-            print("gpg2 executable not available.")
             raise exceptions.InvalidSigningExecutable(
                 "'gpg' or 'gpg2' executables not available. "
                 "Try installing one of these or specifying an executable "

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -193,8 +193,8 @@ class Repository:
                 return resp
             if 500 <= resp.status_code < 600:
                 number_of_redirects += 1
-                print(
-                    f'[yellow]Received "{resp.status_code}: {resp.reason}"'
+                logger.warning(
+                    f'Received "{resp.status_code}: {resp.reason}"'
                     "\nPackage upload appears to have failed."
                     f" Retry {number_of_redirects} of {max_redirects}."
                 )

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -21,6 +21,7 @@ import tqdm
 import urllib3
 from requests import adapters
 from requests_toolbelt.utils import user_agent
+from rich import print
 
 import twine
 from twine import package as package_file
@@ -193,14 +194,9 @@ class Repository:
             if 500 <= resp.status_code < 600:
                 number_of_redirects += 1
                 print(
-                    'Received "{status_code}: {reason}" Package upload '
-                    "appears to have failed.  Retry {retry} of "
-                    "{max_redirects}".format(
-                        status_code=resp.status_code,
-                        reason=resp.reason,
-                        retry=number_of_redirects,
-                        max_redirects=max_redirects,
-                    )
+                    f'[yellow]Received "{resp.status_code}: {resp.reason}"'
+                    "\nPackage upload appears to have failed."
+                    f" Retry {number_of_redirects} of {max_redirects}."
                 )
             else:
                 return resp


### PR DESCRIPTION
Towards #818, and a companion to #874. This uses Rich's [`print` alternative](https://rich.readthedocs.io/en/latest/introduction.html#quick-start) to enable colors, but after some experimentation, I decided to keep it minimal. It also replaces some `print()` calls with `logger.warning` where it felt appropriate.

<img width="702" alt="Screen Shot 2022-02-26 at 9 51 49 PM" src="https://user-images.githubusercontent.com/1326704/155866311-1463f3f3-cb74-4fe7-bd3e-b5b5190d326c.png">

<img width="822" alt="Screen Shot 2022-02-26 at 9 24 44 PM" src="https://user-images.githubusercontent.com/1326704/155866313-d74a57de-1987-4652-a591-07e7f4fad43c.png">
