### PR TITLE
Normalize repository URLs for known PyPI hosts to include trailing slash

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,6 +187,26 @@ def test_sanitize_url(input_url: str, expected_url: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("input_url, expected_url"),
+    [
+        # Known PyPI hosts get trailing slash added
+        ("https://test.pypi.org/legacy", "https://test.pypi.org/legacy/"),
+        ("https://test.pypi.org/legacy/", "https://test.pypi.org/legacy/"),
+        ("https://upload.pypi.org/legacy", "https://upload.pypi.org/legacy/"),
+        ("https://upload.pypi.org/legacy/", "https://upload.pypi.org/legacy/"),
+        # HTTP upgraded to HTTPS for known hosts, with trailing slash
+        ("http://test.pypi.org/legacy", "https://test.pypi.org/legacy/"),
+        # Root path without trailing slash stays as-is
+        ("https://upload.pypi.org", "https://upload.pypi.org"),
+        # Non-PyPI hosts are not modified
+        ("https://custom.example.com/legacy", "https://custom.example.com/legacy"),
+    ],
+)
+def test_normalize_repository_url(input_url: str, expected_url: str) -> None:
+    assert utils.normalize_repository_url(input_url) == expected_url
+
+
+@pytest.mark.parametrize(
     "repo_url, message",
     [
         (

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -234,7 +234,12 @@ def _config_from_repository_url(url: str) -> RepositoryConfig:
 def normalize_repository_url(url: str) -> str:
     parsed = urlparse(url)
     if parsed.netloc in _HOSTNAMES:
-        return urlunparse(("https",) + parsed[1:])
+        # Ensure trailing slash for known PyPI hosts to avoid confusing
+        # server errors like "body may not contain duplicate keys" (#1248).
+        path = parsed.path
+        if path and not path.endswith("/"):
+            path = path + "/"
+        return urlunparse(("https", parsed.netloc, path) + parsed[3:])
     return urlunparse(parsed)
 
 


### PR DESCRIPTION
Fixes #1248

## Problem
When users provide repository URLs like `https://test.pypi.org/legacy` (without trailing slash), the server returns a confusing `body may not contain duplicate keys` error. This is not actionable and takes significant debugging to understand.

## Solution
The `normalize_repository_url` function now ensures that known PyPI host URLs always include a trailing slash. This prevents the confusing server error and makes URLs consistent with the documented defaults (`https://upload.pypi.org/legacy/` and `https://test.pypi.org/legacy/`).

## Changes
- **twine/utils.py**: Updated `normalize_repository_url` to add trailing slash for known PyPI hosts when the path is non-empty and does not already end with `/`
- **tests/test_utils.py**: Added parametrized tests for the normalization behavior

## Test coverage
- Known hosts with/without trailing slash → always get trailing slash
- HTTP URLs → upgraded to HTTPS + trailing slash
- Root path (no path component) → left as-is
- Non-PyPI hosts → not modified