### PR TITLE
Log keyring tracebacks

### DIFF
--- a/changelog/890.bugfix.rst
+++ b/changelog/890.bugfix.rst
@@ -1,0 +1,1 @@
+Improve logging when keyring fails.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -20,7 +20,7 @@ def test_get_username_keyring_defers_to_prompt(monkeypatch, entered_username, co
         def get_credential(system, user):
             return None
 
-    monkeypatch.setattr(auth, "keyring", MockKeyring())
+    monkeypatch.setattr(auth, "keyring", MockKeyring)
 
     username = auth.Resolver(config, auth.CredentialInput()).username
     assert username == "entered user"
@@ -135,7 +135,7 @@ def test_get_username_keyring_runtime_error_logged(
         def get_credential(system, username):
             raise RuntimeError("fail!")
 
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
 
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
@@ -156,7 +156,7 @@ def test_get_password_keyring_runtime_error_logged(
         def get_password(system, username):
             raise RuntimeError("fail!")
 
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
 
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
 
@@ -183,7 +183,7 @@ def test_get_username_keyring_key_error_logged(
         def get_credential(system, username):
             _raise_home_key_error()
 
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
 
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
@@ -205,7 +205,7 @@ def test_get_password_keyring_key_error_logged(
         def get_password(system, username):
             _raise_home_key_error()
 
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
 
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -140,7 +140,9 @@ def test_get_username_keyring_runtime_error_logged(
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
     assert re.search(
-        r"Error from keyring.+Traceback.+RuntimeError: fail!", caplog.text, re.DOTALL
+        r"Error getting username from keyring.+Traceback.+RuntimeError: fail!",
+        caplog.text,
+        re.DOTALL,
     )
 
 
@@ -159,7 +161,9 @@ def test_get_password_keyring_runtime_error_logged(
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
 
     assert re.search(
-        r"Error from keyring.+Traceback.+RuntimeError: fail!", caplog.text, re.DOTALL
+        r"Error getting password from keyring.+Traceback.+RuntimeError: fail!",
+        caplog.text,
+        re.DOTALL,
     )
 
 
@@ -184,7 +188,7 @@ def test_get_username_keyring_key_error_logged(
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
     assert re.search(
-        r"Error from keyring"
+        r"Error getting username from keyring"
         r".+Traceback"
         r".+KeyError: 'HOME'"
         r".+KeyError: 'uid not found: 999'",
@@ -206,7 +210,7 @@ def test_get_password_keyring_key_error_logged(
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
 
     assert re.search(
-        r"Error from keyring"
+        r"Error getting password from keyring"
         r".+Traceback"
         r".+KeyError: 'HOME'"
         r".+KeyError: 'uid not found: 999'",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,23 +14,23 @@ def config() -> utils.RepositoryConfig:
     return dict(repository="system")
 
 
-def test_get_password_keyring_overrides_prompt(monkeypatch, config):
+def test_get_username_keyring_defers_to_prompt(monkeypatch, entered_username, config):
     class MockKeyring:
         @staticmethod
-        def get_password(system, user):
-            return f"{user}@{system} sekure pa55word"
+        def get_credential(system, user):
+            return None
 
-    monkeypatch.setattr(auth, "keyring", MockKeyring)
+    monkeypatch.setattr(auth, "keyring", MockKeyring())
 
-    pw = auth.Resolver(config, auth.CredentialInput("user")).password
-    assert pw == "user@system sekure pa55word"
+    username = auth.Resolver(config, auth.CredentialInput()).username
+    assert username == "entered user"
 
 
 def test_get_password_keyring_defers_to_prompt(monkeypatch, entered_password, config):
     class MockKeyring:
         @staticmethod
         def get_password(system, user):
-            return
+            return None
 
     monkeypatch.setattr(auth, "keyring", MockKeyring)
 
@@ -188,18 +188,6 @@ def test_get_password_keyring_missing_home_logged(monkeypatch, config, caplog):
     assert re.search(
         r"Error from keyring.+Traceback.+KeyError: 'HOME'", caplog.text, re.DOTALL
     )
-
-
-def test_get_username_return_none(entered_username, monkeypatch, config):
-    """Prompt for username when it's not in keyring."""
-
-    class FailKeyring:
-        @staticmethod
-        def get_credential(system, username):
-            return None
-
-    monkeypatch.setattr(auth, "keyring", FailKeyring())
-    assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
 
 def test_logs_cli_values(caplog):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -171,7 +171,9 @@ def _raise_home_key_error():
         raise KeyError("uid not found: 999")
 
 
-def test_get_username_keyring_missing_home_logged(monkeypatch, config, caplog):
+def test_get_username_keyring_key_error_logged(
+    entered_username, monkeypatch, config, caplog
+):
     class FailKeyring:
         @staticmethod
         def get_credential(system, username):
@@ -179,8 +181,7 @@ def test_get_username_keyring_missing_home_logged(monkeypatch, config, caplog):
 
     monkeypatch.setattr(auth, "keyring", FailKeyring())
 
-    resolver = auth.Resolver(config, auth.CredentialInput())
-    assert not resolver.get_username_from_keyring()
+    assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
 
     assert re.search(
         r"Error from keyring"
@@ -192,7 +193,9 @@ def test_get_username_keyring_missing_home_logged(monkeypatch, config, caplog):
     )
 
 
-def test_get_password_keyring_missing_home_logged(monkeypatch, config, caplog):
+def test_get_password_keyring_key_error_logged(
+    entered_username, entered_password, monkeypatch, config, caplog
+):
     class FailKeyring:
         @staticmethod
         def get_password(system, username):
@@ -200,9 +203,7 @@ def test_get_password_keyring_missing_home_logged(monkeypatch, config, caplog):
 
     monkeypatch.setattr(auth, "keyring", FailKeyring())
 
-    resolver = auth.Resolver(config, auth.CredentialInput("user"))
-    assert resolver.username == "user"
-    assert not resolver.get_password_from_keyring()
+    assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
 
     assert re.search(
         r"Error from keyring"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 import getpass
 import logging
+import re
 
 import pytest
 
@@ -152,14 +153,14 @@ def test_get_username_runtime_error_suppressed(
     entered_username, keyring_no_backends_get_credential, caplog, config
 ):
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
-    assert caplog.messages == ["Error from keyring"] and "fail!" in caplog.text
+    assert re.search(r"Error from keyring.+fail!", caplog.text, re.DOTALL)
 
 
 def test_get_password_runtime_error_suppressed(
     entered_password, keyring_no_backends, caplog, config
 ):
     assert auth.Resolver(config, auth.CredentialInput("user")).password == "entered pw"
-    assert caplog.messages == ["Error from keyring"] and "fail!" in caplog.text
+    assert re.search(r"Error from keyring.+fail!", caplog.text, re.DOTALL)
 
 
 def test_get_username_return_none(entered_username, monkeypatch, config):
@@ -248,6 +249,6 @@ def test_log_exception_on_keyring_failure(get_credential, config, monkeypatch, c
 
     assert not get_credential(auth.Resolver(config, auth.CredentialInput()))
 
-    assert (
-        caplog.messages[0] == "Error from keyring" and "KeyError: 'HOME'" in caplog.text
+    assert re.search(
+        r"Error from keyring.+Traceback.+KeyError: 'HOME'", caplog.text, re.DOTALL
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -52,7 +52,7 @@ def test_empty_password_bypasses_prompt(monkeypatch, entered_password, config):
 
 def test_no_username_non_interactive_aborts(config):
     with pytest.raises(exceptions.NonInteractive):
-        auth.Private(config, auth.CredentialInput("user")).password
+        auth.Private(config, auth.CredentialInput()).username
 
 
 def test_no_password_non_interactive_aborts(config):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,8 +181,12 @@ def test_get_password_keyring_runtime_error_logged(
 @pytest.fixture
 def keyring_missing_home(monkeypatch):
     """Simulate environment from https://github.com/pypa/twine/issues/889."""
+
+    def getpwuid(_):
+        raise KeyError("uid not found: 999")
+
     monkeypatch.delenv("HOME")
-    monkeypatch.setattr("os.getuid", lambda: 999)
+    monkeypatch.setattr("pwd.getpwuid", getpwuid)
 
 
 def test_get_username_keyring_missing_home_logged(keyring_missing_home, config, caplog):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -190,21 +190,37 @@ def keyring_missing_home(monkeypatch):
 
 
 def test_get_username_keyring_missing_home_logged(keyring_missing_home, config, caplog):
+    caplog.set_level(logging.INFO)
+
     resolver = auth.Resolver(config, auth.CredentialInput())
     assert not resolver.get_username_from_keyring()
 
     assert re.search(
-        r"Error from keyring.+Traceback.+KeyError: 'HOME'", caplog.text, re.DOTALL
+        r"Querying keyring for username"
+        r".+Error from keyring"
+        r".+Traceback"
+        r".+KeyError: 'HOME'"
+        r".+KeyError: 'uid not found: 999'",
+        caplog.text,
+        re.DOTALL,
     )
 
 
 def test_get_password_keyring_missing_home_logged(keyring_missing_home, config, caplog):
+    caplog.set_level(logging.INFO)
+
     resolver = auth.Resolver(config, auth.CredentialInput("user"))
     assert resolver.username == "user"
     assert not resolver.get_password_from_keyring()
 
     assert re.search(
-        r"Error from keyring.+Traceback.+KeyError: 'HOME'", caplog.text, re.DOTALL
+        r"Querying keyring for password"
+        r".+Error from keyring"
+        r".+Traceback"
+        r".+KeyError: 'HOME'"
+        r".+KeyError: 'uid not found: 999'",
+        caplog.text,
+        re.DOTALL,
     )
 
 

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -63,7 +63,7 @@ class Resolver:
             # To support keyring prior to 15.2
             pass
         except Exception as exc:
-            logger.exception(exc)
+            logger.warning("Error from keyring", exc_info=exc)
         return None
 
     def get_password_from_keyring(self) -> Optional[str]:
@@ -73,7 +73,7 @@ class Resolver:
             logger.info("Querying keyring for password")
             return cast(str, keyring.get_password(system, username))
         except Exception as exc:
-            logger.exception(exc)
+            logger.warning("Error from keyring", exc_info=exc)
         return None
 
     def username_from_keyring_or_prompt(self) -> str:

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -63,7 +63,7 @@ class Resolver:
             # To support keyring prior to 15.2
             pass
         except Exception as exc:
-            logger.warning(str(exc))
+            logger.exception(exc)
         return None
 
     def get_password_from_keyring(self) -> Optional[str]:
@@ -73,7 +73,7 @@ class Resolver:
             logger.info("Querying keyring for password")
             return cast(str, keyring.get_password(system, username))
         except Exception as exc:
-            logger.warning(str(exc))
+            logger.exception(exc)
         return None
 
     def username_from_keyring_or_prompt(self) -> str:

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -63,7 +63,7 @@ class Resolver:
             # To support keyring prior to 15.2
             pass
         except Exception as exc:
-            logger.warning("Error from keyring", exc_info=exc)
+            logger.warning("Error getting username from keyring", exc_info=exc)
         return None
 
     def get_password_from_keyring(self) -> Optional[str]:
@@ -73,7 +73,7 @@ class Resolver:
             logger.info("Querying keyring for password")
             return cast(str, keyring.get_password(system, username))
         except Exception as exc:
-            logger.warning("Error from keyring", exc_info=exc)
+            logger.warning("Error getting password from keyring", exc_info=exc)
         return None
 
     def username_from_keyring_or_prompt(self) -> str:


### PR DESCRIPTION
*Rewritten by @bhrutledge*

This PR makes sure that exceptions occurring during keyring usage are not silenced  (fixes #889).

```
% twine upload --verbose -r testpypi --non-interactive ../example-pkg-bhrutledge/dist/*
Uploading distributions to https://test.pypi.org/legacy/
INFO     ../example-pkg-bhrutledge/dist/example_pkg_bhrutledge-0.0.5-py3-none-any.whl (2.7 KB)                                           
INFO     Querying keyring for username                                                                                                   
WARNING  Error getting username from keyring                                                                                             
         Traceback (most recent call last):                                                                                              
           File "/Users/bhrutledge/.pyenv/versions/3.8.12/lib/python3.8/pathlib.py", line 377, in gethomedir                             
             return os.environ['HOME']                                                                                                   
           File "/Users/bhrutledge/.pyenv/versions/3.8.12/lib/python3.8/os.py", line 675, in __getitem__                                 
             raise KeyError(key) from None                                                                                               
         KeyError: 'HOME'                                                                                                                
                                                                                                                                         
         During handling of the above exception, another exception occurred:                                                             
                                                                                                                                         
         Traceback (most recent call last):                                                                                              
           File "/Users/bhrutledge/Dev/twine/twine/auth.py", line 59, in get_username_from_keyring                                       
             creds = keyring.get_credential(system, None)                                                                                
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 72, in get_credential               
             return get_keyring().get_credential(service_name, username)                                                                 
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 32, in get_keyring                  
             init_backend()                                                                                                              
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 83, in init_backend                 
             set_keyring(_detect_backend(limit))                                                                                         
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 98, in _detect_backend              
             or load_config()                                                                                                            
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 153, in load_config                 
             keyring_cfg = os.path.join(platform.config_root(), filename)                                                                
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/util/platform_.py", line 59, in _config_root_Linux 
             _check_old_config_root()                                                                                                    
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/util/platform_.py", line 43, in                    
         _check_old_config_root                                                                                                          
             config_file_new = os.path.join(_config_root_Linux(), 'keyringrc.cfg')                                                       
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/util/platform_.py", line 60, in _config_root_Linux 
             fallback = pathlib.Path.home() / '.config'                                                                                  
           File "/Users/bhrutledge/.pyenv/versions/3.8.12/lib/python3.8/pathlib.py", line 1103, in home                                  
             return cls(cls()._flavour.gethomedir(None))                                                                                 
           File "/Users/bhrutledge/.pyenv/versions/3.8.12/lib/python3.8/pathlib.py", line 380, in gethomedir                             
             return pwd.getpwuid(os.getuid()).pw_dir                                                                                     
         KeyError: 'getpwuid(): uid not found: 999'                                                                                      
ERROR    NonInteractive: Credential not found for username.                                                                              
```

This changes the behavior defined in #316. Currently, when there's no backend defined, there's a single-line warning:

```
% twine upload -r testpypi -u __token__ --non-interactive ../example-pkg-bhrutledge/dist/*          
Uploading distributions to https://test.pypi.org/legacy/
WARNING  No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if  
         you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.                                 
ERROR    NonInteractive: Credential not found for password.   
```

Now, there's a short traceback:

```
% twine upload -r testpypi -u __token__ --non-interactive ../example-pkg-bhrutledge/dist/*
Uploading distributions to https://test.pypi.org/legacy/
WARNING  Error getting password from keyring                                                                                             
         Traceback (most recent call last):                                                                                              
           File "/Users/bhrutledge/Dev/twine/twine/auth.py", line 74, in get_password_from_keyring                                       
             return cast(str, keyring.get_password(system, username))                                                                    
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/core.py", line 55, in get_password                 
             return get_keyring().get_password(service_name, username)                                                                   
           File "/Users/bhrutledge/Dev/twine/venv/lib/python3.8/site-packages/keyring/backends/fail.py", line 25, in get_password        
             raise NoKeyringError(msg)                                                                                                   
         keyring.errors.NoKeyringError: No recommended backend was available. Install a recommended 3rd party backend package; or,       
         install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for      
         details.                                                                                                                        
ERROR    NonInteractive: Credential not found for password.                                                                              
```

These is definitely noisier, but maybe more helpful? A middle ground might be to add an `except keyring.errors.KeyringError` clause that doesn't show the traceback, that started to feel like extra work for limited value. We  can certainly revisit that if it turns out to be confusing.