### PR TITLE
Remove attempt to resolve 'license' from metadata.

### DIFF
--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -40,4 +40,4 @@ __uri__ = metadata["home-page"]
 __version__ = metadata["version"]
 __author__ = metadata["author"]
 __email__ = metadata["author-email"]
-__license__ = metadata["license"]
+__license__ = None


### PR DESCRIPTION
The 'license' was removed from the metadata in 2c3c0494afd7db38b4f4f8d79d853187fc942ec5, and since 617b0a607c0e78c94c1bf8b9eccc69888743b564 has resolved to `None`. Probably it should be removed, but for compatibility, I'm just suggesting to retain it for now. Addresses deprecation warning introduced in importlib_metadata 5.2.