### PR TITLE
chore: mark 3.13 as explicitly supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         platform:
           - ubuntu-latest
           - macos-latest

--- a/changelog/1184.misc.rst
+++ b/changelog/1184.misc.rst
@@ -1,0 +1,1 @@
+Python 3.13 is now explicitly supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 	"Programming Language :: Python :: Implementation :: CPython",
 ]
 requires-python = ">=3.8"
@@ -66,10 +67,7 @@ keyring = ["keyring >= 15.1"]
 twine = "twine.__main__:main"
 
 [tool.setuptools]
-packages = [
-	"twine",
-	"twine.commands",
-]
+packages = ["twine", "twine.commands"]
 include-package-data = true
 license-files = ["LICENSE"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8
-envlist = lint,types,py{38,39,310,311,312},integration,docs
+envlist = lint,types,py{38,39,310,311,312,313},integration,docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This adds a classifier for 3.13, and adds it to the test matrix.