### PR TITLE
upload: add attestations to PackageFile

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -317,7 +317,7 @@ def test_metadata_dictionary_values(gpg_signature, attestation):
 
     # Attestations
     if attestation:
-        assert result.get("attestations") == json.dumps(package.attestations)
+        assert result["attestations"] == json.dumps(package.attestations)
     else:
         assert "attestations" not in result
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -220,7 +220,8 @@ def test_metadata_dictionary_keys():
 
 
 @pytest.mark.parametrize("gpg_signature", [(None), (pretend.stub())])
-def test_metadata_dictionary_values(gpg_signature):
+@pytest.mark.parametrize("attestation", [(None), ({"fake": "attestation"})])
+def test_metadata_dictionary_values(gpg_signature, attestation):
     """Pass values from pkginfo.Distribution through to dictionary."""
     meta = pretend.stub(
         name="whatever",
@@ -261,6 +262,8 @@ def test_metadata_dictionary_values(gpg_signature):
         filetype=pretend.stub(),
     )
     package.gpg_signature = gpg_signature
+    if attestation:
+        package.attestations = [attestation]
 
     result = package.metadata_dictionary()
 
@@ -311,6 +314,12 @@ def test_metadata_dictionary_values(gpg_signature):
 
     # GPG signature
     assert result.get("gpg_signature") == gpg_signature
+
+    # Attestations
+    if attestation:
+        assert result.get("attestations") == json.dumps(package.attestations)
+    else:
+        assert "attestations" not in result
 
 
 TWINE_1_5_0_WHEEL_HEXDIGEST = package_file.Hexdigest(

--- a/twine/package.py
+++ b/twine/package.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import hashlib
 import io
+import json
 import logging
 import os
 import re
 import subprocess
-from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union, cast
 
 import importlib_metadata
 import pkginfo
@@ -78,6 +79,7 @@ class PackageFile:
         self.signed_filename = self.filename + ".asc"
         self.signed_basefilename = self.basefilename + ".asc"
         self.gpg_signature: Optional[Tuple[str, bytes]] = None
+        self.attestations: Optional[List[Dict[Any, str]]] = None
 
         hasher = HashManager(filename)
         hasher.hash()
@@ -186,6 +188,9 @@ class PackageFile:
         if self.gpg_signature is not None:
             data["gpg_signature"] = self.gpg_signature
 
+        if self.attestations is not None:
+            data["attestations"] = json.dumps(self.attestations)
+
         # FIPS disables MD5 and Blake2, making the digest values None. Some package
         # repositories don't allow null values, so this only sends non-null values.
         # See also: https://github.com/pypa/twine/issues/775
@@ -196,6 +201,21 @@ class PackageFile:
             data["blake2_256_digest"] = self.blake2_256_digest
 
         return data
+
+    def add_attestations(self, attestations: List[str]) -> None:
+        loaded_attestations = []
+        for attestation in attestations:
+            with open(attestation, "rb") as att:
+                raw_attestation = att.read()
+
+            try:
+                loaded_attestations.append(json.loads(raw_attestation))
+            except json.JSONDecodeError:
+                raise exceptions.InvalidDistribution(
+                    f"invalid JSON in attestation: {attestation}"
+                )
+
+        self.attestations = loaded_attestations
 
     def add_gpg_signature(
         self, signature_filepath: str, signature_filename: str

--- a/twine/package.py
+++ b/twine/package.py
@@ -206,14 +206,12 @@ class PackageFile:
         loaded_attestations = []
         for attestation in attestations:
             with open(attestation, "rb") as att:
-                raw_attestation = att.read()
-
-            try:
-                loaded_attestations.append(json.loads(raw_attestation))
-            except json.JSONDecodeError:
-                raise exceptions.InvalidDistribution(
-                    f"invalid JSON in attestation: {attestation}"
-                )
+                try:
+                    loaded_attestations.append(json.load(att))
+                except json.JSONDecodeError:
+                    raise exceptions.InvalidDistribution(
+                        f"invalid JSON in attestation: {attestation}"
+                    )
 
         self.attestations = loaded_attestations
 

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -25,7 +25,7 @@ from rich import print
 import twine
 from twine import package as package_file
 
-KEYWORDS_TO_NOT_FLATTEN = {"gpg_signature", "content"}
+KEYWORDS_TO_NOT_FLATTEN = {"gpg_signature", "attestations", "content"}
 
 LEGACY_PYPI = "https://pypi.python.org/"
 LEGACY_TEST_PYPI = "https://testpypi.python.org/"


### PR DESCRIPTION
~~WIP, needs more tests.~~

Summary of changes:

* Updates `_make_package` to accept an `attestations` parameter, which receives the list of attestations for the distribution (from `_split_inputs`).
* When `--attestations` is set and `attestations` is nonempty, the supplied attestations are passed into the constructed `PackageFile`.
* Internally, `PackageFile` reads each attestation as JSON and compounds it onto a JSON array to send as the `attestations` field during upload, per PEP 740.

See #1094.