### PR TITLE
Bump `packaging >= 26.1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,6 @@ jobs:
           - windows-latest
         tox-environment:
           - py
-        include:
-          # Test with the oldest supported ``packaging`` version.
-          - platform: ubuntu-latest
-            python-version: "3.10"
-            tox-environment: py-packaging240
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 	"keyring >= 21.2.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
 	"rfc3986 >= 1.4.0",
 	"rich >= 12.0.0",
-	"packaging >= 24.0",
+	"packaging >= 26.1",
 	"id",
 ]
 dynamic = ["version"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.10
-envlist = lint,types,py{310,311,312,313,314}{,-packaging240},integration,docs
+envlist = lint,types,py{310,311,312,313,314},integration,docs
 isolated_build = True
 
 [testenv]
@@ -9,7 +9,6 @@ deps =
     pytest
     pytest-socket
     coverage
-    packaging240: packaging==24.0
 passenv =
     PYTEST_ADDOPTS
 setenv =

--- a/twine/package.py
+++ b/twine/package.py
@@ -241,7 +241,7 @@ class PackageFile:
 
         try:
             metadata.Metadata.from_raw(meta)
-        except metadata.ExceptionGroup as group:
+        except metadata.ExceptionGroup as group:  # type: ignore[attr-defined]
             raise exceptions.InvalidDistribution(
                 "Invalid distribution metadata: {}".format(
                     "; ".join(sorted(str(e) for e in group.exceptions))

--- a/twine/package.py
+++ b/twine/package.py
@@ -20,6 +20,7 @@ import re
 import subprocess
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict
 
+from packaging import errors
 from packaging import metadata
 from packaging import version
 from rich import print
@@ -108,7 +109,6 @@ _RAW_TO_PACKAGE_METADATA = {
 
 
 class PackageMetadata(TypedDict, total=False):
-
     # Metadata 1.0 - PEP 241
     metadata_version: str
     name: str
@@ -241,7 +241,7 @@ class PackageFile:
 
         try:
             metadata.Metadata.from_raw(meta)
-        except metadata.ExceptionGroup as group:  # type: ignore[attr-defined]
+        except errors.ExceptionGroup as group:
             raise exceptions.InvalidDistribution(
                 "Invalid distribution metadata: {}".format(
                     "; ".join(sorted(str(e) for e in group.exceptions))


### PR DESCRIPTION
This is tripping the CI in #1309 and on main. 

`packaging==26.1` moves `packaging.metadata.ExceptionGroup` to `packaging.errors.ExceptionGroup`, but re-exports that API through `packaging.metadata` for backwards compatibility. However, that re-export isn't explicitly marked in `__all__`, so mypy flags it.

We could patch around this or suppress it, but bumping to `>= 26.1` is easiest.

Here's the implicit re-export: 

https://github.com/pypa/packaging/blob/b82413d6a1e5037b65aabc44154a97f0b2d63766/src/packaging/metadata.py#L21


CC @henryiii for opinions since I think `packaging.errors` was your change with https://github.com/pypa/packaging/pull/1071 🙂 