### PR TITLE
Restore missing `__main__` logs

### DIFF
--- a/changelog/896.bugfix.rst
+++ b/changelog/896.bugfix.rst
@@ -1,0 +1,1 @@
+Reconfgure root logger to show all log messages.

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -22,7 +22,7 @@ import requests
 from twine import cli
 from twine import exceptions
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("twine")
 
 
 def main() -> Any:

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -22,7 +22,7 @@ import requests
 from twine import cli
 from twine import exceptions
 
-logger = logging.getLogger("twine")
+logger = logging.getLogger(__name__)
 
 
 def main() -> Any:

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -52,6 +52,7 @@ def configure_output() -> None:
     # test_main.py due to capsys not being cleared.
     logging.config.dictConfig(
         {
+            "disable_existing_loggers": False,
             "version": 1,
             "handlers": {
                 "console": {
@@ -61,10 +62,8 @@ def configure_output() -> None:
                     "highlighter": rich.highlighter.NullHighlighter(),
                 }
             },
-            "loggers": {
-                "twine": {
-                    "handlers": ["console"],
-                },
+            "root": {
+                "handlers": ["console"],
             },
         }
     )


### PR DESCRIPTION
Fixes #895 

Instead of configuring only the `twine` logger (and disabling all of the other loggers), this configures the root logger and enables all loggers to use the Rich configuration.

```
% twine upload -r testpypi dist/*
Uploading distributions to https://test.pypi.org/legacy/
ERROR    InvalidDistribution: Unknown distribution format: 'example-pkg-bhrutledge-0.0.5.tar'                                            

% python -m twine upload -r testpypi dist/*
Uploading distributions to https://test.pypi.org/legacy/
ERROR    InvalidDistribution: Unknown distribution format: 'example-pkg-bhrutledge-0.0.5.tar'     
```

FYI @bayersglassey-zesty