### PR TITLE
Python 3 is the default nowadays

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: "Setup Python"
         uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
-        with:
-          python-version: "3.x"
 
       - name: "Install dependencies"
         run: python -m pip install build


### PR DESCRIPTION
No need to explicitly require Python 3.