### PR TITLE
Restore devpi and pypiserver integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,6 @@ import sys
 import venv
 from types import SimpleNamespace
 
-import portend
 import pytest
 import requests
 
@@ -119,7 +118,7 @@ xfail_win32 = pytest.mark.xfail(
 
 
 @pytest.fixture(scope="session")
-def devpi_server(request, watcher_getter, tmp_path_factory):
+def devpi_server(request, port_getter, watcher_getter, tmp_path_factory):
     env_dir = tmp_path_factory.mktemp("venv")
     bin_dir = env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
 
@@ -129,7 +128,7 @@ def devpi_server(request, watcher_getter, tmp_path_factory):
     server_dir = tmp_path_factory.mktemp("devpi")
     username = "foober"
     password = secrets.token_urlsafe()
-    port = portend.find_available_local_port()
+    port = port_getter()
     url = f"http://localhost:{port}/"
     repo = f"{url}/{username}/dev/"
 
@@ -174,14 +173,14 @@ def test_devpi_upload(devpi_server, uploadable_dist):
 
 
 @pytest.fixture(scope="session")
-def pypiserver_instance(request, watcher_getter, tmp_path_factory):
+def pypiserver_instance(request, port_getter, watcher_getter, tmp_path_factory):
     env_dir = tmp_path_factory.mktemp("venv")
     bin_dir = env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
 
     venv.create(env_dir, symlinks=True, with_pip=True, upgrade_deps=True)
     run([bin_dir / "python", "-m", "pip", "install", "pypiserver"])
 
-    port = portend.find_available_local_port()
+    port = port_getter()
     url = f"http://localhost:{port}/"
 
     def ready():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,11 @@ pytestmark = [pytest.mark.enable_socket]
 
 run = functools.partial(subprocess.run, check=True)
 
+xfail_win32 = pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="pytest-services watcher_getter fixture does not support Windows",
+)
+
 
 @pytest.fixture(scope="session")
 def sampleproject_dist(tmp_path_factory: pytest.TempPathFactory):
@@ -116,12 +121,6 @@ def venv_exe_dir(tmp_path_factory):
 )
 def uploadable_dist(request):
     return pathlib.Path(__file__).parent / "fixtures" / request.param
-
-
-xfail_win32 = pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="pytest-services watcher_getter fixture does not support Windows",
-)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -107,7 +107,7 @@ def test_pypi_error(sampleproject_dist, monkeypatch, capsys):
 @pytest.fixture(scope="session")
 def venv_exe_dir(tmp_path_factory):
     env_dir = tmp_path_factory.mktemp("venv")
-    venv.create(env_dir, symlinks=True, with_pip=True, upgrade_deps=True)
+    venv.create(env_dir, symlinks=True, with_pip=True)
     return env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -99,6 +99,13 @@ def test_pypi_error(sampleproject_dist, monkeypatch, capsys):
     assert re.search(message, captured.out, re.DOTALL)
 
 
