### PR TITLE
Fix `test_check` on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
+    pytest -vv --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
 
 [testenv:integration]
 deps =


### PR DESCRIPTION
Some of the tests are [failing consistently](https://github.com/pypa/twine/actions/runs/3301533167/jobs/5447107843); verbose pytest logging shows errors like:

```
>       assert capsys.readouterr().out == f"Checking {sdist}: " + (
            "FAILED due to warnings\n" if strict else "PASSED with warnings\n"
        )
E       AssertionError: assert ('Checking '\n 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-unknown\\pytest-\x1b[1m0\x1b[0m\\test_warns_missing_description0\\dist\\test-package-\x1b[1m0.0\x1b[0m.\x1b[1m1.\x1b[0mtar.gz: '\n 'PASSED with warnings\n') == ('Checking '\n 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-unknown\\pytest-0\\test_warns_missing_description0\\dist\\test-package-0.0.1.tar.gz: '\n 'PASSED with warnings\n')
E         - Checking C:\Users\runneradmin\AppData\Local\Temp\pytest-of-unknown\pytest-0\test_warns_missing_description0\dist\test-package-0.0.1.tar.gz: PASSED with warnings
E         + Checking C:\Users\runneradmin\AppData\Local\Temp\pytest-of-unknown\pytest-0\test_warns_missing_description0\dist\test-package-0.0.1.tar.gz: PASSED with warnings
E         ?                                                                           ++++ ++++                                                   ++++   ++++ ++++  ++++
```

I can't make sense of that, and I don't have access to a Windows machine. I might be able to set up a cloud desktop, but if someone has a Windows machine, and is able to [run the tests locally](https://twine.readthedocs.io/en/stable/contributing.html#testing) to reproduce this, I'd appreciate it.