### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate hashes"
         id: hash
         run: |
-          cd dist && echo "$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
+          cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: "Upload dists"
         uses: "actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808"


### PR DESCRIPTION
We need to explicitly name the variable we're using when writing to GITHUB_OUTPUT so we can use that in later steps.