### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=6.0"]
+requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,9 +9,10 @@ authors = [
 	{ name = "Donald Stufft and individual contributors", email = "donald@stufft.io" },
 ]
 description = "Collection of utilities for publishing packages on PyPI"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
 	"Intended Audience :: Developers",
-	"License :: OSI Approved :: Apache Software License",
 	"Natural Language :: English",
 	"Operating System :: MacOS :: MacOS X",
 	"Operating System :: POSIX",
@@ -68,7 +69,6 @@ twine = "twine.__main__:main"
 [tool.setuptools]
 packages = ["twine", "twine.commands"]
 include-package-data = true
-license-files = ["LICENSE"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
The CI error seems unrelated.
<details>
<summary>CI error</summary>

```
=================================== FAILURES ===================================
_________________________ test_fails_rst_syntax_error __________________________

tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_fails_rst_syntax_error0')
capsys = <_pytest.capture.CaptureFixture object at 0x7f23f321df10>
caplog = <_pytest.logging.LogCaptureFixture object at 0x7f23f321d040>

    def test_fails_rst_syntax_error(tmp_path, capsys, caplog):
        sdist = build_sdist_with_metadata(
            tmp_path,
            """\
            Metadata-Version: 2.1
            Name: test-package
            Version: 1.2.3
            Description-Content-Type: text/x-rst
    
    
            ============
    
            """,
        )
    
        assert check.check([sdist])
    
        assert capsys.readouterr().out == f"Checking {sdist}: FAILED\n"
    
>       assert caplog.record_tuples == [
            (
                "twine.commands.check",
                logging.ERROR,
                "`long_description` has syntax errors in markup "
                "and would not be rendered on PyPI.\n"
                "line 2: Error: Document or section may not begin with a transition.",
            ),
        ]
E       AssertionError: assert [('twine.comm...transition.')] == [('twine.comm...transition.')]
E         
E         At index 0 diff: ('twine.commands.check', 40, '`long_description` has syntax errors in markup and would not be rendered on PyPI.\nline 2: Warning: Document or section may not begin with a transition.') != ('twine.commands.check', 40, '`long_description` has syntax errors in markup and would not be rendered on PyPI...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

tests/test_check.py:116: AssertionError
----------------------------- Captured stderr call -----------------------------
`long_description` has syntax errors in markup and would not be rendered on PyPI.
line 2: Warning: Document or section may not begin with a transition.
------------------------------ Captured log call -------------------------------
ERROR    twine.commands.check:check.py:147 `long_description` has syntax errors in markup and would not be rendered on PyPI.
line 2: Warning: Document or section may not begin with a transition.
=========================== short test summary info ============================
FAILED tests/test_check.py::test_fails_rst_syntax_error - AssertionError: assert [('twine.comm...transition.')] == [('twine.comm...tr...
======================== 1 failed, 229 passed in 2.15s =========================
py: exit 1 (3.21 seconds) /home/runner/work/twine/twine> python -m coverage run -m pytest pid=2657
  py: FAIL code 1 (13.22=setup[10.01]+cmd[3.21] seconds)
  evaluation failed :( (13.33 seconds)
Error: Process completed with exit code 1.
```
</details>

Maybe caused by the release of [packaging 25.0](https://github.com/pypa/packaging/releases/tag/25.0) a few months ago, or even an earlier release?