### PR TITLE
Don't replace underscores with hyphens in distribution name

### DIFF
--- a/changelog/901.bugfix.rst
+++ b/changelog/901.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed replacing underscores by hyphens in package names.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -121,6 +121,7 @@ def test_package_signed_name_is_correct():
         (string.digits, string.digits),
         (string.punctuation, "-.-"),
         ("mosaik.SimConfig", "mosaik.SimConfig"),
+        ("package_name", "package_name"),
         ("mosaik$$$$.SimConfig", "mosaik-.SimConfig"),
     ],
 )

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -119,9 +119,8 @@ def test_package_signed_name_is_correct():
     [
         (string.ascii_letters, string.ascii_letters),
         (string.digits, string.digits),
-        (string.punctuation, "-.-"),
-        ("mosaik.SimConfig", "mosaik.SimConfig"),
-        ("package_name", "package_name"),
+        (string.punctuation, "-.-_-"),
+        ("mosaik._SimConfig", "mosaik._SimConfig"),
         ("mosaik$$$$.SimConfig", "mosaik-.SimConfig"),
     ],
 )

--- a/twine/package.py
+++ b/twine/package.py
@@ -51,12 +51,12 @@ logger = logging.getLogger(__name__)
 def _safe_name(name: str) -> str:
     """Convert an arbitrary string to a standard distribution name.
 
-    Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+    Any runs of non-alphanumeric/./_ characters are replaced with a single '-'.
 
     Copied from pkg_resources.safe_name for compatibility with warehouse.
     See https://github.com/pypa/twine/issues/743.
     """
-    return re.sub("[^A-Za-z0-9.]+", "-", name)
+    return re.sub("[^A-Za-z0-9._]+", "-", name)
 
 
 class PackageFile:


### PR DESCRIPTION
Fixes #920