### PR TITLE
Move integration ignore to pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ filterwarnings=
 
 addopts =
 	--disable-socket
+	--ignore-glob '*integration*.py'

--- a/tox.ini
+++ b/tox.ini
@@ -13,16 +13,15 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 commands =
-    python -m coverage run -m pytest --ignore-glob '*integration*.py'
-    python -m coverage html --show-contexts
+    python -m coverage run -m pytest {posargs}
     python -m coverage report -m --fail-under 97
+    python -m coverage html --show-contexts
 
 [testenv:integration]
 deps =
     {[testenv]deps}
     pytest-rerunfailures
     pytest-services
-    build
 passenv =
     PYTEST_ADDOPTS
 commands =


### PR DESCRIPTION
This allows a contributor to just run `pytest`, and skip the integration tests by default, instead of relying on `tox`. The integration can still be run via `tox -e integration` or `pytest tests/test_integration.py`.

I got the idea from https://github.com/pypa/twine/issues/911#issuecomment-1205830034.