### PR TITLE
Always skip integration tests on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,13 @@ jobs:
   # it's still helpful to run them on PRs. See:
   # https://github.com/pypa/twine/issues/684#issuecomment-703150619
   integration:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,13 +63,8 @@ jobs:
   # it's still helpful to run them on PRs. See:
   # https://github.com/pypa/twine/issues/684#issuecomment-703150619
   integration:
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.platform }}
+    # Only run on Ubuntu because most of the tests are skipped on Windows
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,12 +18,12 @@ from twine import cli
 
 pytestmark = [pytest.mark.enable_socket]
 
-run = functools.partial(subprocess.run, check=True)
-
-xfail_win32 = pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="pytest-services watcher_getter fixture does not support Windows",
+skip_if_windows = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="pytest-services fixtures don't support Windows",
 )
+
+run = functools.partial(subprocess.run, check=True)
 
 
 @pytest.fixture(scope="session")
@@ -174,6 +174,7 @@ def devpi_server(request, venv_exe_dir, port_getter, watcher_getter, tmp_path_fa
     return SimpleNamespace(url=repo, username=username, password=password)
 
 
+@skip_if_windows
 def test_devpi_upload(devpi_server, uploadable_dist):
     command = [
         "upload",
@@ -221,6 +222,7 @@ def pypiserver_instance(
     return SimpleNamespace(url=url)
 
 
+@skip_if_windows
 def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
     command = [
         "upload",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ def sampleproject_dist(tmp_path_factory: pytest.TempPathFactory):
     checkout = tmp_path_factory.mktemp("sampleproject", numbered=False)
     tag = datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
 
-    run(["git", "clone", "https://github.com/pypa/sampleproject", checkout])
+    run(["git", "clone", "https://github.com/pypa/sampleproject", str(checkout)])
 
     pyproject = checkout / "pyproject.toml"
     pyproject.write_text(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,7 +174,6 @@ def devpi_server(request, venv_exe_dir, port_getter, watcher_getter, tmp_path_fa
     return SimpleNamespace(url=repo, username=username, password=password)
 
 
-@xfail_win32
 def test_devpi_upload(devpi_server, uploadable_dist):
     command = [
         "upload",
@@ -222,7 +221,6 @@ def pypiserver_instance(
     return SimpleNamespace(url=url)
 
 
-@xfail_win32
 def test_pypiserver_upload(pypiserver_instance, uploadable_dist):
     command = [
         "upload",


### PR DESCRIPTION
This is simply out of curiosity; wondering if this is still true:

https://github.com/pypa/twine/blob/8a057d59415b7ee86413d34fcfe7c145ff69798c/tests/test_integration.py#L23-L26

Update: yep, they still fail. I don't think there's much sense in running them, so I've changed them from xfail to skip.