### PR TITLE
check: fix handling of non-shell-expanded globs

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,10 +18,11 @@ import os
 import pathlib
 
 TESTS_DIR = pathlib.Path(__file__).parent
-SDIST_FIXTURE = os.path.join(TESTS_DIR, "fixtures/twine-1.5.0.tar.gz")
-WHEEL_FIXTURE = os.path.join(TESTS_DIR, "fixtures/twine-1.5.0-py2.py3-none-any.whl")
-NEW_SDIST_FIXTURE = os.path.join(TESTS_DIR, "fixtures/twine-1.6.5.tar.gz")
-NEW_WHEEL_FIXTURE = os.path.join(TESTS_DIR, "fixtures/twine-1.6.5-py2.py3-none-any.whl")
+FIXTURES_DIR = os.path.join(TESTS_DIR, "fixtures")
+SDIST_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.5.0.tar.gz")
+WHEEL_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.5.0-py2.py3-none-any.whl")
+NEW_SDIST_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.6.5.tar.gz")
+NEW_WHEEL_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.6.5-py2.py3-none-any.whl")
 
 
 @contextlib.contextmanager

--- a/twine/commands/check.py
+++ b/twine/commands/check.py
@@ -127,6 +127,7 @@ def check(
     :return:
         ``True`` if there are rendering errors, otherwise ``False``.
     """
+    dists = commands._find_dists(dists)
     uploads, _, _ = commands._split_inputs(dists)
     if not uploads:  # Return early, if there are no files to check.
         logger.error("No files to check.")


### PR DESCRIPTION
This should fix #1187 -- I've also added a regression test to ensure that the glob's expansion (rather than the literal glob) is passed into `_check_file`.

For context, the bug here was caused by another bugfix in #1172 -- I changed `twine check` to use the same `_split_inputs` helper as `twine upload`, but accidentally removed the `_find_dists` helper call that "primes" the inputs list by expanding any globs.

There's a potential refactor here, which would be to put `_find_dists` inside of `_split_inputs` and avoid the need for two separate calls, since the two are always called together. I can do a follow up for that; I left it out here since it'd make the diff larger with test changes.