### PR TITLE
Add environment variable for --skip-existing

### DIFF
--- a/changelog/907.feature.rst
+++ b/changelog/907.feature.rst
@@ -1,0 +1,1 @@
+Add support for specifying ``--skip-existing`` as an environment variable (`TWINE_SKIP_EXISTING`).

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -233,11 +233,11 @@ class Settings:
         )
         parser.add_argument(
             "--skip-existing",
-            default=False,
-            action="store_true",
+            action=utils.EnvironmentFlag,
+            env="TWINE_SKIP_EXISTING",
             help="Continue uploading files if one already exists. (Only valid "
             "when uploading to PyPI. Other implementations may not "
-            "support this.)",
+            "support this.) Can also be set via %(env)s environment variable.",
         )
         parser.add_argument(
             "--cert",


### PR DESCRIPTION
This allow users to set TWINE_SKIP_EXISTING in addition to using the
flag.

Closes #906.