### PR TITLE
Fix failing CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,9 +3,10 @@
 max-line-length = 88
 
 extend-ignore =
-    D107,  # Missing docstring in __init__
+    # Missing docstring in __init__
+    D107
 
-per-file-ignores = 
+per-file-ignores =
     # TODO: Incrementally add missing docstrings
     # D100 Missing docstring in public module
     # D101 Missing docstring in public class

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,7 @@ jobs:
       - name: Run type-checking
         run: python -m tox -e types
       - name: Run tests
-        run: python -m tox -e py -- --cov-report xml
-      - uses: codecov/codecov-action@v1
-        if: github.event_name != 'schedule'
-        with:
-          file: ./coverage.xml
-          name: ${{ matrix.python-version }} - ${{ matrix.platform }}
-          fail_ci_if_error: true
+        run: python -m tox -e py
 
   # Because the tests can be flaky, they shouldn't be required for merge, but
   # it's still helpful to run them on PRs. See:

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,6 @@
 .. image:: https://img.shields.io/github/workflow/status/pypa/twine/Main
    :target: https://github.com/pypa/twine/actions
 
-.. image:: https://img.shields.io/codecov/c/github/pypa/twine
-   :target: https://codecov.io/gh/pypa/twine
-
 twine
 =====
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,4 @@ filterwarnings=
 	ignore:the imp module is deprecated::setuptools
 
 addopts =
-	--cov=twine --cov-context=test --cov-report=
 	--disable-socket

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ def configure_output():
     """
     rich.reconfigure(
         no_color=True,
+        color_system=None,
+        emoji=False,
+        highlight=False,
         width=500,
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,15 @@ isolated_build = True
 deps =
     pretend
     pytest
-    pytest-cov
     pytest-socket
     build
+    coverage
 passenv =
     PYTEST_ADDOPTS
 commands =
-    pytest --ignore-glob '*integration*.py' {posargs:--cov-report term-missing --cov-report html}
+    python -m coverage run -m pytest --ignore-glob '*integration*.py'
+    python -m coverage html --show-contexts
+    python -m coverage report -m --fail-under 97
 
 [testenv:integration]
 deps =
@@ -26,8 +28,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    # Skipping coverage because that should be handled by the other tests
-    pytest -r aR --no-cov tests/test_integration.py
+    pytest -r aR tests/test_integration.py
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
CodeCov's services seem to be getting more and more unavailable, and are causing our tests to fail (e.g., https://github.com/pypa/twine/actions/runs/3577489389/jobs/6016720780).

This PR removes CodeCov entirely in favor of running `coverage` in CI and asserting on some coverage percentage, currently 97%.

Fixes #658. This includes #942 to get CI to pass, closes #942. Closes #936.