### PR TITLE
add `AttributeError` to `hashlib.blake2b` check

### DIFF
--- a/twine/package.py
+++ b/twine/package.py
@@ -266,7 +266,7 @@ class HashManager:
         self._blake_hasher = None
         try:
             self._blake_hasher = hashlib.blake2b(digest_size=256 // 8)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, AttributeError):
             # FIPS mode disables blake2
             pass
 


### PR DESCRIPTION
in FIPS python build, getting an `AttributeError` when `blake2b` isn't found