### PR TITLE
cli: use truststore if available

### DIFF
--- a/twine/cli.py
+++ b/twine/cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import logging
 import logging.config
 from typing import Any, List, Tuple
 
@@ -22,6 +23,8 @@ import rich.logging
 import rich.theme
 
 import twine
+
+logger = logging.getLogger(__name__)
 
 args = argparse.Namespace()
 
@@ -67,6 +70,18 @@ def configure_output() -> None:
             },
         }
     )
+
+
+def init_truststore(required: bool = False) -> None:
+    try:
+        import truststore
+    except ImportError as exc:
+        logger.debug("Error importing truststore", exc_info=exc)
+        if required:
+            raise
+    else:
+        # https://truststore.readthedocs.io/en/latest/#using-truststore-with-requests
+        truststore.inject_into_ssl()
 
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
@@ -117,6 +132,8 @@ def dispatch(argv: List[str]) -> Any:
     parser.parse_args(argv, namespace=args)
 
     configure_output()
+
+    init_truststore()
 
     main = registered_commands[args.command].load()  # type: ignore[no-untyped-call] # python/importlib_metadata#288  # noqa: E501
 


### PR DESCRIPTION
The lack of this has been a *perennial* thorn for people behind corporate TLS MITM ALG proxies; when it's soluble, it's still annoying, and sometimes the proxy applications don't use a stable root bundle, rendering the situation kinda insoluble.

Pip added truststore support back in version 22.2, but Twine still seems to require users to rustle up CA bundles themselves, which can be difficult and is actually infeasible with certain proxy software \(e.g. ZScaler\) that rotates the roots regularly and distributes new bundles into the system trust stores via a system-level mechanism like Active Directory.

The current draft of the code only applies truststore during CLI dispatch, to avoid interfering with Twine's use as a library, per truststore documentation:

> `inject_into_ssl()` **must not be used by libraries or packages** as it will cause issues on import time when integrated with other libraries. Libraries and packages should instead use `truststore.SSLContext` directly which is detailed below. The `inject_into_ssl()` function is intended only for use in applications and scripts.