### PR TITLE
Marked PyPI integration tests as xfail.

### DIFF
--- a/changelog/684.bugfix.rst
+++ b/changelog/684.bugfix.rst
@@ -1,1 +1,0 @@
-Marked PyPI integration tests as xfail.

--- a/changelog/684.bugfix.rst
+++ b/changelog/684.bugfix.rst
@@ -1,0 +1,1 @@
+Marked PyPI integration tests as xfail.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,6 +70,7 @@ sampleproject_token = (
 )
 
 
+@pytest.mark.xfail(reason="service is unreliable (#684)")
 def test_pypi_upload(sampleproject_dist):
     command = [
         "upload",
@@ -84,6 +85,7 @@ def test_pypi_upload(sampleproject_dist):
     cli.dispatch(command)
 
 
+@pytest.mark.xfail(reason="service is unreliable (#684)")
 def test_pypi_error(sampleproject_dist, monkeypatch, capsys):
     command = [
         "twine",


### PR DESCRIPTION
Closes #684
