### PR TITLE
Set a nonexistent HOME for tests (don't read ~/.pypirc)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     setuptools
 passenv =
     PYTEST_ADDOPTS
+setenv =
+    HOME=/tmp/nonexistent
 commands =
     python -m coverage run -m pytest {posargs}
     python -m coverage html


### PR DESCRIPTION
Fixes: #1121