+@pytest.fixture(scope="session")
+def venv_exe_dir(tmp_path_factory):
+    env_dir = tmp_path_factory.mktemp("venv")
+    venv.create(env_dir, symlinks=True, with_pip=True, upgrade_deps=True)
+    return env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
+
+
 @pytest.fixture(
     params=[
         "twine-1.5.0.tar.gz",
@@ -118,12 +125,8 @@ xfail_win32 = pytest.mark.xfail(
 
 
 @pytest.fixture(scope="session")
-def devpi_server(request, port_getter, watcher_getter, tmp_path_factory):
-    env_dir = tmp_path_factory.mktemp("venv")
-    bin_dir = env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
-
-    venv.create(env_dir, symlinks=True, with_pip=True, upgrade_deps=True)
-    run([bin_dir / "python", "-m", "pip", "install", "devpi-server", "devpi"])
+def devpi_server(request, venv_exe_dir, port_getter, watcher_getter, tmp_path_factory):
+    run([venv_exe_dir / "python", "-m", "pip", "install", "devpi-server", "devpi"])
 
     server_dir = tmp_path_factory.mktemp("devpi")
     username = "foober"
@@ -132,14 +135,22 @@ def devpi_server(request, port_getter, watcher_getter, tmp_path_factory):
     url = f"http://localhost:{port}/"
     repo = f"{url}/{username}/dev/"
 
-    run([bin_dir / "devpi-init", "--serverdir", server_dir, "--root-passwd", password])
+    run(
+        [
+            venv_exe_dir / "devpi-init",
+            "--serverdir",
+            server_dir,
+            "--root-passwd",
+            password,
+        ]
+    )
 
     def ready():
         with contextlib.suppress(Exception):
             return requests.get(url)
 
     watcher_getter(
-        name=bin_dir / "devpi-server",
+        name=venv_exe_dir / "devpi-server",
         arguments=["--port", str(port), "--serverdir", server_dir],
         checker=ready,
         # Needed for the correct execution order of finalizers
@@ -147,7 +158,14 @@ def devpi_server(request, port_getter, watcher_getter, tmp_path_factory):
     )
 
     def devpi_run(cmd):
-        return run([bin_dir / "devpi", "--clientdir", server_dir / "client", *cmd])
+        return run(
+            [
+                venv_exe_dir / "devpi",
+                "--clientdir",
+                server_dir / "client",
+                *cmd,
+            ]
+        )
 
     devpi_run(["use", url + "root/pypi/"])
     devpi_run(["user", "--create", username, f"password={password}"])
@@ -173,12 +191,10 @@ def test_devpi_upload(devpi_server, uploadable_dist):
 
 
 @pytest.fixture(scope="session")
-def pypiserver_instance(request, port_getter, watcher_getter, tmp_path_factory):
-    env_dir = tmp_path_factory.mktemp("venv")
-    bin_dir = env_dir / ("Scripts" if platform.system() == "Windows" else "bin")
-
-    venv.create(env_dir, symlinks=True, with_pip=True, upgrade_deps=True)
-    run([bin_dir / "python", "-m", "pip", "install", "pypiserver"])
+def pypiserver_instance(
+    request, venv_exe_dir, port_getter, watcher_getter, tmp_path_factory
+):
+    run([venv_exe_dir / "python", "-m", "pip", "install", "pypiserver"])
 
     port = port_getter()
     url = f"http://localhost:{port}/"
@@ -188,7 +204,7 @@ def pypiserver_instance(request, port_getter, watcher_getter, tmp_path_factory):
             return requests.get(url)
 
     watcher_getter(
-        name=bin_dir / "pypi-server",
+        name=venv_exe_dir / "pypi-server",
         arguments=[
             "--port",
             str(port),

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ commands =
 [testenv:integration]
 deps =
     {[testenv]deps}
-    jaraco.envs
-    munch
     portend
     pytest-rerunfailures
     pytest-services
@@ -122,12 +120,3 @@ usedevelop = True
 commands =
     python -c 'import sys; print(sys.executable)'
     python --version
-
-[testenv:devpi]
-deps =
-    devpi-server
-    devpi
-
-[testenv:pypiserver]
-deps =
-    pypiserver

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ commands =
 [testenv:integration]
 deps =
     {[testenv]deps}
-    portend
     pytest-rerunfailures
     pytest-services
     build


### PR DESCRIPTION
As suggested in https://github.com/pypa/twine/issues/684#issuecomment-1347366875. This removes some external dependencies by:

- Using Python's `venv` module instead of coupling to tox via `jaraco.envs`
- Using `types.SimpleNamespace` instead of `munch`
- Using `port_getter` from pytest-services instead of `portend`

It also includes some additional tidying.

This passes locally via `pytest tests/test_integration.py` and `tox -e integration` (using Tox 4). 🤞 it passes CI.