### PR TITLE
Update sampleproject fixture

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,10 @@ import requests
 from twine import __main__ as dunder_main
 from twine import cli
 
-pytestmark = [pytest.mark.enable_socket, pytest.mark.flaky(reruns=3, reruns_delay=1)]
+pytestmark = [
+    pytest.mark.enable_socket,
+    pytest.mark.flaky(reruns=3, reruns_delay=1),
+]
 
 
 @pytest.fixture(scope="session")
@@ -27,7 +30,7 @@ def sampleproject_dist(tmp_path_factory):
     )
     with (checkout / "setup.py").open("r+") as setup:
         orig = setup.read()
-        sub = orig.replace("name='sampleproject'", "name='twine-sampleproject'")
+        sub = orig.replace('name="sampleproject"', 'name="twine-sampleproject"')
         assert orig != sub
         setup.seek(0)
         setup.write(sub)


### PR DESCRIPTION
This should fix the integration test failure, by accounting for a [recent change in pypa/sampleproject](https://github.com/pypa/sampleproject/commit/918bd331501de42be32666bd5140d04d00b39386#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L32)