### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   TOX_TESTENV_PASSENV: "FORCE_COLOR"
-  MIN_PYTHON_VERSION: "3.8"
-  DEFAULT_PYTHON_VERSION: "3.10"
+  MIN_PYTHON_VERSION: "3.9"
+  DEFAULT_PYTHON_VERSION: "3.11"
 
 permissions:
   contents: read
@@ -38,7 +38,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3 :: Only",
-	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
@@ -29,7 +28,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.13",
 	"Programming Language :: Python :: Implementation :: CPython",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
 	"readme-renderer >= 35.0",
 	"requests >= 2.20",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-minversion = 3.8
-envlist = lint,types,py{38,39,310,311,312,313},integration,docs
+minversion = 3.9
+envlist = lint,types,py{39,310,311,312,313},integration,docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Is it too early to drop Python 3.8?

https://devguide.python.org/versions/