### PR TITLE
Make missing `long_description` check more flexible

### DIFF
--- a/changelog/887.bugfix.rst
+++ b/changelog/887.bugfix.rst
@@ -1,0 +1,1 @@
+Restore warning for missing ``long_description``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,18 @@ import getpass
 import textwrap
 
 import pytest
+import rich
 
 from twine import settings
 from twine import utils
+
+
+def pytest_configure(config):
+    # Disable color codes and wrapping during tests
+    rich.reconfigure(
+        no_color=True,
+        width=500,
+    )
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import getpass
+import logging.config
 import textwrap
 
 import pytest
@@ -8,11 +9,34 @@ from twine import settings
 from twine import utils
 
 
-def pytest_configure(config):
-    # Disable color codes and wrapping during tests
+@pytest.fixture(autouse=True)
+def configure_output():
+    """
+    Disable colored output and line wrapping before each test.
+
+    Some tests (e.g. test_main.py) will end up calling (and making assertions based on)
+    twine.cli.configure_output, which overrides this configuration. This fixture should
+    prevent that leaking into subsequent tests.
+    """
     rich.reconfigure(
         no_color=True,
         width=500,
+    )
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                }
+            },
+            "loggers": {
+                "twine": {
+                    "handlers": ["console"],
+                },
+            },
+        }
     )
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -107,10 +107,11 @@ def test_check_passing_distribution_with_none_renderer(
     assert capsys.readouterr().out == "Checking dist/dist.tar.gz: PASSED\n"
 
 
-def test_check_no_description(monkeypatch, capsys, caplog):
+@pytest.mark.parametrize("description", [None, "UNKNOWN\n\n", "UNKNOWN\n\n\n"])
+def test_check_no_description(description, monkeypatch, capsys, caplog):
     package = pretend.stub(
         metadata_dictionary=lambda: {
-            "description": None,
+            "description": description,
             "description_content_type": None,
         }
     )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import textwrap
 
+import build
 import pretend
 import pytest
 
-from twine import commands
-from twine import package as package_file
 from twine.commands import check
 
 
@@ -45,10 +45,8 @@ class TestWarningStream:
         assert str(self.stream) == "result"
 
 
-def test_check_no_distributions(monkeypatch, caplog):
-    monkeypatch.setattr(commands, "_find_dists", lambda a: [])
-
-    assert not check.check(["dist/*"])
+def test_fails_no_distributions(caplog):
+    assert not check.check([])
     assert caplog.record_tuples == [
         (
             "twine.commands.check",
@@ -58,76 +56,51 @@ def test_check_no_distributions(monkeypatch, caplog):
     ]
 
 
-def test_check_passing_distribution(monkeypatch, capsys):
-    renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: "valid"))
-    package = pretend.stub(
-        metadata_dictionary=lambda: {
-            "description": "blah",
-            "description_content_type": "text/markdown",
-        }
-    )
-    warning_stream = ""
+def build_sdist(src_path, project_files):
+    """
+    Build a source distribution similar to `python3 -m build --sdist`.
 
-    monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
-    monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
-    monkeypatch.setattr(
-        package_file,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
-    )
-    monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
+    Returns the absolute path of the built distribution.
+    """
+    project_files = {
+        "pyproject.toml": (
+            """
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
+            """
+        ),
+        **project_files,
+    }
 
