### PR TITLE
Update changelog for 4.0.1

### DIFF
--- a/changelog/890.bugfix.rst
+++ b/changelog/890.bugfix.rst
@@ -1,1 +1,0 @@
-Improve logging when keyring fails.

--- a/changelog/896.bugfix.rst
+++ b/changelog/896.bugfix.rst
@@ -1,1 +1,0 @@
-Reconfgure root logger to show all log messages.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,16 @@ schemes recommended by the Python Packaging Authority.
 
 .. towncrier release notes start
 
+Twine 4.0.1 (2022-06-01)
+------------------------
+
+Bugfixes
+^^^^^^^^
+
+- Improve logging when keyring fails. (`#890 <https://github.com/pypa/twine/issues/890>`_)
+- Reconfgure root logger to show all log messages. (`#896 <https://github.com/pypa/twine/issues/896>`_)
+
+
 Twine 4.0.0 (2022-03-31)
 ------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ commands =
     python -c 'with open("mypy/index.txt") as f: print(f.read())'
 
 [testenv:changelog]
-skip_install = True
 basepython = python3
 deps =
     towncrier


### PR DESCRIPTION
This also fixes this error when running `tox -e changelog`:

```
Rendering news fragments...
ERROR: tried to import twine, but ran into this error: No module named 'importlib_metadata'
Traceback (most recent call last):
  File "/Users/bhrutledge/Dev/twine/.tox/changelog/lib/python3.8/site-packages/towncrier/_project.py", line 20, in _get_package
    module = import_module(package)
  File "/Users/bhrutledge/.pyenv/versions/3.8.12/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'twine'
```