### PR TITLE
check: ignore attestations, like signatures

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from tests import helpers
 from twine import commands
 from twine import exceptions
 
@@ -49,3 +50,43 @@ def test_find_dists_handles_real_files():
     ]
     files = commands._find_dists(expected)
     assert expected == files
+
+
+def test_split_inputs():
+    """Split inputs into dists, signatures, and attestations."""
+    inputs = [
+        helpers.WHEEL_FIXTURE,
+        helpers.WHEEL_FIXTURE + ".asc",
+        helpers.WHEEL_FIXTURE + ".build.attestation",
+        helpers.WHEEL_FIXTURE + ".publish.attestation",
+        helpers.SDIST_FIXTURE,
+        helpers.SDIST_FIXTURE + ".asc",
+        helpers.NEW_WHEEL_FIXTURE,
+        helpers.NEW_WHEEL_FIXTURE + ".frob.attestation",
+        helpers.NEW_SDIST_FIXTURE,
+    ]
+
+    inputs = commands._split_inputs(inputs)
+
+    assert inputs.dists == [
+        helpers.WHEEL_FIXTURE,
+        helpers.SDIST_FIXTURE,
+        helpers.NEW_WHEEL_FIXTURE,
+        helpers.NEW_SDIST_FIXTURE,
+    ]
+
+    expected_signatures = {
+        os.path.basename(dist) + ".asc": dist + ".asc"
+        for dist in [helpers.WHEEL_FIXTURE, helpers.SDIST_FIXTURE]
+    }
+    assert inputs.signatures == expected_signatures
+
+    assert inputs.attestations_by_dist == {
+        helpers.WHEEL_FIXTURE: [
+            helpers.WHEEL_FIXTURE + ".build.attestation",
+            helpers.WHEEL_FIXTURE + ".publish.attestation",
+        ],
+        helpers.SDIST_FIXTURE: [],
+        helpers.NEW_WHEEL_FIXTURE: [helpers.NEW_WHEEL_FIXTURE + ".frob.attestation"],
+        helpers.NEW_SDIST_FIXTURE: [],
+    }

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -116,46 +116,6 @@ def test_make_package_attestations_flagged_but_missing(upload_settings):
         upload._make_package(helpers.NEW_WHEEL_FIXTURE, {}, [], upload_settings)
 
 
-def test_split_inputs():
-    """Split inputs into dists, signatures, and attestations."""
-    inputs = [
-        helpers.WHEEL_FIXTURE,
-        helpers.WHEEL_FIXTURE + ".asc",
-        helpers.WHEEL_FIXTURE + ".build.attestation",
-        helpers.WHEEL_FIXTURE + ".publish.attestation",
-        helpers.SDIST_FIXTURE,
-        helpers.SDIST_FIXTURE + ".asc",
-        helpers.NEW_WHEEL_FIXTURE,
-        helpers.NEW_WHEEL_FIXTURE + ".frob.attestation",
-        helpers.NEW_SDIST_FIXTURE,
-    ]
-
-    inputs = upload._split_inputs(inputs)
-
-    assert inputs.dists == [
-        helpers.WHEEL_FIXTURE,
-        helpers.SDIST_FIXTURE,
-        helpers.NEW_WHEEL_FIXTURE,
-        helpers.NEW_SDIST_FIXTURE,
-    ]
-
-    expected_signatures = {
-        os.path.basename(dist) + ".asc": dist + ".asc"
-        for dist in [helpers.WHEEL_FIXTURE, helpers.SDIST_FIXTURE]
-    }
-    assert inputs.signatures == expected_signatures
-
-    assert inputs.attestations_by_dist == {
-        helpers.WHEEL_FIXTURE: [
-            helpers.WHEEL_FIXTURE + ".build.attestation",
-            helpers.WHEEL_FIXTURE + ".publish.attestation",
-        ],
-        helpers.SDIST_FIXTURE: [],
-        helpers.NEW_WHEEL_FIXTURE: [helpers.NEW_WHEEL_FIXTURE + ".frob.attestation"],
-        helpers.NEW_SDIST_FIXTURE: [],
-    }
-
-
 def test_successs_prints_release_urls(upload_settings, stub_repository, capsys):
     """Print PyPI release URLS for each uploaded package."""
     stub_repository.release_urls = lambda packages: {RELEASE_URL, NEW_RELEASE_URL}

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -127,7 +127,7 @@ def check(
     :return:
         ``True`` if there are rendering errors, otherwise ``False``.
     """
-    uploads = [i for i in commands._find_dists(dists) if not i.endswith(".asc")]
+    uploads, _, _ = commands._split_inputs(dists)
     if not uploads:  # Return early, if there are no files to check.
         logger.error("No files to check.")
         return False


### PR DESCRIPTION
This fixes a bug that I accidentally introduced with attestations support: `twine upload` learned the difference between distributions and attestations, but `twine check` didn't.

As a result, `twine check dist/*` would fail with
an `InvalidDistribution` error whenever attestations are present in the dist directory, like so:

```
Checking dist/svgcheck-0.9.0.tar.gz: PASSED
Checking dist/svgcheck-0.9.0.tar.gz.publish.attestation: ERROR    InvalidDistribution: Unknown distribution format:
         'svgcheck-0.9.0.tar.gz.publish.attestation'
```

This fixes the behavior of `twine check` by having it skip attestations in the input list, like it does with `.asc` signatures. To do this, I reused the `_split_inputs` helper that was added with #1095, meaning that `twine upload` and `twine check` now have the same input splitting/filtering logic.

As part of reusing `_split_inputs`, I moved it to the top-level `twine.commands` module, since that's where other shared input handling helpers live. I've also moved the test to match.

See https://github.com/pypa/gh-action-pypi-publish/issues/283 for some additional breakage context.