### PR TITLE
fix(tests): update expected error message

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -119,7 +119,7 @@ def test_fails_rst_syntax_error(tmp_path, capsys, caplog):
             logging.ERROR,
             "`long_description` has syntax errors in markup "
             "and would not be rendered on PyPI.\n"
-            "line 2: Error: Document or section may not begin with a transition.",
+            "line 2: Warning: Document or section may not begin with a transition.",
         ),
     ]
 


### PR DESCRIPTION
This fixes the test failure that's currently red on main + blocking #1256.

I dug into this, and it looks like an indirect change via `readme-renderer` -- this commit changed the reporting from an error to a warning:

https://github.com/docutils/docutils/commit/353b6f0eddd1bb5aaef5ec090dea6d3cdbb28d01

(So the chain of effect here is `twine -> readme-renderer -> docutils`.)