### PR TITLE
Use "source" as python-version for sdist uploads

### DIFF
--- a/changelog/1191.misc.txt
+++ b/changelog/1191.misc.txt
@@ -1,0 +1,3 @@
+- Use ``"source"`` instead of ``None`` as ``pyversion`` for ``sdist``
+  uploads. This is what PyPI (and most likely other package indexes)
+  expects.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -466,3 +466,9 @@ def test_malformed_from_file(monkeypatch):
 def test_package_from_egg():
     filename = "tests/fixtures/twine-3.3.0-py3.9.egg"
     package_file.PackageFile.from_filename(filename, comment=None)
+
+
+def test_package_from_sdist():
+    filename = "tests/fixtures/twine-1.5.0.tar.gz"
+    p = package_file.PackageFile.from_filename(filename, comment=None)
+    assert p.python_version == "source"

--- a/twine/package.py
+++ b/twine/package.py
@@ -157,7 +157,6 @@ class PackageFile:
                 )
             raise exceptions.InvalidDistribution(msg)
 
-        py_version: Optional[str]
         if dtype == "bdist_egg":
             (dist,) = importlib_metadata.Distribution.discover(path=[filename])
             py_version = dist.metadata["Version"]
@@ -165,8 +164,11 @@ class PackageFile:
             py_version = cast(wheel.Wheel, meta).py_version
         elif dtype == "bdist_wininst":
             py_version = cast(wininst.WinInst, meta).py_version
+        elif dtype == "sdist":
+            py_version = "source"
         else:
-            py_version = None
+            # This should not be reached.
+            raise ValueError
 
         return cls(
             filename, comment, cast(CheckedDistribution, meta), py_version, dtype


### PR DESCRIPTION
Although not setting the "pyversion" field in the upload data works, and despite it not being used for much, this is what PyPI (and most likely other indexes) expects.

This will simplify follow-up patches.