### PR TITLE
Use tox<4 to fix broken CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
       - name: Install dependencies
-        run: python -m pip install tox
+        run: python -m pip install 'tox<4'
       - name: Run tests
         run: python -m tox -e integration
 
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
       - name: Install dependencies
-        run: python -m pip install tox
+        run: python -m pip install 'tox<4'
       - name: Build docs
         run: python -m tox -e docs
 


### PR DESCRIPTION
This is a temporary hack for `docs` and `integration`, which are currently failing, likely due to breaking changes in Tox 4.