### PR TITLE
Add explicit isort config for build package.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,4 +3,5 @@ profile=black
 force_single_line=True
 single_line_exclusions=typing
 default_section=THIRDPARTY
+known_third_party=build
 known_first_party=twine,helpers


### PR DESCRIPTION
This is a hack to workaround an obscure edge case. As of tox>=4, running `tox -e py` generates a `build/` directory in the project root. That confuses isort into thinking that `build` is a first-party package, which sorts it in the same section as `twine`. This forces `build` to be recognized as ta third-party package.