### PR TITLE
Indicate which files failed to find metadata info

### DIFF
--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -96,6 +96,8 @@ def test_read_wheel_empty_metadata(tmpdir):
 
     with pytest.raises(
         exceptions.InvalidDistribution,
-        match=re.escape(f"No METADATA in archive: {whl_file}"),
+        match=re.escape(
+            f"No METADATA in archive or METADATA missing 'Metadata-Version': {whl_file}"
+        ),
     ):
         wheel.Wheel(whl_file)

--- a/twine/wheel.py
+++ b/twine/wheel.py
@@ -73,16 +73,21 @@ class Wheel(distribution.Distribution):
                 "Not a known archive format for file: %s" % fqn
             )
 
+        searched_files: List[str] = []
         try:
             for path in self.find_candidate_metadata_files(names):
                 candidate = "/".join(path)
                 data = read_file(candidate)
                 if b"Metadata-Version" in data:
                     return data
+                searched_files.append(candidate)
         finally:
             archive.close()
 
-        raise exceptions.InvalidDistribution("No METADATA in archive: %s" % fqn)
+        raise exceptions.InvalidDistribution(
+            "No METADATA in archive or METADATA missing 'Metadata-Version': "
+            "%s (searched %s)" % (fqn, ",".join(searched_files))
+        )
 
     def parse(self, data: bytes) -> None:
         super().parse(data)


### PR DESCRIPTION
When showing users an error, explain that we couldn't find a file with Metadata-Version in it and list the names of files we searched in the archive.

Closes #1100