### PR TITLE
test_integration: allow PEP 625 sdist name

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,7 +48,15 @@ def sampleproject_dist(tmp_path_factory: pytest.TempPathFactory):
     run([sys.executable, "-m", "build", "--sdist"], cwd=checkout)
 
     [dist, *_] = (checkout / "dist").glob("*")
-    assert dist.name == f"twine-sampleproject-3.0.0.post{tag}.tar.gz"
+    # NOTE: newer versions of setuptools (invoked via build) adhere to PEP 625,
+    # causing the dist name to be `twine_sampleproject` instead of
+    # `twine-sampleproject`. Both are allowed here for now, but the hyphenated
+    # version can be removed eventually.
+    # See: https://github.com/pypa/setuptools/issues/3593
+    assert dist.name in (
+        f"twine-sampleproject-3.0.0.post{tag}.tar.gz",
+        f"twine_sampleproject-3.0.0.post{tag}.tar.gz",
+    )
 
     return dist
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,8 +78,7 @@ commands =
 
 [testenv:types]
 deps =
-    mypy
-    lxml
+    mypy[reports]
     # required for more thorough type declarations
     keyring >= 22.3
     # consider replacing with `mypy --install-types` when

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ deps =
     # https://github.com/python/mypy/issues/10600 is resolved
     types-requests
 commands =
+    pip list
     mypy --html-report mypy --txt-report mypy {posargs:twine}
     python -c 'with open("mypy/index.txt") as f: print(f.read())'
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,11 @@ commands =
 
 [testenv:types]
 deps =
-    mypy[reports]
+    mypy
+    # required for report generation. 5.2.1 is forbidden due to an observed
+    # broken wheel on CPython 3.8:
+    # https://bugs.launchpad.net/lxml/+bug/2064158
+    lxml >= 5.2.0, != 5.2.1
     # required for more thorough type declarations
     keyring >= 22.3
     # consider replacing with `mypy --install-types` when


### PR DESCRIPTION
This should fix the integration tests.

Explanation: the integration suite uses `pypa/sampleproject`, which uses `setuptools` as its build backend. `setuptools` in turn has recently switched to adhering to PEP 625, which enforces that hyphens in package names be normalized to underscores to eliminate a parsing ambiguity in the sdist file format.

`sampleproject`'s backend dependency on `setuptools` is unconstrained, which means in principle that the latest version should always be used. However, this patch allows both the PEP 625 and the old variant, just in case `pip` or other layers of the stack select an older `setuptools`.

See also: https://github.com/pypa/setuptools/issues/3593