### PR TITLE
Pin pkginfo to untyped release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages =
     twine.commands
 python_requires = >=3.7
 install_requires=
-    pkginfo >= 1.8.1
+    pkginfo >= 1.8.1, < 1.9.3  # https://github.com/pypa/twine/issues/971
     readme-renderer >= 35.0
     requests >= 2.20
     requests-toolbelt >= 0.8.0, != 0.9.0


### PR DESCRIPTION
Workaround for https://github.com/pypa/twine/issues/971 and https://bugs.launchpad.net/pkginfo/+bug/2002104.

