### PR TITLE
Set trusted publishing logging to INFO/WARN

### DIFF
--- a/1247.misc.rst
+++ b/1247.misc.rst
@@ -1,0 +1,1 @@
+Log when performing built-in trusted publishing key exchange.

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -99,7 +99,7 @@ class Resolver:
             logger.warning("This environment is not supported for trusted publishing")
             return None  # Fall back to prompting for a token (if possible)
 
-        logger.info("Got OIDC token for audience %s", audience)
+        logger.warning("Got OIDC token for audience %s", audience)
 
         token_exchange_url = f"https://{repository_domain}/_/oidc/mint-token"
 
@@ -125,7 +125,7 @@ class Resolver:
                 f"reasons:\n\n{reasons}"
             )
 
-        logger.info("Minted upload token for trusted publishing")
+        logger.warning("Minted upload token for trusted publishing")
         return cast(str, mint_token_payload["token"])
 
     @property

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -96,10 +96,10 @@ class Resolver:
             )
 
         if oidc_token is None:
-            logger.debug("This environment is not supported for trusted publishing")
+            logger.warning("This environment is not supported for trusted publishing")
             return None  # Fall back to prompting for a token (if possible)
 
-        logger.debug("Got OIDC token for audience %s", audience)
+        logger.info("Got OIDC token for audience %s", audience)
 
         token_exchange_url = f"https://{repository_domain}/_/oidc/mint-token"
 
@@ -125,7 +125,7 @@ class Resolver:
                 f"reasons:\n\n{reasons}"
             )
 
-        logger.debug("Minted upload token for trusted publishing")
+        logger.info("Minted upload token for trusted publishing")
         return cast(str, mint_token_payload["token"])
 
     @property
@@ -179,7 +179,7 @@ class Resolver:
             return password
 
         if self.is_pypi() and self.username == "__token__":
-            logger.debug(
+            logger.info(
                 "Trying to use trusted publishing (no token was explicitly provided)"
             )
             if (token := self.make_trusted_publishing_token()) is not None:


### PR DESCRIPTION
Trusted publishing is the only part of the codebase using `logger.debug()`, which can't be easily accessed from the CLI. This PR changes most to `logger.info` – therefore always printing them – and one to `logger.warning()` (visible with `--verbose`).