### PR TITLE
Updates provides_extras to provides_extra to be consistent with pypi upload server

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -177,7 +177,7 @@ def test_metadata_dictionary_keys():
         "requires_external",
         "requires_python",
         # Metadata 2.1
-        "provides_extras",
+        "provides_extra",
         "description_content_type",
         # Metadata 2.2
         "dynamic",
@@ -268,7 +268,7 @@ def test_metadata_dictionary_values(gpg_signature):
     assert result["requires_python"] == meta.requires_python
 
     # Metadata 2.1
-    assert result["provides_extras"] == meta.provides_extras
+    assert result["provides_extra"] == meta.provides_extras
     assert result["description_content_type"] == meta.description_content_type
 
     # Metadata 2.2

--- a/twine/package.py
+++ b/twine/package.py
@@ -177,7 +177,7 @@ class PackageFile:
             "requires_external": meta.requires_external,
             "requires_python": meta.requires_python,
             # Metadata 2.1
-            "provides_extras": meta.provides_extras,
+            "provides_extra": meta.provides_extras,
             "description_content_type": meta.description_content_type,
             # Metadata 2.2
             "dynamic": meta.dynamic,


### PR DESCRIPTION
Closes #1064

It updates the `provides_extras`  to `provides_extra` as provides_extra is the name expected on pypi upload file server.

I managed to upload the package properly after the changes:

![image](https://github.com/pypa/twine/assets/23180089/f2e667aa-8533-4185-8859-7d810f5394e5)

cc @di 