### PR TITLE
Rename wheel filetype back to bdist_wheel

### DIFF
--- a/twine/package.py
+++ b/twine/package.py
@@ -46,12 +46,12 @@ from twine import exceptions
 from twine import wheel
 
 DIST_TYPES = {
-    "wheel": wheel.Wheel,
+    "bdist_wheel": wheel.Wheel,
     "sdist": pkginfo.SDist,
 }
 
 DIST_EXTENSIONS = {
-    ".whl": "wheel",
+    ".whl": "bdist_wheel",
     ".tar.bz2": "sdist",
     ".tar.gz": "sdist",
     ".zip": "sdist",
@@ -152,7 +152,7 @@ class PackageFile:
                 )
             raise exceptions.InvalidDistribution(msg)
 
-        if dtype == "wheel":
+        if dtype == "bdist_wheel":
             py_version = cast(wheel.Wheel, meta).py_version
         elif dtype == "sdist":
             py_version = "source"


### PR DESCRIPTION
Uploads to TestPyPI failed while testing #1194. When I added `--verbose`, the error message from PyPI said:

> 400 Invalid value for filetype. Error: Use a known file type.

It looks like the filetype was changed to 'wheel' in #1195 on the assumption that this was purely an internal name. Changing it back to 'bdist_wheel' made the uploads work for me.