### PR TITLE
fix: Retrieve metadata correctly from importlib_metadata

### DIFF
--- a/changelog/1115.bugfix.rst
+++ b/changelog/1115.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve DeprecationWarnings when extracting ``twine`` metadata.

--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -30,6 +30,8 @@ __all__ = (
 
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
+import email
+
 import importlib_metadata
 
 metadata = importlib_metadata.metadata("twine")
@@ -37,8 +39,11 @@ metadata = importlib_metadata.metadata("twine")
 
 __title__ = metadata["name"]
 __summary__ = metadata["summary"]
-__uri__ = metadata["home-page"]
+__uri__ = next(
+    entry.split(", ")[1]
+    for entry in metadata.get_all("Project-URL", ())
+    if entry.startswith("Homepage")
+)
 __version__ = metadata["version"]
-__author__ = metadata["author"]
-__email__ = metadata["author-email"]
+__author__, __email__ = email.utils.parseaddr(metadata["author-email"])
 __license__ = None


### PR DESCRIPTION
Running twine with `PYTHONWARNINGS=error`, DeprecationWarnings about missing keys indicate that `twine.__uri__` is being set to `None`. `author` is also missing from package metadata.

This change iterates over Project-URLs looking for "Homepage", and parses the author and email from Author-Email. The email stdlib module is used for correctness; it is already imported by importlib_metadata, so this does not add to import time.