### PR TITLE
feat: skip upload for sonatype nexus collision

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -520,6 +520,16 @@ def test_prints_skip_message_for_response(
             ),
             id="gitlab_enterprise",
         ),
+        pytest.param(
+            dict(
+                status_code=400,
+                text=(
+                    "pypi-local:twine/1.5.0/twine-1.5.0-py2.py3-none-any.whl"
+                    " cannot be updated"
+                ),
+            ),
+            id="sonatype_nexus",
+        ),
     ],
 )
 def test_skip_existing_skips_files_on_repository(response_kwargs):

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -67,6 +67,9 @@ def skip_upload(
         or (status == 403 and "overwrite artifact" in text)
         # Gitlab Enterprise Edition (https://about.gitlab.com)
         or (status == 400 and "already been taken" in text)
+        # Sonatype Nexus Repository
+        # (https://help.sonatype.com/en/pypi-repositories.html)
+        or (status == 400 and "cannot be updated" in text)
     )
 
 


### PR DESCRIPTION
**Context:**
We want to use the `--skip-existing` option with Sonatype Nexus' pypi.
However when package already exists, Sonatype Nexus is delivering a 400 reponse with a message not handled yet in the code.

The purpose of this PR is to handle such messages.