### PR TITLE
Use brackets for the default value of option arguments

### DIFF
--- a/twine/settings.py
+++ b/twine/settings.py
@@ -165,8 +165,8 @@ class Settings:
             env="TWINE_REPOSITORY",
             default="pypi",
             help="The repository (package index) to upload the package to. "
-            "Should be a section in the config file (default: "
-            "%(default)s). (Can also be set via %(env)s environment "
+            "Should be a section in the config file [default: "
+            "%(default)s]. (Can also be set via %(env)s environment "
             "variable.)",
         )
         parser.add_argument(
@@ -195,7 +195,7 @@ class Settings:
         parser.add_argument(
             "--sign-with",
             default="gpg",
-            help="GPG program used to sign uploads (default: %(default)s).",
+            help="GPG program used to sign uploads [default: %(default)s].",
         )
         parser.add_argument(
             "-i",


### PR DESCRIPTION
The goal is to standardize the format of the help text printed by pypa commands. It is not easy to choose between brackets `[]` and parentheses `()`. I went for the [docopt](http://docopt.org/) style, which is the closest to a standard I could find
> [...] and whether that argument has a default value ([default: 10]).

This change has already been applied to setuptools (pypa/setuptools#4442).