### PR TITLE
Simplify generation of test packages used in test_check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,7 @@ deps =
     pretend
     pytest
     pytest-socket
-    build
     coverage
-    # Needed on 3.12 and newer due to setuptools not being pre-installed
-    # in fresh venvs.
-    # See: https://github.com/python/cpython/issues/95299
-    setuptools
 passenv =
     PYTEST_ADDOPTS
 setenv =


### PR DESCRIPTION
These tests used `build` to invoke the `setuptools.build_meta` build backend on a package directory generated on the fly. The tests are only interested in the content of the package metadata and use variations of `setup.cfg` to generate the desired metadata.

This can be simplified to the direct generation of sdist archives with synthetic `PKG-INFO` metadata files. This makes the actual metadata the tests are checking obvious and avoid two test dependencies.

The tests simplification highlighted that two tests are actually testing the exact same thing. Remove one.