### PR TITLE
Fix broken URL in docs

### DIFF
--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -115,7 +115,7 @@ def check(
     """Check that a distribution will render correctly on PyPI and display the results.
 
     This is currently only validates ``long_description``, but more checks could be
-    added; see https://github.com/pypa/twine/projects/2.
+    added; see https://github.com/pypa/twine/issues/848.
 
     :param dists:
         The distribution files to check.


### PR DESCRIPTION
I cannot find twine projects:
https://github.com/pypa/twine/projects

So I switched to the twine issue closest to the idea of adding more checks.