### PR TITLE
Use Dependabot for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I noticed that there are several deprecated actions, and that this method is used by other PyPA repos.

https://github.com/search?q=org%3Apypa+filename%3Adependabot.yml+github-actions