### PR TITLE
Introduce a centralized GHA check/gate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,12 +81,28 @@ jobs:
       - name: Build docs
         run: python -m tox -e docs
 
-  release:
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
     needs:
       - lint
       - test
-      # Not requiring integration, because they can be flaky
+      - integration
       - docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        allowed-failures: integration  # can be flaky
+        jobs: ${{ toJSON(needs) }}
+
+  release:
+    needs:
+      - check
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This patch is intended to lower the maintenance burden of having to manually go through each matrix subjob name in the branch protection repository settings. It allows to only include the `check` job in the branch protection and it will robustly determine if the dependencies have succeeded or not.

It is currently mostly serves the Python ecosystem in projects like aiohttp, attrs, cryptography, pydantic, open edX, pip etc. But I've also seen other communities picking it up lately, like the AWS Rust SDK and even the engine powering https://dev.to, to my surprise. Strictly speaking, it is agnostic.

Ref: https://github.com/marketplace/actions/alls-green#why