### PR TITLE
Fix issue form syntax for GitHub validations

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_upload_failed.yml
+++ b/.github/ISSUE_TEMPLATE/01_upload_failed.yml
@@ -44,7 +44,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: environment-os-other
     attributes:
       label: "If you selected 'Other', describe your Operating System here"
@@ -90,7 +90,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: package-repository
     attributes:
       label: "Which package repository are you using?"

--- a/.github/ISSUE_TEMPLATE/02_bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug.yml
@@ -44,10 +44,11 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: environment-os-other
     attributes:
       label: "If you selected 'Other', describe your Operating System here"
+      placeholder: "example: Linux hostname 6.5.10-200.fc38.x86_64"
     validations:
       required: false
 
@@ -90,7 +91,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: package-repository
     attributes:
       label: "Which package repository are you using?"


### PR DESCRIPTION
These seemed to work when we created them but GitHub has become more srict in its validation. That's a whole lot of fun when there's nothing to verify these locally. Naturally, the top of their "common validation errors" page says "Issue forms are currently in beta and subject to change" so that probably explains it just fine.

Further, viewing the files on the branch on GitHub shows the validation errors seem to be fixed.