### PR TITLE
docs, twine: improve messaging around #1040

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,11 +53,15 @@ Bugfixes
 
 - Use ``email.message`` instead of ``cgi`` as ``cgi`` has been deprecated (`#969 <https://github.com/pypa/twine/issues/969>`_)
 
+Features
+^^^^^^^^
+
+- Remove support for usernames other than ``__token__`` when uploading to PyPI and TestPyPI (`#1040 <https://github.com/pypa/twine/issues/1040>`_)
 
 Misc
 ^^^^
 
-- `#931 <https://github.com/pypa/twine/issues/931>`_, `#991 <https://github.com/pypa/twine/issues/991>`_, `#1028 <https://github.com/pypa/twine/issues/1028>`_, `#1040 <https://github.com/pypa/twine/issues/1040>`_
+- `#931 <https://github.com/pypa/twine/issues/931>`_, `#991 <https://github.com/pypa/twine/issues/991>`_, `#1028 <https://github.com/pypa/twine/issues/1028>`_
 
 
 Twine 4.0.2 (2022-11-30)

--- a/twine/settings.py
+++ b/twine/settings.py
@@ -209,8 +209,8 @@ class Settings:
             env="TWINE_USERNAME",
             required=False,
             help="The username to authenticate to the repository "
-            "(package index) as. (Can also be set via "
-            "%(env)s environment variable.)",
+            "(package index) as. Has no effect on PyPI or TestPyPI. "
+            "(Can also be set via %(env)s environment variable.)",
         )
         parser.add_argument(
             "-p",


### PR DESCRIPTION
This adopts 2 of the 3 proposed improvements in #1133. The other one (warning when the user sets a different username on PyPI/TestPyPI) seems like a good idea to me but will require a more involved change, so I figured I'd keep this PR small and start with the non-functional changes 🙂 

Closes #1133.