### PR TITLE
Fix usage of GitHub state/output commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate hashes"
         id: hash
         run: |
-          cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+          cd dist && echo "$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: "Upload dists"
         uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/