### PR TITLE
chore: remove unused wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=61.2", "wheel", "setuptools_scm[toml]>=6.0"]
+requires = ["setuptools>=61.2", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This has never been required due to PEP 517's `get_requires_for_build_wheel` hook, is a needless download when building the SDist, and won't be required in the next setuptools release at all and will be deprecated as a library shortly after that.
