### PR TITLE
Validate Trove classifiers in twine check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"keyring >= 15.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
 	"rfc3986 >= 1.4.0",
 	"rich >= 12.0.0",
-	"trove-classifiers >= 2024.10.12 ",
+	"trove-classifiers >= 2024.10.12",
 
 	# workaround for #1116
 	"pkginfo < 1.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 	"keyring >= 15.1; platform_machine != 'ppc64le' and platform_machine != 's390x'",
 	"rfc3986 >= 1.4.0",
 	"rich >= 12.0.0",
+	"trove-classifiers >= 2024.10.12 ",
 
 	# workaround for #1116
 	"pkginfo < 1.11",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -293,7 +293,7 @@ def test_fails_invalid_classifiers(tmp_path, capsys, caplog):
                     long_description = file:README.md
                     long_description_content_type = text/markdown
                     classifiers =
-                        Framework :: Django :: 5
+                        Framework | Django |  5
                     """
             ),
             "README.md": (
@@ -315,7 +315,7 @@ def test_fails_invalid_classifiers(tmp_path, capsys, caplog):
         (
             "twine.commands.check",
             logging.ERROR,
-            "`Framework :: Django :: 5` is not a valid classifier"
+            "`Framework | Django |  5` is not a valid classifier"
             " and would prevent upload to PyPI.\n",
         )
     ]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -281,6 +281,80 @@ def test_main(monkeypatch):
     assert check_stub.calls == [pretend.call(["dist/*"], strict=False)]
 
 
+def test_fails_invalid_classifiers(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                    [metadata]
+                    name = test-package
+                    version = 0.0.1
+                    long_description = file:README.md
+                    long_description_content_type = text/markdown
+                    classifiers =
+                        Framework :: Django :: 5
+                    """
+            ),
+            "README.md": (
+                """
+                # test-package
+
+                A test package.
+                """
+            ),
+        },
+    )
+
+    assert check.check([sdist])
+
+    assert capsys.readouterr().out == f"Checking {sdist}: FAILED\n"
+
+    assert len(caplog.record_tuples) > 0
+    assert caplog.record_tuples == [
+        (
+            "twine.commands.check",
+            logging.ERROR,
+            "`Framework :: Django :: 5` is not a valid classifier"
+            " and would prevent upload to PyPI.\n",
+        )
+    ]
+
+
+def test_passes_valid_classifiers(tmp_path, capsys, caplog):
+    sdist = build_sdist(
+        tmp_path,
+        {
+            "setup.cfg": (
+                """
+                    [metadata]
+                    name = test-package
+                    version = 0.0.1
+                    long_description = file:README.md
+                    long_description_content_type = text/markdown
+                    classifiers =
+                        Programming Language :: Python :: 3
+                        Framework :: Django
+                        Framework :: Django :: 5.1
+                    """
+            ),
+            "README.md": (
+                """
+                # test-package
+
+                A test package.
+                """
+            ),
+        },
+    )
+
+    assert not check.check([sdist])
+
+    assert capsys.readouterr().out == f"Checking {sdist}: PASSED\n"
+
+    assert caplog.record_tuples == []
+
+
 # TODO: Test print() color output
 
 # TODO: Test log formatting

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -183,7 +183,13 @@ def main(args: List[str]) -> bool:
     :return:
         The exit status of the ``check`` command.
     """
-    parser = argparse.ArgumentParser(prog="twine check")
+    parser = argparse.ArgumentParser(
+        prog="twine check",
+        description=(
+            "Check distribution files and make sure they will upload and render"
+            " correctly on PyPI. Validates description and all classifiers."
+        ),
+    )
     parser.add_argument(
         "dists",
         nargs="+",

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -18,7 +18,7 @@ import email.message
 import io
 import logging
 import re
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Sequence, Tuple, cast
 
 import readme_renderer.rst
 from rich import print
@@ -111,7 +111,7 @@ def _check_file(
             )
 
     # Check classifiers
-    dist_classifiers = cast(Optional[List[str]], metadata["classifiers"])
+    dist_classifiers = cast(Sequence[str], metadata["classifiers"])
     for classifier in dist_classifiers:
         if classifier not in all_classifiers:
             errors.append(

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -134,8 +134,6 @@ def check(
 
     :param dists:
         The distribution files to check.
-    :param output_stream:
-        The destination of the resulting output.
     :param strict:
         If ``True``, treat warnings as errors.
 

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -22,7 +22,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, cast
 
 import readme_renderer.rst
 from rich import print
-from trove_classifiers import classifiers as all_classifiers
+from trove_classifiers import classifiers as valid_classifiers
 
 from twine import commands
 from twine import package as package_file
@@ -113,7 +113,7 @@ def _check_file(
     # Check classifiers
     dist_classifiers = cast(Sequence[str], metadata["classifiers"])
     for classifier in dist_classifiers:
-        if classifier not in all_classifiers:
+        if classifier not in valid_classifiers:
             errors.append(
                 f"`{classifier}` is not a valid classifier"
                 f" and would prevent upload to PyPI."

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -126,10 +126,11 @@ def check(
     dists: List[str],
     strict: bool = False,
 ) -> bool:
-    """Check that a distribution will render correctly on PyPI and display the results.
+    """Check that a distribution will upload and render correctly on PyPI.
 
-    This is currently only validates ``long_description``, but more checks could be
-    added.
+    This currently validates
+    - ``long_description``, to make sure it would render correctly on PyPI
+    - ``classifiers``, to make sure that all classifiers are valid
 
     :param dists:
         The distribution files to check.


### PR DESCRIPTION
I've been bitten by #976 today while trying to use `Framework :: Django :: 5` as classifier. It used to work with earlier versions of Django (e.g. `Framework :: Django :: 4`) and the package in question was using these, so it wasn't clear that just 5 wouldn't work. 

Reading the conversation in the issue, it sems like folks are happy to add this feature to Twine so I went ahead a tried to do it.

- [x] Add new tests to cover pass/fail behaviour
- [x] Implement new check in command
- [x] Update documentation

Fix #976