### PR TITLE
Sanitize URLs for logging/display purposes.

### DIFF
--- a/changelog/1104.misc.rst
+++ b/changelog/1104.misc.rst
@@ -1,0 +1,1 @@
+This change will remove sensitive output in URLs for private repositories require a login provided in the format of http(s)://<user>:<pass>@domain.com, replacing the sensitive text with a sanitized "*****:*****" to prevent these details from showing up in log files.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,6 +150,31 @@ def test_get_repository_config_missing(config_file):
     assert utils.get_repository_from_config(config_file, "pypi") == exp
 
 
+def test_get_repository_config_url_with_auth(config_file):
+    repository_url = "https://user:pass@notexisting.python.org/pypi"
+    exp = {
+        "repository": "https://notexisting.python.org/pypi",
+        "username": "user",
+        "password": "pass",
+    }
+    assert utils.get_repository_from_config(config_file, "foo", repository_url) == exp
+    assert utils.get_repository_from_config(config_file, "pypi", repository_url) == exp
+
+
+@pytest.mark.parametrize(
+    "input_url, expected_url",
+    [
+        ("https://upload.pypi.org/legacy/", "https://upload.pypi.org/legacy/"),
+        (
+            "https://user:pass@upload.pypi.org/legacy/",
+            "https://********@upload.pypi.org/legacy/",
+        ),
+    ],
+)
+def test_sanitize_url(input_url: str, expected_url: str) -> None:
+    assert utils.sanitize_url(input_url) == expected_url
+
+
 @pytest.mark.parametrize(
     "repo_url, message",
     [

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -149,8 +149,9 @@ def _split_inputs(
     return Inputs(dists, signatures, attestations_by_dist)
 
 
-def _sanitize_url(url) -> str:
-    """
+def _sanitize_url(url: str) -> str:
+    """Sanitize a URL.
+
     Sanitize URLs, removing any user:password combinations and replacing them with
     asterisks.  Returns the original URL if the string is a non-matching pattern.
 
@@ -160,7 +161,7 @@ def _sanitize_url(url) -> str:
     return:
         str either sanitized or as entered depending on pattern match.
     """
-    pattern = "(.*https?://)(\w+:\w+)@(\w+\..*)"
+    pattern = r"(.*https?://)(\w+:\w+)@(\w+\..*)"
     m = re.match(pattern, url)
     if m:
         newurl = f"{m.group(1)}*****:*****@{m.group(3)}"


### PR DESCRIPTION
Sanitize URLs that contain user and password combinations since this output can show up in logging.  The alternative is to silence ALL output.

It may need to be sanitized in the "raise exceptions.RedirectDetected" block, but I'm not familiar enough with it to say for sure.