### PR TITLE
Limit CI on push to main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: Main
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *" # daily


### PR DESCRIPTION
This seems to be common practice, and should hopefully avoid redundant workflow runs on pull requests.