### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.MIN_PYTHON_VERSION }}
+          python-version: "3.8"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Build docs


### PR DESCRIPTION
There's a [persistent error](https://github.com/pypa/twine/actions/runs/3201736981/jobs/5230007607) that seems to be coming from the stevedore package.

Starting with running under Python 3.8, since that's working for me locally.