### PR TITLE
settings: remove old mypy workarounds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   TOX_TESTENV_PASSENV: "FORCE_COLOR"
-  MIN_PYTHON_VERSION: "3.7"
-  DEFAULT_PYTHON_VERSION: "3.9"
+  MIN_PYTHON_VERSION: "3.8"
+  DEFAULT_PYTHON_VERSION: "3.10"
 
 permissions:
   contents: read
@@ -38,10 +38,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
         platform:
           - ubuntu-latest
           - macos-latest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,7 @@
 doc8>=0.8.0
 furo>=2021.10.09
 readme-renderer>=17.4
-Sphinx>=4.3.1
+# Remove this upper bound when twine's minimum Python is 3.9+.
+# See: https://github.com/sphinx-doc/sphinx/issues/11767
+Sphinx>=6,<7.1
 sphinxcontrib-programoutput>=0.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 packages =
     twine
     twine.commands
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires=
     pkginfo >= 1.8.1
     readme-renderer >= 35.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-minversion = 3.3
-envlist = lint,types,py{37,38,39,310},integration,docs
+minversion = 3.8
+envlist = lint,types,py{38,39,310,311,312},integration,docs
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ deps =
     pytest-socket
     build
     coverage
+    # Needed on 3.12 and newer due to setuptools not being pre-installed
+    # in fresh venvs.
+    # See: https://github.com/python/cpython/issues/95299
+    setuptools
 passenv =
     PYTEST_ADDOPTS
 commands =

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -127,14 +127,12 @@ class Settings:
 
     @property
     def username(self) -> Optional[str]:
-        # Workaround for https://github.com/python/mypy/issues/5858
-        return cast(Optional[str], self.auth.username)
+        return self.auth.username
 
     @property
     def password(self) -> Optional[str]:
         with self._allow_noninteractive():
-            # Workaround for https://github.com/python/mypy/issues/5858
-            return cast(Optional[str], self.auth.password)
+            return self.auth.password
 
     def _allow_noninteractive(self) -> "contextlib.AbstractContextManager[None]":
         """Bypass NonInteractive error when client cert is present."""


### PR DESCRIPTION
These workarounds are no longer necessary on recent versions of `mypy`, and are causing CI failures (due to redundant casts).