### PR TITLE
Subclass `StringIO` for `_WarningStream`.

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -24,25 +24,18 @@ from twine.commands import check
 class TestWarningStream:
     def setup(self):
         self.stream = check._WarningStream()
-        self.stream.output = pretend.stub(
-            write=pretend.call_recorder(lambda a: None),
-            getvalue=lambda: "result",
-        )
 
     def test_write_match(self):
         self.stream.write("<string>:2: (WARNING/2) Title underline too short.")
-
-        assert self.stream.output.write.calls == [
-            pretend.call("line 2: Warning: Title underline too short.\n")
-        ]
+        assert self.stream.getvalue() == "line 2: Warning: Title underline too short.\n"
 
     def test_write_nomatch(self):
         self.stream.write("this does not match")
-
-        assert self.stream.output.write.calls == [pretend.call("this does not match")]
+        assert self.stream.getvalue() == "this does not match"
 
     def test_str_representation(self):
-        assert str(self.stream) == "result"
+        self.stream.write("<string>:2: (WARNING/2) Title underline too short.")
+        assert str(self.stream) == "line 2: Warning: Title underline too short."
 
 
 def test_check_no_distributions(monkeypatch, caplog):

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -48,27 +48,19 @@ _REPORT_RE = re.compile(
 )
 
 
-class _WarningStream:
-    def __init__(self) -> None:
-        self.output = io.StringIO()
-
-    def write(self, text: str) -> None:
+class _WarningStream(io.StringIO):
+    def write(self, text: str) -> int:
         matched = _REPORT_RE.search(text)
+        if matched:
+            line = matched.group("line")
+            level_text = matched.group("level").capitalize()
+            message = matched.group("message").rstrip("\r\n")
+            text = f"line {line}: {level_text}: {message}\n"
 
-        if not matched:
-            self.output.write(text)
-            return
-
-        self.output.write(
-            "line {line}: {level_text}: {message}\n".format(
-                level_text=matched.group("level").capitalize(),
-                line=matched.group("line"),
-                message=matched.group("message").rstrip("\r\n"),
-            )
-        )
+        return super().write(text)
 
     def __str__(self) -> str:
-        return self.output.getvalue().strip()
+        return self.getvalue().strip()
 
 
 def _check_file(


### PR DESCRIPTION
Resolves #884.

This is responding to a change in `readme_renderer.rst.render` that expects [an `IO[str]` instance](https://github.com/pypa/readme_renderer/blob/75127422ceecc0f8bcc33a58dfb9f3f46257e086/readme_renderer/rst.py#L106-L110). See discussion at https://github.com/pypa/readme_renderer/pull/231#pullrequestreview-915151083.

Requesting review from @di as a maintainer of both projects. Also FYI @miketheman.