### PR TITLE
Use monkeypatch.setenv() instead of home grown helpers.set_env()

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test functions useful across twine's tests."""
 
-import contextlib
 import os
 import pathlib
 
@@ -23,26 +22,3 @@ SDIST_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.5.0.tar.gz")
 WHEEL_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.5.0-py2.py3-none-any.whl")
 NEW_SDIST_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.6.5.tar.gz")
 NEW_WHEEL_FIXTURE = os.path.join(FIXTURES_DIR, "twine-1.6.5-py2.py3-none-any.whl")
-
-
-@contextlib.contextmanager
-def set_env(**environ):
-    """Set the process environment variables temporarily.
-
-    >>> with set_env(PLUGINS_DIR=u'test/plugins'):
-    ...   "PLUGINS_DIR" in os.environ
-    True
-
-    >>> "PLUGINS_DIR" in os.environ
-    False
-
-    :param environ: Environment variables to set
-    :type environ: dict[str, unicode]
-    """
-    old_environ = dict(os.environ)
-    os.environ.update(environ)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(old_environ)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -94,8 +94,9 @@ def test_values_from_env_pypi(monkeypatch, repo):
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
-    with helpers.set_env(**testenv):
-        cli.dispatch(["register", helpers.WHEEL_FIXTURE])
+    for key, value in testenv.items():
+        monkeypatch.setenv(key, value)
+    cli.dispatch(["register", helpers.WHEEL_FIXTURE])
     register_settings = replaced_register.calls[0].args[0]
     assert "pypipassword" == register_settings.password
     assert "pypiuser" == register_settings.username
@@ -128,8 +129,9 @@ def test_values_from_env_not_pypi(monkeypatch, write_config_file):
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
-    with helpers.set_env(**testenv):
-        cli.dispatch(["register", helpers.WHEEL_FIXTURE])
+    for key, value in testenv.items():
+        monkeypatch.setenv(key, value)
+    cli.dispatch(["register", helpers.WHEEL_FIXTURE])
     register_settings = replaced_register.calls[0].args[0]
     assert "pypipassword" == register_settings.password
     assert "someusername" == register_settings.username

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -568,8 +568,9 @@ def test_values_from_env_pypi(monkeypatch, repo):
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
-    with helpers.set_env(**testenv):
-        cli.dispatch(["upload", "path/to/file"])
+    for key, value in testenv.items():
+        monkeypatch.setenv(key, value)
+    cli.dispatch(["upload", "path/to/file"])
     upload_settings = replaced_upload.calls[0].args[0]
     assert "pypipassword" == upload_settings.password
     assert "pypiuser" == upload_settings.username
@@ -601,8 +602,9 @@ def test_values_from_env_non_pypi(monkeypatch, write_config_file):
         "TWINE_PASSWORD": "pypipassword",
         "TWINE_CERT": "/foo/bar.crt",
     }
-    with helpers.set_env(**testenv):
-        cli.dispatch(["upload", "path/to/file"])
+    for key, value in testenv.items():
+        monkeypatch.setenv(key, value)
+    cli.dispatch(["upload", "path/to/file"])
     upload_settings = replaced_upload.calls[0].args[0]
     assert "pypipassword" == upload_settings.password
     assert "someusername" == upload_settings.username

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,6 @@ import requests
 from twine import exceptions
 from twine import utils
 
-from . import helpers
-
 
 def test_get_config(write_config_file):
     config_file = write_config_file(
@@ -279,16 +277,19 @@ def test_get_userpass_value(cli_value, config, key, strategy, expected):
         ("URL", "https://example.org", {"URL": "https://pypi.org"}, "https://pypi.org"),
     ],
 )
-def test_default_to_environment_action(env_name, default, environ, expected):
+def test_default_to_environment_action(
+    monkeypatch, env_name, default, environ, expected
+):
     option_strings = ("-x", "--example")
     dest = "example"
-    with helpers.set_env(**environ):
-        action = utils.EnvironmentDefault(
-            env=env_name,
-            default=default,
-            option_strings=option_strings,
-            dest=dest,
-        )
+    for key, value in environ.items():
+        monkeypatch.setenv(key, value)
+    action = utils.EnvironmentDefault(
+        env=env_name,
+        default=default,
+        option_strings=option_strings,
+        dest=dest,
+    )
     assert action.env == env_name
     assert action.default == expected
 


### PR DESCRIPTION
Just reducing the amount of code that needs to be maintained.