### PR TITLE
Adopt Python 3.7+ syntax

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,7 +17,7 @@ def test_get_password_keyring_overrides_prompt(monkeypatch, config):
     class MockKeyring:
         @staticmethod
         def get_password(system, user):
-            return "{user}@{system} sekure pa55word".format(**locals())
+            return f"{user}@{system} sekure pa55word"
 
     monkeypatch.setattr(auth, "keyring", MockKeyring)
 
@@ -68,7 +68,7 @@ def test_get_username_and_password_keyring_overrides_prompt(
         @staticmethod
         def get_credential(system, user):
             return auth.CredentialInput(
-                "real_user", "real_user@{system} sekure pa55word".format(**locals())
+                "real_user", f"real_user@{system} sekure pa55word"
             )
 
         @staticmethod

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -36,7 +36,7 @@ def test_sign_file(monkeypatch):
     )
     try:
         package.sign("gpg2", None)
-    except IOError:
+    except OSError:
         pass
     args = ("gpg2", "--detach-sign", "-a", filename)
     assert replaced_check_call.calls == [pretend.call(args)]
@@ -56,7 +56,7 @@ def test_sign_file_with_identity(monkeypatch):
     )
     try:
         package.sign("gpg", "identity")
-    except IOError:
+    except OSError:
         pass
     args = ("gpg", "--detach-sign", "--local-user", "identity", "-a", filename)
     assert replaced_check_call.calls == [pretend.call(args)]
@@ -139,51 +139,49 @@ def test_package_safe_name_is_correct(pkg_name, expected_name):
 def test_metadata_dictionary_keys():
     """Merge multiple sources of metadata into a single dictionary."""
     package = package_file.PackageFile.from_filename(helpers.SDIST_FIXTURE, None)
-    assert set(package.metadata_dictionary()) == set(
-        [
-            # identify release
-            "name",
-            "version",
-            # file content
-            "filetype",
-            "pyversion",
-            # additional meta-data
-            "metadata_version",
-            "summary",
-            "home_page",
-            "author",
-            "author_email",
-            "maintainer",
-            "maintainer_email",
-            "license",
-            "description",
-            "keywords",
-            "platform",
-            "classifiers",
-            "download_url",
-            "supported_platform",
-            "comment",
-            "md5_digest",
-            "sha256_digest",
-            "blake2_256_digest",
-            # PEP 314
-            "provides",
-            "requires",
-            "obsoletes",
-            # Metadata 1.2
-            "project_urls",
-            "provides_dist",
-            "obsoletes_dist",
-            "requires_dist",
-            "requires_external",
-            "requires_python",
-            # Metadata 2.1
-            "provides_extras",
-            "description_content_type",
-            # Metadata 2.2
-            "dynamic",
-        ]
-    )
+    assert set(package.metadata_dictionary()) == {
+        # identify release
+        "name",
+        "version",
+        # file content
+        "filetype",
+        "pyversion",
+        # additional meta-data
+        "metadata_version",
+        "summary",
+        "home_page",
+        "author",
+        "author_email",
+        "maintainer",
+        "maintainer_email",
+        "license",
+        "description",
+        "keywords",
+        "platform",
+        "classifiers",
+        "download_url",
+        "supported_platform",
+        "comment",
+        "md5_digest",
+        "sha256_digest",
+        "blake2_256_digest",
+        # PEP 314
+        "provides",
+        "requires",
+        "obsoletes",
+        # Metadata 1.2
+        "project_urls",
+        "provides_dist",
+        "obsoletes_dist",
+        "requires_dist",
+        "requires_external",
+        "requires_python",
+        # Metadata 2.1
+        "provides_extras",
+        "description_content_type",
+        # Metadata 2.2
+        "dynamic",
+    }
 
 
 @pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pretend
 import pytest
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -97,7 +97,7 @@ def dispatch(argv: List[str]) -> Any:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s version {} ({})".format(twine.__version__, dep_versions()),
+        version=f"%(prog)s version {twine.__version__} ({dep_versions()})",
     )
     parser.add_argument(
         "--no-color",

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -214,7 +214,7 @@ class Repository:
             releases = self._releases_json_data.get(safe_name)
 
         if releases is None:
-            url = "{url}pypi/{package}/json".format(package=safe_name, url=LEGACY_PYPI)
+            url = f"{LEGACY_PYPI}pypi/{safe_name}/json"
             headers = {"Accept": "application/json"}
             response = self.session.get(url, headers=headers)
             if response.status_code == 200:
@@ -240,7 +240,7 @@ class Repository:
             return set()
 
         return {
-            "{}project/{}/{}/".format(url, package.safe_name, package.metadata.version)
+            f"{url}project/{package.safe_name}/{package.metadata.version}/"
             for package in packages
         }
 

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -11,8 +11,6 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-from __future__ import annotations
-
 # limitations under the License.
 import argparse
 import contextlib
@@ -138,7 +136,7 @@ class Settings:
             # Workaround for https://github.com/python/mypy/issues/5858
             return cast(Optional[str], self.auth.password)
 
-    def _allow_noninteractive(self) -> contextlib.AbstractContextManager[None]:
+    def _allow_noninteractive(self) -> "contextlib.AbstractContextManager[None]":
         """Bypass NonInteractive error when client cert is present."""
         suppressed = (exceptions.NonInteractive,) if self.client_cert else ()
         return contextlib.suppress(*suppressed)

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -53,7 +53,7 @@ class Wheel(distribution.Distribution):
     def find_candidate_metadata_files(names: List[str]) -> List[List[str]]:
         """Filter files that may be METADATA files."""
         tuples = [x.split("/") for x in names if "METADATA" in x]
-        return [x[1] for x in sorted([(len(x), x) for x in tuples])]
+        return [x[1] for x in sorted((len(x), x) for x in tuples)]
 
     def read(self) -> bytes:
         fqn = os.path.abspath(os.path.normpath(self.filename))

--- a/twine/wininst.py
+++ b/twine/wininst.py
@@ -47,7 +47,7 @@ class WinInst(distribution.Distribution):
                 for x in names
                 if x.endswith(".egg-info") or x.endswith("PKG-INFO")
             ]
-            schwarz = sorted([(len(x), x) for x in tuples])
+            schwarz = sorted((len(x), x) for x in tuples)
             for path in [x[1] for x in schwarz]:
                 candidate = "/".join(path)
                 data = read_file(candidate)


### PR DESCRIPTION
Via [`pyupgrade --py37-plus`](https://github.com/asottile/pyupgrade). Closes #881.

I started [another branch](https://github.com/pypa/twine/compare/main...bhrutledge:881-pyupgrade-37) to adopt `from __future__ import annotations`, but found that support for abbreviated Union types won't be fully supported at runtime (e.g. in type aliases and `cast`) until Python 3.10. Rather than having multiple idioms for the same concept (e.g. [`str | None` and `Optional[str]`](https://github.com/pypa/twine/compare/main...bhrutledge:881-pyupgrade-37#diff-9250db35ee8e4d842122ac961aa131fc17b3d14ed0bee21ff3be874b24c7c07cL131-L133)), I found a workaround for the one instance where `__future__` annotations was used.