### PR TITLE
Set COVERAGE_FILE in tox.ini to allow for parallel tox runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ passenv =
     PYTEST_ADDOPTS
 setenv =
     HOME=/tmp/nonexistent
+    COVERAGE_FILE={env_tmp_dir}/.coverage
 commands =
     python -m coverage run -m pytest {posargs}
     python -m coverage html


### PR DESCRIPTION
This is a minor configuration tweak to allow `tox p` to finish successfully.
