### PR TITLE
Allow for an HttpError without a response

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
 commands =
     python -m coverage run -m pytest {posargs}
     python -m coverage html
-    python -m coverage report --skip-covered --show-missing --fail-under 96
+    python -m coverage report --skip-covered --show-missing --fail-under 97
 
 [testenv:integration]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
 commands =
     python -m coverage run -m pytest {posargs}
     python -m coverage html
-    python -m coverage report --skip-covered --show-missing --fail-under 97
+    python -m coverage report --skip-covered --show-missing --fail-under 96
 
 [testenv:integration]
 deps =

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -32,6 +32,9 @@ def main() -> Any:
     try:
         error = cli.dispatch(sys.argv[1:])
     except requests.HTTPError as exc:
+        if not exc.response:
+            raise
+        
         error = True
         status_code = exc.response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -32,7 +32,7 @@ def main() -> Any:
     try:
         error = cli.dispatch(sys.argv[1:])
     except requests.HTTPError as exc:
-        if not exc.response:
+        if not exc.response:  # pragma: no cover
             raise
 
         error = True

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -15,7 +15,7 @@
 import http
 import logging
 import sys
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -32,16 +32,16 @@ def main() -> Any:
     try:
         error = cli.dispatch(sys.argv[1:])
     except requests.HTTPError as exc:
-        if not exc.response:  # pragma: no cover
-            raise
+        # Assuming this response will never be None
+        response = cast(requests.Response, exc.response)
 
         error = True
-        status_code = exc.response.status_code
+        status_code = response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase
         logger.error(
             f"{exc.__class__.__name__}: {status_code} {status_phrase} "
-            f"from {exc.response.url}\n"
-            f"{exc.response.reason}"
+            f"from {response.url}\n"
+            f"{response.reason}"
         )
     except exceptions.TwineException as exc:
         error = True

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -34,7 +34,7 @@ def main() -> Any:
     except requests.HTTPError as exc:
         if not exc.response:
             raise
-        
+
         error = True
         status_code = exc.response.status_code
         status_phrase = http.HTTPStatus(status_code).phrase


### PR DESCRIPTION
Hopefully this will fix the [CI failures that started last week](https://github.com/pypa/twine/actions/workflows/main.yml?query=event%3Aschedule), probably as a result of [types-requests 2.31.09](https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/requests.md#23109-2023-10-13).