-    assert not check.check(["dist/*"])
-    assert capsys.readouterr().out == "Checking dist/dist.tar.gz: PASSED\n"
-    assert renderer.render.calls == [pretend.call("blah", stream=warning_stream)]
+    for filename, content in project_files.items():
+        (src_path / filename).write_text(textwrap.dedent(content))
+
+    builder = build.ProjectBuilder(src_path)
+    return builder.build("sdist", str(src_path / "dist"))
 
 
-@pytest.mark.parametrize("content_type", ["text/plain", "text/markdown"])
-def test_check_passing_distribution_with_none_renderer(
-    content_type,
-    monkeypatch,
-    capsys,
-):
-    """Pass when rendering a content type can't fail."""
-    package = pretend.stub(
-        metadata_dictionary=lambda: {
-            "description": "blah",
-            "description_content_type": content_type,
-        }
-    )
-
-    monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
-    monkeypatch.setattr(
-        package_file,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
+@pytest.mark.parametrize("strict", [False, True])
+def test_warns_missing_description(strict, tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                """
+            ),
+        },
     )
 
-    assert not check.check(["dist/*"])
-    assert capsys.readouterr().out == "Checking dist/dist.tar.gz: PASSED\n"
+    assert check.check([sdist], strict=strict) is strict
 
-
-@pytest.mark.parametrize("description", [None, "UNKNOWN\n\n", "UNKNOWN\n\n\n"])
-def test_check_no_description(description, monkeypatch, capsys, caplog):
-    package = pretend.stub(
-        metadata_dictionary=lambda: {
-            "description": description,
-            "description_content_type": None,
-        }
+    assert capsys.readouterr().out == f"Checking {sdist}: " + (
+        "FAILED due to warnings\n" if strict else "PASSED with warnings\n"
     )
 
-    monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
-    monkeypatch.setattr(
-        package_file,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
-    )
-
-    assert not check.check(["dist/*"])
-
-    assert capsys.readouterr().out == (
-        "Checking dist/dist.tar.gz: PASSED with warnings\n"
-    )
     assert caplog.record_tuples == [
         (
             "twine.commands.check",
@@ -142,32 +115,27 @@ def test_check_no_description(description, monkeypatch, capsys, caplog):
     ]
 
 
-def test_strict_fails_on_warnings(monkeypatch, capsys, caplog):
-    package = pretend.stub(
-        metadata_dictionary=lambda: {
-            "description": None,
-            "description_content_type": None,
-        }
+def test_warns_missing_file(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                long_description = file:README.rst
+                long_description_content_type = text/x-rst
+                """
+            ),
+        },
     )
 
-    monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
-    monkeypatch.setattr(
-        package_file,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
-    )
+    assert not check.check([sdist])
 
-    assert check.check(["dist/*"], strict=True)
+    assert capsys.readouterr().out == f"Checking {sdist}: PASSED with warnings\n"
 
