### PR TITLE
Update changelog for 3.8.1

### DIFF
--- a/changelog/871.bugfix.rst
+++ b/changelog/871.bugfix.rst
@@ -1,1 +1,0 @@
-Remove Twine's dependencies from the ``User-Agent`` header when uploading.

--- a/changelog/879.bugfix.rst
+++ b/changelog/879.bugfix.rst
@@ -1,1 +1,0 @@
-Improve detection of disabled BLAKE2 hashing due to FIPS mode.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,16 @@ schemes recommended by the Python Packaging Authority.
 
 .. towncrier release notes start
 
+Twine 3.8.1 (2022-03-02)
+------------------------
+
+Bugfixes
+^^^^^^^^
+
+- Remove Twine's dependencies from the ``User-Agent`` header when uploading. (`#871 <https://github.com/pypa/twine/issues/871>`_)
+- Improve detection of disabled BLAKE2 hashing due to FIPS mode. (`#879 <https://github.com/pypa/twine/issues/879>`_)
+
+
 Twine 3.8.0 (2022-02-02)
 ------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -256,7 +256,7 @@ A checklist for creating, testing, and distributing a new version.
 
    .. code-block:: bash
 
-      tox -e changelog -- --version $VERSION
+      tox -e changelog -- $VERSION
 
       git commit -am "Update changelog for $VERSION"
 

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ basepython = python3
 deps =
     towncrier
 commands =
-    towncrier {posargs}
+    towncrier build --yes --version {posargs}
 
 [testenv:release]
 # specify Python 3 to use platform's default Python 3


### PR DESCRIPTION
While waiting to release [4.0.0](https://github.com/pypa/twine/milestone/12), I thought it'd be nice to release some bugfixes. I took a guess at how to do this; happy to do something differently.

- Create `3.x` branch based on `3.8.0` tag
- Cherry-pick bugfix commits from `main` to `3.x`: https://github.com/pypa/twine/compare/3.8.0...3.x
- Create this PR off of `3.x`

After merge, I'm thinking:

- Tag and publish the 3.8.1 release from the `3.x` branch
- Cherry-pick the changelog update to `main`