### PR TITLE
Make keyring optional on ppc64le and s390x

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,5 +11,8 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run
     if __name__ == .__main__.:
 
+    # exclude typing.TYPE_CHECKING
+    if TYPE_CHECKING:
+
 [html]
 show_contexts = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 	"requests-toolbelt >= 0.8.0, != 0.9.0",
 	"urllib3 >= 1.26.0",
 	"importlib-metadata >= 3.6",
-	"keyring >= 15.1",
+	# workaround for missing binaries on these platforms, see #1158
+	"keyring >= 15.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
 	"rfc3986 >= 1.4.0",
 	"rich >= 12.0.0",
 
@@ -59,6 +60,9 @@ Documentation = "https://twine.readthedocs.io/en/latest/"
 check = "twine.commands.check:main"
 upload = "twine.commands.upload:main"
 register = "twine.commands.register:main"
+
+[project.optional-dependencies]
+keyring = ["keyring >= 15.1"]
 
 [project.scripts]
 twine = "twine.__main__:main"


### PR DESCRIPTION
Twine can now be installed on Linux pp64le and s390x without C and Rust compiler. The `keyring` package has an indirect dependency on `cryptography` package. Upstream PyCA does not provide wheels for ppc64le and s390x architecture, because the team has no means to run CI in reasonable time.

Fixes: #1158