### PR TITLE
Remove parentheses to functools.lru_cache

### DIFF
--- a/twine/auth.py
+++ b/twine/auth.py
@@ -29,7 +29,7 @@ class Resolver:
         return cls if interactive else Private
 
     @property
-    @functools.lru_cache()
+    @functools.lru_cache
     def username(self) -> Optional[str]:
         return utils.get_userpass_value(
             self.input.username,
@@ -39,7 +39,7 @@ class Resolver:
         )
 
     @property
-    @functools.lru_cache()
+    @functools.lru_cache
     def password(self) -> Optional[str]:
         return utils.get_userpass_value(
             self.input.password,


### PR DESCRIPTION
They are not necessary in Python ≥ 3.8:
	https://bugs.python.org/issue36772