### PR TITLE
fix: bump minimum rich dependency to 14.3.3 to prevent verbose hang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 	# workaround for missing binaries on these platforms, see #1158
 	"keyring >= 21.2.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
 	"rfc3986 >= 1.4.0",
-	"rich >= 12.0.0",
+	"rich >= 14.3.3",
 	"packaging >= 24.0",
 	"id",
 ]


### PR DESCRIPTION
## Problem

`twine upload --verbose` hangs indefinitely in non-TTY environments (e.g. CI pipelines) when the server response body starts with a UTF-8 BOM character. This occurs with Azure DevOps Artifacts using an expired PAT.

## Root Cause

Rich < 14.3.3 has a bug where `RichHandler` enters an infinite loop in `split_graphemes`/`chop_cells` when word-wrapping text containing a BOM character. Fixed upstream in [Rich 14.3.3](https://github.com/Textualize/rich/releases/tag/v14.3.3).

Twine's current dependency `rich >= 12.0.0` allows the buggy versions.

## Solution

Bump minimum rich dependency from `>= 12.0.0` to `>= 14.3.3`.

## Testing

The fix is verified by the upstream Rich release. A minimal reproduction:

```python
import rich.logging, logging
handler = rich.logging.RichHandler()
logger = logging.getLogger("test")
logger.addHandler(handler)
logger.info("\ufeff" + "x" * 400)  # Hangs on rich < 14.3.3
```

Fixes #1302