### PR TITLE
Fix CI

### DIFF
--- a/twine/auth.py
+++ b/twine/auth.py
@@ -65,7 +65,7 @@ class Resolver:
             logger.info("Querying keyring for username")
             creds = keyring.get_credential(system, None)
             if creds:
-                return cast(str, creds.username)
+                return creds.username
         except AttributeError:
             # To support keyring prior to 15.2
             pass

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -115,7 +115,7 @@ def check(
     """Check that a distribution will render correctly on PyPI and display the results.
 
     This is currently only validates ``long_description``, but more checks could be
-    added; see https://github.com/pypa/twine/projects/2.
+    added.
 
     :param dists:
         The distribution files to check.


### PR DESCRIPTION
1. Remove redundant `cast()`. Improved typing in keyring: https://github.com/jaraco/keyring/pull/689
2. Remove broken link to: https://github.com/pypa/twine/projects/2