### PR TITLE
Rely on email.message to parse a header.

### DIFF
--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -64,7 +64,7 @@ class _WarningStream(io.StringIO):
 
 
 # from Python 3.11 docs
-def parse_content_type(value):
+def parse_content_type(value: str) -> Tuple[str, dict[str, str]]:
     msg = email.message.EmailMessage()
     msg["content-type"] = value
     return msg.get_content_type(), msg["content-type"].params

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -17,7 +17,7 @@ import email.message
 import io
 import logging
 import re
-from typing import List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Tuple, cast
 
 import readme_renderer.rst
 from rich import print
@@ -64,7 +64,7 @@ class _WarningStream(io.StringIO):
 
 
 # from Python 3.11 docs
-def parse_content_type(value: str) -> Tuple[str, dict[str, str]]:
+def parse_content_type(value: str) -> Tuple[str, Dict[str, str]]:
     msg = email.message.EmailMessage()
     msg["content-type"] = value
     return msg.get_content_type(), msg["content-type"].params

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import cgi
+import email.message
 import io
 import logging
 import re
@@ -63,6 +63,13 @@ class _WarningStream(io.StringIO):
         return self.getvalue().strip()
 
 
+# from Python 3.11 docs
+def parse_content_type(value):
+    msg = email.message.EmailMessage()
+    msg['content-type'] = value
+    return msg.get_content_type(), msg['content-type'].params
+
+
 def _check_file(
     filename: str, render_warning_stream: _WarningStream
 ) -> Tuple[List[str], bool]:
@@ -82,7 +89,7 @@ def _check_file(
         )
         description_content_type = "text/x-rst"
 
-    content_type, params = cgi.parse_header(description_content_type)
+    content_type, params = parse_content_type(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
     if description is None or description.rstrip() == "UNKNOWN":

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -63,8 +63,11 @@ class _WarningStream(io.StringIO):
         return self.getvalue().strip()
 
 
-# from Python 3.11 docs
 def _parse_content_type(value: str) -> Tuple[str, Dict[str, str]]:
+    """Implement logic of deprecated cgi.parse_header().
+
+    From https://docs.python.org/3.11/library/cgi.html#cgi.parse_header.
+    """
     msg = email.message.EmailMessage()
     msg["content-type"] = value
     return msg.get_content_type(), msg["content-type"].params

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -64,7 +64,7 @@ class _WarningStream(io.StringIO):
 
 
 # from Python 3.11 docs
-def parse_content_type(value: str) -> Tuple[str, Dict[str, str]]:
+def _parse_content_type(value: str) -> Tuple[str, Dict[str, str]]:
     msg = email.message.EmailMessage()
     msg["content-type"] = value
     return msg.get_content_type(), msg["content-type"].params
@@ -89,7 +89,7 @@ def _check_file(
         )
         description_content_type = "text/x-rst"
 
-    content_type, params = parse_content_type(description_content_type)
+    content_type, params = _parse_content_type(description_content_type)
     renderer = _RENDERERS.get(content_type, _RENDERERS[None])
 
     if description is None or description.rstrip() == "UNKNOWN":

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -66,8 +66,8 @@ class _WarningStream(io.StringIO):
 # from Python 3.11 docs
 def parse_content_type(value):
     msg = email.message.EmailMessage()
-    msg['content-type'] = value
-    return msg.get_content_type(), msg['content-type'].params
+    msg["content-type"] = value
+    return msg.get_content_type(), msg["content-type"].params
 
 
 def _check_file(


### PR DESCRIPTION
Fixes DeprecationWarning for `cgi` module in Python 3.11+.