### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,13 @@ formats:
   - pdf
   - epub
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  # Mininum supported Python version
-  version: "3.7"
-  # Install twine first, because RTD uses `--upgrade-strategy eager`,
+ # Install twine first, because RTD uses `--upgrade-strategy eager`,
   # which installs the latest version of docutils via readme_renderer.
   # However, Sphinx 4.2.0 requires docutils>=0.14,<0.18.
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     python: "3.11"
 
 python:
- # Install twine first, because RTD uses `--upgrade-strategy eager`,
+  # Install twine first, because RTD uses `--upgrade-strategy eager`,
   # which installs the latest version of docutils via readme_renderer.
   # However, Sphinx 4.2.0 requires docutils>=0.14,<0.18.
   install:

--- a/changelog/991.misc.rst
+++ b/changelog/991.misc.rst
@@ -1,0 +1,1 @@
+Fix the ReadTheDocs build by removing minimum python version and specifiying build requirements.


### PR DESCRIPTION
The ReadTheDocs build will fail now for python <= 3.8 specified. See urllib3/urllib3#2168