### PR TITLE
Remove support for .tar.bz2 sdists

### DIFF
--- a/twine/package.py
+++ b/twine/package.py
@@ -52,7 +52,6 @@ DIST_TYPES = {
 
 DIST_EXTENSIONS = {
     ".whl": "bdist_wheel",
-    ".tar.bz2": "sdist",
     ".tar.gz": "sdist",
     ".zip": "sdist",
 }


### PR DESCRIPTION
PEP 527 deprecated .tar.bz2 sdists in September 2016 and PyPI removed support in April 2020 https://github.com/pypi/warehouse/pull/7529.

There is little evidence of other package indexes supporting this file format for sdists and there is no known modern Python package build tool that generates source distributions as .tat.bz2 archives.

Moving to 'packaging' for parsing metadata as the code for extracting the metadata from distribution archives will need to be implemented in twine. This change allows to have to implement only one archive format for sdists.

Note that PyPI still supports sdists in .zip format but twine does not.

Fixes #1196.