### PR TITLE
feat(package): remove MD5 hashing entirely

### DIFF
--- a/changelog/1262.removal.rst
+++ b/changelog/1262.removal.rst
@@ -1,0 +1,7 @@
+Remove support for MD5 digests during uploads.
+
+This support was entirely vestigial, as MD5 is not a secure hash function
+and is not actually required on upload by PyPI.
+
+Indices that cross-reference the uploaded content with a digest should
+use the provided SHA-256 and/or BLAKE2 digests instead.


### PR DESCRIPTION
This removes MD5 from HashManager, which in turn means we no longer supply a `md5_digest` in the metadata when uploading to a repository. This is consistent with PyPI's own expectation that MD5 is optional.

In terms of security this has no impact as MD5 is considered insecure for integrity purposes and PyPI already uniformly uses SHA-256 and BLAKE2 for package integrity.

Closes #1258.