### PR TITLE
Uses RST substitution to put badges in 1 line.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,16 @@
-.. image:: https://img.shields.io/pypi/v/twine.svg
+.. |twine-version| image:: https://img.shields.io/pypi/v/twine.svg
    :target: https://pypi.org/project/twine
 
-.. image:: https://img.shields.io/pypi/pyversions/twine.svg
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/twine.svg
    :target: https://pypi.org/project/twine
 
-.. image:: https://img.shields.io/readthedocs/twine
+.. |docs-badge| image:: https://img.shields.io/readthedocs/twine
    :target: https://twine.readthedocs.io
 
-.. image:: https://img.shields.io/github/actions/workflow/status/pypa/twine/main.yml?branch=main
+.. |build-badge| image:: https://img.shields.io/github/actions/workflow/status/pypa/twine/main.yml?branch=main
    :target: https://github.com/pypa/twine/actions
+
+|twine-version| |python-versions| |docs-badge| |build-badge|
 
 twine
 =====


### PR DESCRIPTION
It might be some update to the Github's RST renderer caused badges display in multi lines. use RST substitution to put badges in 1 line.

### Before the change

![image](https://github.com/pypa/twine/assets/3353385/385efc1d-3fd1-4294-94c8-5ea2bc8042e7)

### After the change

![image](https://github.com/pypa/twine/assets/3353385/f977fd1f-ab36-48bc-bbf9-be092144105c)

