### PR TITLE
Move compatibility logic into its own module

### DIFF
--- a/twine/__init__.py
+++ b/twine/__init__.py
@@ -31,14 +31,10 @@ __all__ = (
 __copyright__ = "Copyright 2019 Donald Stufft and individual contributors"
 
 import email.utils
-import sys
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
+from .compat.py39 import importlib
 
-metadata = importlib_metadata.metadata("twine")
+metadata = importlib.metadata.metadata("twine")
 
 
 __title__ = metadata["name"]

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -16,17 +16,14 @@ import logging.config
 import sys
 from typing import Any, List, Tuple
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import rich
 import rich.highlighter
 import rich.logging
 import rich.theme
 
 import twine
+
+from .compat.py39 import importlib
 
 args = argparse.Namespace()
 
@@ -84,7 +81,7 @@ def list_dependencies_and_versions() -> List[Tuple[str, str]]:
     ]
     if sys.version_info < (3, 10):
         deps.append("importlib-metadata")
-    return [(dep, importlib_metadata.version(dep)) for dep in deps]
+    return [(dep, importlib.metadata.version(dep)) for dep in deps]
 
 
 def dep_versions() -> str:
@@ -94,7 +91,7 @@ def dep_versions() -> str:
 
 
 def dispatch(argv: List[str]) -> Any:
-    registered_commands = importlib_metadata.entry_points(
+    registered_commands = importlib.metadata.entry_points(
         group="twine.registered_commands"
     )
 

--- a/twine/cli.py
+++ b/twine/cli.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import argparse
 import logging.config
-import sys
 from typing import Any, List, Tuple
 
 import rich
@@ -23,6 +22,7 @@ import rich.theme
 
 import twine
 
+from .compat import py39
 from .compat.py39 import importlib
 
 args = argparse.Namespace()
@@ -72,15 +72,13 @@ def configure_output() -> None:
 
 
 def list_dependencies_and_versions() -> List[Tuple[str, str]]:
-    deps = [
+    deps = (
         "keyring",
         "pkginfo",
         "requests",
         "requests-toolbelt",
         "urllib3",
-    ]
-    if sys.version_info < (3, 10):
-        deps.append("importlib-metadata")
+    ) + py39.deps
     return [(dep, importlib.metadata.version(dep)) for dep in deps]
 
 

--- a/twine/compat/py39.py
+++ b/twine/compat/py39.py
@@ -2,10 +2,14 @@ import sys
 
 if sys.version_info >= (3, 10):
     import importlib.metadata
+
+    deps = ()
 else:
 
     class importlib:
         import importlib_metadata as metadata  # noqa: F401
 
+    deps = ("importlib_metadata",)
 
-__all__ = ['importlib']
+
+__all__ = ["importlib", "deps"]

--- a/twine/compat/py39.py
+++ b/twine/compat/py39.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata
+else:
+
+    class importlib:
+        import importlib_metadata as metadata  # noqa: F401
+
+
+__all__ = ['importlib']

--- a/twine/package.py
+++ b/twine/package.py
@@ -18,13 +18,7 @@ import logging
 import os
 import re
 import subprocess
-import sys
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union, cast
-
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 import pkginfo
 from rich import print
@@ -32,6 +26,8 @@ from rich import print
 from twine import exceptions
 from twine import wheel
 from twine import wininst
+
+from .compat.py39 import importlib
 
 DIST_TYPES = {
     "bdist_wheel": wheel.Wheel,
@@ -131,7 +127,7 @@ class PackageFile:
 
         py_version: Optional[str]
         if dtype == "bdist_egg":
-            (dist,) = importlib_metadata.Distribution.discover(path=[filename])
+            (dist,) = importlib.metadata.Distribution.discover(path=[filename])
             py_version = dist.metadata["Version"]
         elif dtype == "bdist_wheel":
             py_version = cast(wheel.Wheel, meta).py_version


### PR DESCRIPTION
- **Import the full module as used.**
- **Move compatibility logic into its own module.**
- **Move 'deps' to the compat module as well.**

From https://github.com/pypa/twine/pull/1024#discussion_r1655343383:

First, I found the use of `importlib_metadata` a little grating, since it's using the legacy name over the preferred, future name. I aim to make the diff between the future syntax and the current syntax as small as possible. I've been using this technique across a number of projects ([example](https://github.com/pypa/distutils/tree/main/distutils/compat)) and found it particularly useful when maintaining compatibility for a backport (like importlib_metadata itself), as it allows the code to be ported into another place that doesn't require the library with a small diff to the main code, but also nice to clearly illustrate what code is essential and what code is there temporarily to serve for compatibility. Essentially, write the code as you would if you had the latest Python, then write a compatibility shim that makes that functionality possible with as little diff to the essential code as possible.

I also wanted to re-use the logic rather than repeating it everywhere it's used. My rule of thumb is it's okay to repeat the logic once, but if there's a third instance, consider refactoring to consolidate the logic.

With this approach, when python 3.9 is dropped, this module can be dropped and its functionality in the modules replaced with the built-in support with very little change to the implementation.

I also wanted to reduce the diff in this PR by not creating a mutable `deps` where an immutable one was suitable before (although presumably a `+=` could have done the trick).

I do find it a little regrettable that tools like ruff won't be able to remove the blocks because they're no longer following a basic if/else pattern. I've just found that in general, the if/else pattern is messy at best and inadequate at worst to creating a robust abstraction around compatibility. It feels like the difference between a macro in C and a proper library. I thought maybe ruff would be able to at least remove the unreachable blocks in `compat.py39` but it seems not.
