### PR TITLE
doc: using keyring with API key

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,19 +192,16 @@ require `additional installation steps`_.
 Once Twine is installed, use the ``keyring`` program to set a username and
 password to use for each repository to which you may upload.
 
-For example, to set a username and password for PyPI:
+For example, to set an API token for PyPI:
 
 .. code-block:: bash
 
-   keyring set https://upload.pypi.org/legacy/ your-username
+   keyring set https://upload.pypi.org/legacy/ __token__
 
-and enter the password when prompted.
+and paste your API key when prompted.
 
 For a different repository, replace the URL with the relevant repository
 URL. For example, for Test PyPI, use ``https://test.pypi.org/legacy/``.
-
-The next time you run ``twine``, it will prompt you for a username, and then
-get the appropriate password from Keyring.
 
 .. note::
 


### PR DESCRIPTION
Show how to use twine+keyring post 2024-01-01.

This is my attempt to prevent anyone else from being bitten by this change:

`auth.py`
```python
    def username(self) -> Optional[str]:
        if cast(str, self.config["repository"]).startswith(
            (utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY)
        ):
            # As of 2024-01-01, PyPI requires API tokens for uploads, meaning
            # that the username is invariant.
            return "__token__"
```