### PR TITLE
Fix test setup warning

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -22,7 +22,7 @@ from twine.commands import check
 
 
 class TestWarningStream:
-    def setup(self):
+    def setup_method(self):
         self.stream = check._WarningStream()
 
     def test_write_match(self):


### PR DESCRIPTION
Prompted by this warning from `pytest`:

```
tests/test_check.py::TestWarningStream::test_write_match
  /Users/bhrutledge/Dev/twine/venv/lib/python3.10/site-packages/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  tests/test_check.py::TestWarningStream::test_write_match is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)
```