### PR TITLE
Remove timeouts from TP requests

### DIFF
--- a/twine/auth.py
+++ b/twine/auth.py
@@ -166,7 +166,7 @@ class Resolver:
         # Indices are expected to support `https://{domain}/_/oidc/audience`,
         # which tells OIDC exchange clients which audience to use.
         audience_url = f"https://{repository_domain}/_/oidc/audience"
-        resp = session.get(audience_url, timeout=5)
+        resp = session.get(audience_url)
         resp.raise_for_status()
         audience = cast(str, resp.json()["audience"])
 
@@ -197,7 +197,6 @@ class Resolver:
         mint_token_resp = session.post(
             token_exchange_url,
             json={"token": oidc_token},
-            timeout=5,  # S113 wants a timeout
         )
         try:
             mint_token_payload = mint_token_resp.json()


### PR DESCRIPTION
This PR removes the timeouts used in both trusted-publishing requests: the `GET` requesting an OIDC token, and the `POST` requesting the actual API token.

I have noticed that when a single identity is registered as the trusted publisher for _many_ packages (200+), twine can occasionally* timeout. I have therefore had to start performing the token exchange myself again, as we had to do before v6.10.

I suspect this is because the API token is a macaroon, and the server must therefore identify all the packages that have registered that same identity as a "trusted publisher", and then store them in the macaroon. I assume this is computationally expensive, so, with many packages (and/or if the server is busy with many other requests), the current hardcoded timeouts become insufficient.

Now, the better solution here would be to allow users to pass a custom timeout: `twine upload --timeout 30`. However, I've noticed that none of the other requests performed by `twine` have timeouts:

https://github.com/pypa/twine/blob/91753343daa1366711a441b4a13bd1b31146909b/twine/repository.py#L102-L107

https://github.com/pypa/twine/blob/91753343daa1366711a441b4a13bd1b31146909b/twine/repository.py#L151-L156

https://github.com/pypa/twine/blob/91753343daa1366711a441b4a13bd1b31146909b/twine/repository.py#L215

I have therefore chosen to simply remove the timeouts to be consistent with the rest of the codebase. This is largely because I'm not familiar enough with twine's codebase to make the larger changes necessary to make a potential `--timeout` argument apply everywhere (as users would expect).

If preferred and if someone can point me in the right direction(s), I'll be happy to set a user-defined global timeout everywhere instead.

---

\* I haven't kept track of how often it happens... it's just common enough to be annoying... maybe 10% of the time?