### PR TITLE
Fix python_version metadata extraction for bdist_egg distributions

### DIFF
--- a/changelog/1192.bug.txt
+++ b/changelog/1192.bug.txt
@@ -1,0 +1,1 @@
+- Fix python_version metadata extraction for bdist_egg distributions.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -465,4 +465,5 @@ def test_malformed_from_file(monkeypatch):
 
 def test_package_from_egg():
     filename = "tests/fixtures/twine-3.3.0-py3.9.egg"
-    package_file.PackageFile.from_filename(filename, comment=None)
+    p = package_file.PackageFile.from_filename(filename, comment=None)
+    assert p.python_version == "3.9"


### PR DESCRIPTION
Fixes #1190.