### PR TITLE
Add Python 3.14 to CI + tox matrices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         platform:
           - ubuntu-latest
           - macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",
+	"Programming Language :: Python :: 3.14",
 	"Programming Language :: Python :: Implementation :: CPython",
 ]
 requires-python = ">=3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9
-envlist = lint,types,py{39,310,311,312,313}{,-packaging240},integration,docs
+envlist = lint,types,py{39,310,311,312,313,314}{,-packaging240},integration,docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python 3.14 has been out and stable for a bit, this adds it to the CI + tox matrices.

(Maybe we should remove 3.9 now that it's EOL? If there's no objections to that I can do a follow-up.)