### PR TITLE
upload: warn about potential PGP deprecation

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -188,7 +188,6 @@ def test_warns_potential_pgp_removal_on_3p_index(
     make_settings, stub_repository, caplog
 ):
     """Warn when a PGP signature is specified for upload to a third-party index."""
-
     upload_settings = make_settings(
         """
         [pypi]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -17,7 +17,8 @@ import pretend
 import pytest
 import requests
 
-from twine import cli, exceptions
+from twine import cli
+from twine import exceptions
 from twine import package as package_file
 from twine.commands import upload
 

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -20,8 +20,11 @@ from typing import Dict, List, cast
 import requests
 from rich import print
 
-from twine import commands, exceptions, settings, utils
+from twine import commands
+from twine import exceptions
 from twine import package as package_file
+from twine import settings
+from twine import utils
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is my (belated) follow-on to #1010: when the package URL *doesn't* look like PyPI or TestPyPI, we emit a separate warning message telling the user that `twine` *may* remove support for PGP signatures at some point in the future.

Like with the last changeset, I've added a testcase that ensures we render this error in the expected scenario.

See: #1009.