### PR TITLE
ci: apply fixes from zizmor

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.2.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -57,6 +59,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -75,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
@@ -87,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
@@ -121,6 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: "actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55"


### PR DESCRIPTION
This applies a handful of defense-in-depth suggestions from [zizmor](https://github.com/woodruffw/zizmor).

In particular, zizmor's only findings were around unnecessary credential persistence, so I've gone ahead and fixed those without adding a periodic scanning workflow. However, adding one wouldn't be too hard either.