### PR TITLE
upload: add connection exceptions to upload retry protocol

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -191,7 +191,8 @@ class Repository:
             ) as exc:
                 number_of_redirects += 1
                 logger.warning(
-                    f"Exception raised ({exc})."
+                    f"{exc.__class__.__name__} raised."
+                    "\nPackage upload appears to have failed."
                     f" Retry {number_of_redirects} of {max_redirects}."
                 )
                 continue
@@ -207,8 +208,6 @@ class Repository:
                     )
                 else:
                     return resp
-
-        return resp
 
     def package_is_uploaded(
         self, package: package_file.PackageFile, bypass_cache: bool = False


### PR DESCRIPTION
Addresses our intermittent upload issues as described that #1017 was initially trying to address. 

Although we are mainly running into "connection reset by peer" exceptions, I've added connection timeouts, and I'd consider adding a sleep between retries. 