-    assert capsys.readouterr().out == (
-        "Checking dist/dist.tar.gz: FAILED due to warnings\n"
-    )
     assert caplog.record_tuples == [
-        (
-            "twine.commands.check",
-            logging.WARNING,
-            "`long_description_content_type` missing. defaulting to `text/x-rst`.",
-        ),
         (
             "twine.commands.check",
             logging.WARNING,
@@ -176,37 +144,138 @@ def test_strict_fails_on_warnings(monkeypatch, capsys, caplog):
     ]
 
 
-def test_check_failing_distribution(monkeypatch, capsys, caplog):
-    renderer = pretend.stub(render=pretend.call_recorder(lambda *a, **kw: None))
-    package = pretend.stub(
-        metadata_dictionary=lambda: {
-            "description": "blah",
-            "description_content_type": "text/markdown",
-        }
+def test_fails_rst_syntax_error(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                long_description = file:README.rst
+                long_description_content_type = text/x-rst
+                """
+            ),
+            "README.rst": (
+                """
+                ============
+                """
+            ),
+        },
     )
-    warning_stream = "Syntax error"
 
-    monkeypatch.setattr(check, "_RENDERERS", {None: renderer})
-    monkeypatch.setattr(commands, "_find_dists", lambda a: ["dist/dist.tar.gz"])
-    monkeypatch.setattr(
-        package_file,
-        "PackageFile",
-        pretend.stub(from_filename=lambda *a, **kw: package),
-    )
-    monkeypatch.setattr(check, "_WarningStream", lambda: warning_stream)
+    assert check.check([sdist])
 
-    assert check.check(["dist/*"])
+    assert capsys.readouterr().out == f"Checking {sdist}: FAILED\n"
 
-    assert capsys.readouterr().out == "Checking dist/dist.tar.gz: FAILED\n"
     assert caplog.record_tuples == [
         (
             "twine.commands.check",
             logging.ERROR,
-            "`long_description` has syntax errors in markup and would not be rendered "
-            "on PyPI.\nSyntax error",
+            "`long_description` has syntax errors in markup "
+            "and would not be rendered on PyPI.\n"
+            "line 2: Error: Document or section may not begin with a transition.",
         ),
     ]
-    assert renderer.render.calls == [pretend.call("blah", stream=warning_stream)]
+
+
+def test_fails_rst_no_content(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                long_description = file:README.rst
+                long_description_content_type = text/x-rst
+                """
+            ),
+            "README.rst": (
+                """
+                test-package
+                ============
+                """
+            ),
+        },
+    )
+
+    assert check.check([sdist])
+
+    assert capsys.readouterr().out == f"Checking {sdist}: FAILED\n"
+
+    assert caplog.record_tuples == [
+        (
+            "twine.commands.check",
+            logging.ERROR,
+            "`long_description` has syntax errors in markup "
+            "and would not be rendered on PyPI.\n",
+        ),
+    ]
+
+
+def test_passes_rst_description(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                long_description = file:README.rst
+                long_description_content_type = text/x-rst
+                """
+            ),
+            "README.rst": (
+                """
+                test-package
+                ============
+
+                A test package.
+                """
+            ),
+        },
+    )
+
+    assert not check.check([sdist])
+
+    assert capsys.readouterr().out == f"Checking {sdist}: PASSED\n"
+
+    assert not caplog.record_tuples
+
+
+@pytest.mark.parametrize("content_type", ["text/markdown", "text/plain"])
+def test_passes_markdown_description(content_type, tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                f"""
+                [metadata]
+                name = test-package
+                version = 0.0.1
+                long_description = file:README.md
+                long_description_content_type = {content_type}
+                """
+            ),
+            "README.md": (
+                """
+                # test-package
+
+                A test package.
+                """
+            ),
+        },
+    )
+
+    assert not check.check([sdist])
+
+    assert capsys.readouterr().out == f"Checking {sdist}: PASSED\n"
+
+    assert not caplog.record_tuples
 
 
 def test_main(monkeypatch):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -337,7 +337,7 @@ def test_exception_for_redirect(
 
 
 def test_prints_skip_message_for_uploaded_package(
-    upload_settings, stub_repository, capsys
+    upload_settings, stub_repository, capsys, caplog
 ):
     upload_settings.skip_existing = True
 
@@ -348,12 +348,16 @@ def test_prints_skip_message_for_uploaded_package(
     assert result is None
 
     captured = capsys.readouterr()
-    assert "Skipping twine-1.5.0-py2.py3-none-any.whl" in captured.out
     assert RELEASE_URL not in captured.out
+
+    assert caplog.messages == [
+        "Skipping twine-1.5.0-py2.py3-none-any.whl "
+        "because it appears to already exist"
+    ]
 
 
 def test_prints_skip_message_for_response(
-    upload_settings, stub_response, stub_repository, capsys
+    upload_settings, stub_response, stub_repository, capsys, caplog
 ):
     upload_settings.skip_existing = True
 
@@ -368,8 +372,12 @@ def test_prints_skip_message_for_response(
     assert result is None
 
     captured = capsys.readouterr()
-    assert "Skipping twine-1.5.0-py2.py3-none-any.whl" in captured.out
     assert RELEASE_URL not in captured.out
+
+    assert caplog.messages == [
+        "Skipping twine-1.5.0-py2.py3-none-any.whl "
+        "because it appears to already exist"
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest
     pytest-cov
     pytest-socket
+    build
 passenv =
     PYTEST_ADDOPTS
 commands =

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -93,7 +93,7 @@ def _check_file(
     content_type, params = cgi.parse_header(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
-    if description is None or description.rstrip("\n") == "UNKNOWN":
+    if description is None or description.rstrip() == "UNKNOWN":
         warnings.append("`long_description` missing.")
     elif renderer:
         rendering_result = renderer.render(

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -93,7 +93,7 @@ def _check_file(
     content_type, params = cgi.parse_header(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
-    if description in {None, "UNKNOWN\n\n\n"}:
+    if description is None or description.rstrip("\n") == "UNKNOWN":
         warnings.append("`long_description` missing.")
     elif renderer:
         rendering_result = renderer.render(


### PR DESCRIPTION
Related to #884.

A missing `long_description` results in `UNKNOWN` being written to PKG-INFO, but at some point, the number of trailing newlines changed.

For background, see https://github.com/pypa/readme_renderer/pull/231#discussion_r830531638.

I went down a rabbit hole and rewrote the `check` tests to use a built sdist, instead of lots of patching and stubbing. The tests are slower, but I think they're easier to understand, and more valuable. By exercising third-party code, hopefully they'll catch upstream issues before Twine users report them.