### PR TITLE
Silence mypy errors related to importlib_metadata

### DIFF
--- a/twine/cli.py
+++ b/twine/cli.py
@@ -78,7 +78,7 @@ def list_dependencies_and_versions() -> List[Tuple[str, str]]:
         "requests-toolbelt",
         "urllib3",
     )
-    return [(dep, importlib_metadata.version(dep)) for dep in deps]  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
+    return [(dep, importlib_metadata.version(dep)) for dep in deps]
 
 
 def dep_versions() -> str:
@@ -118,6 +118,6 @@ def dispatch(argv: List[str]) -> Any:
 
     configure_output()
 
-    main = registered_commands[args.command].load()
+    main = registered_commands[args.command].load()  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 
     return main(args.args)

--- a/twine/package.py
+++ b/twine/package.py
@@ -124,9 +124,7 @@ class PackageFile:
 
         py_version: Optional[str]
         if dtype == "bdist_egg":
-            (dist,) = importlib_metadata.Distribution.discover(  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
-                path=[filename]
-            )
+            (dist,) = importlib_metadata.Distribution.discover(path=[filename])
             py_version = dist.metadata["Version"]
         elif dtype == "bdist_wheel":
             py_version = cast(wheel.Wheel, meta).py_version


### PR DESCRIPTION
I haven't dug into this, but I'm guessing recent versions of mypy and/or importlib_metadata caused these new errors:

```
twine/package.py:127: error: Unused "type: ignore" comment
twine/cli.py:81: error: Unused "type: ignore" comment
twine/cli.py:121: error: Call to untyped function "load" in typed context  [no-untyped-call]
```