### PR TITLE
fix: KeyError: 'home-page'

### DIFF
--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -37,8 +37,10 @@ metadata = importlib_metadata.metadata("twine")
 
 __title__ = metadata["name"]
 __summary__ = metadata["summary"]
-__uri__ = metadata["home-page"]
+__uri__ = "https://twine.readthedocs.io/"
 __version__ = metadata["version"]
-__author__ = metadata["author"]
-__email__ = metadata["author-email"]
+# __author__ = metadata["author"]
+__author__ = "Donald Stufft and individual contributors"
+# __email__ = metadata["author-email"]
+__email__ = "donald@stufft.io"
 __license__ = None


### PR DESCRIPTION
This is the simplest fix to move forward on resolving the issue a `KeyError` occurring.

Error seen is like this:
$ python -m twine check dist/*
Traceback (most recent call last):
  File "/py/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/py/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/py/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/venv/lib/python3.8/site-packages/twine/__init__.py", line 40, in <module>
    __uri__ = metadata["home-page"]
  File "/venv/lib/python3.8/site-packages/importlib_metadata/_adapters.py", line 54, in __getitem__
    raise KeyError(item)
KeyError: 'home-page'

Related: #977