### PR TITLE
Remove distutils index-servers from config

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,11 +61,6 @@ def test_get_config_no_distutils(write_config_file):
             "username": "testuser",
             "password": "testpassword",
         },
-        "testpypi": {
-            "repository": utils.TEST_REPOSITORY,
-            "username": None,
-            "password": None,
-        },
     }
 
 
@@ -105,11 +100,6 @@ def test_get_config_missing(config_file):
     assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
-            "username": None,
-            "password": None,
-        },
-        "testpypi": {
-            "repository": utils.TEST_REPOSITORY,
             "username": None,
             "password": None,
         },
@@ -198,11 +188,6 @@ def test_get_config_deprecated_pypirc():
     assert utils.get_config(deprecated_pypirc_path) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
-            "username": "testusername",
-            "password": "testpassword",
-        },
-        "testpypi": {
-            "repository": utils.TEST_REPOSITORY,
             "username": "testusername",
             "password": "testpassword",
         },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,11 @@ def test_get_config(write_config_file):
             "username": "testuser",
             "password": "testpassword",
         },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
     }
 
 
@@ -60,6 +65,11 @@ def test_get_config_no_distutils(write_config_file):
             "repository": utils.DEFAULT_REPOSITORY,
             "username": "testuser",
             "password": "testpassword",
+        },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None,
         },
     }
 
@@ -82,6 +92,11 @@ def test_get_config_no_section(write_config_file):
             "username": "testuser",
             "password": "testpassword",
         },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
     }
 
 
@@ -100,6 +115,11 @@ def test_get_config_missing(config_file):
     assert utils.get_config(config_file) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
+            "username": None,
+            "password": None,
+        },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
             "username": None,
             "password": None,
         },
@@ -188,6 +208,11 @@ def test_get_config_deprecated_pypirc():
     assert utils.get_config(deprecated_pypirc_path) == {
         "pypi": {
             "repository": utils.DEFAULT_REPOSITORY,
+            "username": "testusername",
+            "password": "testpassword",
+        },
+        "testpypi": {
+            "repository": utils.TEST_REPOSITORY,
             "username": "testusername",
             "password": "testpassword",
         },

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -55,7 +55,7 @@ def get_config(path: str) -> Dict[str, RepositoryConfig]:
     pypyi and testpypi.
     """
     realpath = os.path.realpath(os.path.expanduser(path))
-    parser = configparser.RawConfigParser()
+    parser = configparser.ConfigParser()
 
     try:
         with open(realpath) as f:
@@ -75,17 +75,17 @@ def get_config(path: str) -> Dict[str, RepositoryConfig]:
     config: DefaultDict[str, RepositoryConfig]
     config = collections.defaultdict(lambda: defaults.copy())
 
-    index_servers = parser.get(
-        "distutils", "index-servers", fallback="pypi testpypi"
-    ).split()
-
     # Don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY
-    if "testpypi" in index_servers:
+    if parser.has_section("testpypi"):
         config["testpypi"]["repository"] = TEST_REPOSITORY
 
     # Optional configuration values for individual repositories
-    for repository in index_servers:
+    for repository in parser.sections():
+        if repository == "server-login":
+            # handled by defaults already, don't add an extra key to config
+            continue
+
         for key in [
             "username",
             "repository",

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -77,8 +77,7 @@ def get_config(path: str) -> Dict[str, RepositoryConfig]:
 
     # Don't require users to manually configure URLs for these repositories
     config["pypi"]["repository"] = DEFAULT_REPOSITORY
-    if parser.has_section("testpypi"):
-        config["testpypi"]["repository"] = TEST_REPOSITORY
+    config["testpypi"]["repository"] = TEST_REPOSITORY
 
     # Optional configuration values for individual repositories
     for repository in parser.sections():


### PR DESCRIPTION
Replace RawConfigParser with ConfigParser
Update lookup to use `.sections()` and `.has_section()`

Removes extra entries from tests, since the default fallback will no longer automatically add them to an empty config.