### PR TITLE
Update coverage threshold after bugfix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,7 @@ passenv =
 commands =
     python -m coverage run -m pytest {posargs}
     python -m coverage html
-    # HACK: The threshold could be 97, but py37 reports less
-    # See https://github.com/nedbat/coveragepy/issues/1524
-    python -m coverage report --skip-covered --show-missing --fail-under 96
+    python -m coverage report --skip-covered --show-missing --fail-under 97
 
 [testenv:integration]
 deps =


### PR DESCRIPTION
Reverting a change in #970, since https://github.com/nedbat/coveragepy/issues/1524 was fixed in [Coverage.py 7.0.5](https://github.com/nedbat/coveragepy/releases/tag/7.0.5).