### PR TITLE
Fix detection of FIPS mode for blake2b

### DIFF
--- a/changelog/879.bugfix.rst
+++ b/changelog/879.bugfix.rst
@@ -1,0 +1,1 @@
+Improve detection of disabled BLAKE2 hashing due to FIPS mode.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -307,9 +307,10 @@ def test_fips_hash_manager_md5(monkeypatch):
     assert hasher.hexdigest() == hashes
 
 
-def test_fips_hash_manager_blake2(monkeypatch):
+@pytest.mark.parametrize("exception_class", [TypeError, ValueError])
+def test_fips_hash_manager_blake2(exception_class, monkeypatch):
     """Generate hexdigest without BLAKE2 when hashlib is using FIPS mode."""
-    replaced_blake2b = pretend.raiser(ValueError("fipsmode"))
+    replaced_blake2b = pretend.raiser(exception_class("fipsmode"))
     monkeypatch.setattr(package_file.hashlib, "blake2b", replaced_blake2b)
 
     filename = "tests/fixtures/twine-1.5.0-py2.py3-none-any.whl"

--- a/twine/package.py
+++ b/twine/package.py
@@ -268,7 +268,7 @@ class HashManager:
         self._blake_hasher = None
         try:
             self._blake_hasher = hashlib.blake2b(digest_size=256 // 8)
-        except ValueError:
+        except (ValueError, TypeError):
             # FIPS mode disables blake2
             pass
 


### PR DESCRIPTION
Blake2 algorithms are disabled on FIPS mode on OpenSSL level
and preferred on Python level which cause the check of
API (attributes) to fail sooner than OpenSSL raises ValueError
for unavailable function.

Fixes: #857 