### PR TITLE
upload: warn the user if their signature(s) are ignored

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -162,7 +162,7 @@ def test_print_response_if_verbose(upload_settings, stub_response, caplog):
     assert caplog.messages.count(response_log) == 2
 
 
-def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
+def test_success_with_pre_signed_distribution(upload_settings, stub_repository, caplog):
     """Add GPG signature provided by user to uploaded package."""
     # Upload a pre-signed distribution
     result = upload.upload(
@@ -175,6 +175,12 @@ def test_success_with_pre_signed_distribution(upload_settings, stub_repository):
     assert package.gpg_signature == (
         "twine-1.5.0-py2.py3-none-any.whl.asc",
         b"signature",
+    )
+
+    # Ensure that a warning is emitted.
+    assert (
+        "One or more packages has an associated armored signature; these will "
+        "be silently ignored by the index" in caplog.messages
     )
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -179,7 +179,7 @@ def test_success_with_pre_signed_distribution(upload_settings, stub_repository, 
 
     # Ensure that a warning is emitted.
     assert (
-        "One or more packages has an associated armored signature; these will "
+        "One or more packages has an associated PGP signature; these will "
         "be silently ignored by the index" in caplog.messages
     )
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -124,6 +124,19 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         _make_package(filename, signatures, upload_settings) for filename in uploads
     ]
 
+    # Warn the user if they're trying to upload a PGP signature to PyPI
+    # or TestPyPI, which will (as of May 2023) ignore it.
+    # This check is currently limited to just those indices, since other
+    # indices may still support PGP signatures.
+    if (
+        any(p.gpg_signature for p in packages_to_upload)
+        and "pypi.org" in repository_url
+    ):
+        logger.warning(
+            "One or more packages has an associated armored signature; "
+            "these will be silently ignored by the index"
+        )
+
     repository = upload_settings.create_repository()
     uploaded_packages = []
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -128,9 +128,8 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
     # or TestPyPI, which will (as of May 2023) ignore it.
     # This check is currently limited to just those indices, since other
     # indices may still support PGP signatures.
-    if (
-        any(p.gpg_signature for p in packages_to_upload)
-        and "pypi.org" in repository_url
+    if any(p.gpg_signature for p in packages_to_upload) and repository_url.startswith(
+        (utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY)
     ):
         logger.warning(
             "One or more packages has an associated PGP signature; "

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -133,7 +133,7 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
         and "pypi.org" in repository_url
     ):
         logger.warning(
-            "One or more packages has an associated armored signature; "
+            "One or more packages has an associated PGP signature; "
             "these will be silently ignored by the index"
         )
 


### PR DESCRIPTION
This is an initial step towards #1009: if `twine upload` sees that any to-be-uploaded dist has an associated PGP signature and that the index URL looks like `pypi.org` (i.e. PyPI or TestPyPI), it emits a warning notifying the user that their PGP signature will be silently ignored.

See #1009.