### PR TITLE
Remove isolated venv for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,9 @@ deps =
     {[testenv]deps}
     pytest-rerunfailures
     pytest-services
+    devpi-server
+    devpi
+    pypiserver
 passenv =
     PYTEST_ADDOPTS
 commands =


### PR DESCRIPTION
To reduce the complexity and runtime of the integration tests, this installs devpi and pypiserver as dependencies of `testenv:integration`, instead of creating an isolated venv for each during testing.