### PR TITLE
Handle non-standard HTTP status codes

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@
 import sys
 
 import pretend
+import pytest
 import requests
 
 from twine import __main__ as dunder_main
@@ -42,7 +43,10 @@ def test_exception_handling(monkeypatch, capsys):
     )
 
 
-def test_http_exception_handling(monkeypatch, capsys):
+@pytest.mark.parametrize(
+    ("status_code", "status_phrase"), [(400, "Bad Request"), (599, "Unknown Status")]
+)
+def test_http_exception_handling(monkeypatch, capsys, status_code, status_phrase):
     monkeypatch.setattr(sys, "argv", ["twine", "upload", "test.whl"])
     monkeypatch.setattr(
         upload,
@@ -51,7 +55,7 @@ def test_http_exception_handling(monkeypatch, capsys):
             requests.HTTPError(
                 response=pretend.stub(
                     url="https://example.org",
-                    status_code=400,
+                    status_code=status_code,
                     reason="Error reason",
                 )
             )
@@ -64,8 +68,8 @@ def test_http_exception_handling(monkeypatch, capsys):
     captured = capsys.readouterr()
 
     assert _unwrap_lines(captured.out) == (
-        f"{RED_ERROR} HTTPError: 400 Bad Request from https://example.org "
-        "Error reason"
+        f"{RED_ERROR} HTTPError: {status_code} {status_phrase} "
+        "from https://example.org Error reason"
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,9 +44,12 @@ def test_exception_handling(monkeypatch, capsys):
 
 
 @pytest.mark.parametrize(
-    ("status_code", "status_phrase"), [(400, "Bad Request"), (599, "Unknown Status")]
+    ("status_code", "status_phrase", "reason"),
+    [(400, "Bad Request", "Error reason"), (599, "Unknown Status", "Another reason")],
 )
-def test_http_exception_handling(monkeypatch, capsys, status_code, status_phrase):
+def test_http_exception_handling(
+    monkeypatch, capsys, status_code, status_phrase, reason
+):
     monkeypatch.setattr(sys, "argv", ["twine", "upload", "test.whl"])
     monkeypatch.setattr(
         upload,
@@ -54,9 +57,7 @@ def test_http_exception_handling(monkeypatch, capsys, status_code, status_phrase
         pretend.raiser(
             requests.HTTPError(
                 response=pretend.stub(
-                    url="https://example.org",
-                    status_code=status_code,
-                    reason="Error reason",
+                    url="https://example.org", status_code=status_code, reason=reason
                 )
             )
         ),
@@ -69,7 +70,7 @@ def test_http_exception_handling(monkeypatch, capsys, status_code, status_phrase
 
     assert _unwrap_lines(captured.out) == (
         f"{RED_ERROR} HTTPError: {status_code} {status_phrase} "
-        "from https://example.org Error reason"
+        f"from https://example.org {reason}"
     )
 
 

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -19,7 +19,8 @@ from typing import Any, cast
 
 import requests
 
-from twine import cli, exceptions
+from twine import cli
+from twine import exceptions
 
 logger = logging.getLogger(__name__)
 

--- a/twine/__main__.py
+++ b/twine/__main__.py
@@ -19,8 +19,7 @@ from typing import Any, cast
 
 import requests
 
-from twine import cli
-from twine import exceptions
+from twine import cli, exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +36,20 @@ def main() -> Any:
 
         error = True
         status_code = response.status_code
-        status_phrase = http.HTTPStatus(status_code).phrase
+
+        try:
+            status_phrase = http.HTTPStatus(status_code).phrase
+        except ValueError:
+            # HTTPStatus will raise ValueError if the server responds with
+            # a non-standard status code. This is almost certainly an upstream
+            # index error since non-standard status codes should only be used
+            # for internal signaling, but there's nothing we can do about that
+            # here other than avoid propagating it as an unhandled exception.
+            #
+            # See: <https://github.com/pypa/twine/issues/1304>
+            # See: <https://github.com/pypi/warehouse/issues/19713>
+            status_phrase = "Unknown Status"
+
         logger.error(
             f"{exc.__class__.__name__}: {status_code} {status_phrase} "
             f"from {response.url}\n"


### PR DESCRIPTION
This addresses #1304 by turning the uncaught exception into a graceful error message and exit instead. For example, a user will now see something like:

```
HTTPError: 499 Unknown Status from https://...
```

...instead of a stack trace.

~~I'll also add a test for this.~~ Done.

Closes #1304.