### PR TITLE
Restore test isolation by allowing username override for PyPI

### DIFF
--- a/changelog/1121.removal.rst
+++ b/changelog/1121.removal.rst
@@ -1,0 +1,1 @@
+Username for PyPI and Test PyPI now defaults to __token__ but no longer overrides a username configured in the environment or supplied on the command line. Workflows still supplying anything other than __token__ for the username when uploading to PyPI or Test PyPI will now fail. Either supply __token__ or do not supply a username at all.

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -90,8 +90,7 @@ def test_values_from_env_pypi(monkeypatch, repo):
     monkeypatch.setattr(register, "register", replaced_register)
     testenv = {
         "TWINE_REPOSITORY": repo,
-        # Ignored because the TWINE_REPOSITORY is PyPI/TestPyPI
-        "TWINE_USERNAME": "this-is-ignored",
+        "TWINE_USERNAME": "pypiuser",
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
@@ -99,7 +98,7 @@ def test_values_from_env_pypi(monkeypatch, repo):
         cli.dispatch(["register", helpers.WHEEL_FIXTURE])
     register_settings = replaced_register.calls[0].args[0]
     assert "pypipassword" == register_settings.password
-    assert "__token__" == register_settings.username
+    assert "pypiuser" == register_settings.username
     assert "/foo/bar.crt" == register_settings.cacert
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -604,8 +604,7 @@ def test_values_from_env_pypi(monkeypatch, repo):
     monkeypatch.setattr(upload, "upload", replaced_upload)
     testenv = {
         "TWINE_REPOSITORY": repo,
-        # Ignored because TWINE_REPOSITORY is PyPI/TestPyPI
-        "TWINE_USERNAME": "this-is-ignored",
+        "TWINE_USERNAME": "pypiuser",
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
@@ -613,7 +612,7 @@ def test_values_from_env_pypi(monkeypatch, repo):
         cli.dispatch(["upload", "path/to/file"])
     upload_settings = replaced_upload.calls[0].args[0]
     assert "pypipassword" == upload_settings.password
-    assert "__token__" == upload_settings.username
+    assert "pypiuser" == upload_settings.username
     assert "/foo/bar.crt" == upload_settings.cacert
 
 

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -31,9 +31,9 @@ class Resolver:
     @property
     @functools.lru_cache()
     def username(self) -> Optional[str]:
-        if self.is_pypi():
-            # Username is invariant.
-            return "__token__"
+        if self.is_pypi() and not self.input.username:
+            # Default username.
+            self.input.username = "__token__"
 
         return utils.get_userpass_value(
             self.input.username,

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -31,11 +31,8 @@ class Resolver:
     @property
     @functools.lru_cache()
     def username(self) -> Optional[str]:
-        if cast(str, self.config["repository"]).startswith(
-            (utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY)
-        ):
-            # As of 2024-01-01, PyPI requires API tokens for uploads, meaning
-            # that the username is invariant.
+        if self.is_pypi():
+            # Username is invariant.
             return "__token__"
 
         return utils.get_userpass_value(
@@ -97,19 +94,22 @@ class Resolver:
             logger.info("password set from keyring")
             return password
 
-        # As of 2024-01-01, PyPI requires API tokens for uploads;
-        # specialize the prompt to clarify that an API token must be provided.
-        if cast(str, self.config["repository"]).startswith(
-            (utils.DEFAULT_REPOSITORY, utils.TEST_REPOSITORY)
-        ):
-            prompt = "API token"
-        else:
-            prompt = "password"
+        # Prompt for API token when required.
+        what = "API token" if self.is_pypi() else "password"
 
-        return self.prompt(prompt, getpass.getpass)
+        return self.prompt(what, getpass.getpass)
 
     def prompt(self, what: str, how: Callable[..., str]) -> str:
         return how(f"Enter your {what}: ")
+
+    def is_pypi(self) -> bool:
+        """As of 2024-01-01, PyPI requires API tokens for uploads."""
+        return cast(str, self.config["repository"]).startswith(
+            (
+                utils.DEFAULT_REPOSITORY,
+                utils.TEST_REPOSITORY,
+            )
+        )
 
 
 class Private(Resolver):


### PR DESCRIPTION
Closes #1121 

- **Extract method for 'is_pypi' to consolidate repeated behavior and documentation.**
- **Default username to '__token__' if not specified.**
- **Restore ability for users to override the username even for PyPI.**
