### PR TITLE
Apply Repo-Review suggestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Apply a [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=pypa%2Ftwine&branch=main) suggestion.

* [PP003](https://learn.scientific-python.org/development/guides/packaging-classic#PP003): Does not list wheel as a build-dep
  Do not include `"wheel"` in your `build-system.requires`, setuptools does this via [PEP 517](https://peps.python.org/pep-0517/) already. Setuptools will also only require this for actual wheel builds, and might have version limits.