### PR TITLE
Update integration tests for latest sampleproject

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,10 +16,7 @@ import requests
 from twine import __main__ as dunder_main
 from twine import cli
 
-pytestmark = [
-    pytest.mark.enable_socket,
-    pytest.mark.flaky(reruns=3, reruns_delay=1),
-]
+pytestmark = [pytest.mark.enable_socket]
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     portend
     pytest-rerunfailures
     pytest-services
+    build
 passenv =
     PYTEST_ADDOPTS
 commands =


### PR DESCRIPTION
https://github.com/pypa/sampleproject/pull/166 switched to `pyproject.toml`, which broke these tests' use of `setup.py`. This is my quick attempt to resolve that, with a little bit of refactoring. I also turned off re-runs, because the error message didn't indicate the missing file.