### PR TITLE
Support Metadata v2.5

### DIFF
--- a/twine/package.py
+++ b/twine/package.py
@@ -30,7 +30,9 @@ from twine import sdist
 from twine import wheel
 
 # Monkeypatch Metadata 2.0 support
-metadata._VALID_METADATA_VERSIONS[3:3] = ["2.0"]
+if hasattr(metadata, "_VALID_METADATA_VERSIONS"):
+    if "2.0" not in metadata._VALID_METADATA_VERSIONS:
+        metadata._VALID_METADATA_VERSIONS[3:3] = ["2.0"]
 
 DIST_TYPES = {
     "bdist_wheel": wheel.Wheel,

--- a/twine/package.py
+++ b/twine/package.py
@@ -30,16 +30,7 @@ from twine import sdist
 from twine import wheel
 
 # Monkeypatch Metadata 2.0 support
-metadata._VALID_METADATA_VERSIONS = [
-    "1.0",
-    "1.1",
-    "1.2",
-    "2.0",
-    "2.1",
-    "2.2",
-    "2.3",
-    "2.4",
-]
+metadata._VALID_METADATA_VERSIONS[3:3] = ["2.0"]
 
 DIST_TYPES = {
     "bdist_wheel": wheel.Wheel,

--- a/twine/package.py
+++ b/twine/package.py
@@ -32,7 +32,8 @@ from twine import wheel
 # Monkeypatch Metadata 2.0 support
 if hasattr(metadata, "_VALID_METADATA_VERSIONS"):
     if "2.0" not in metadata._VALID_METADATA_VERSIONS:
-        metadata._VALID_METADATA_VERSIONS[3:3] = ["2.0"]
+        i = metadata._VALID_METADATA_VERSIONS.index("2.1")
+        metadata._VALID_METADATA_VERSIONS.insert(i, "2.0")
 
 DIST_TYPES = {
     "bdist_wheel": wheel.Wheel,


### PR DESCRIPTION
Twine currently fails to upload a dist with `Metadata-Version: 2.5`, despite [packaging supporting that](https://github.com/pypa/packaging/blob/26.2/src/packaging/metadata.py#L514), due to a monkeypatch introduced in [0605ef0](https://github.com/pypa/twine/commit/0605ef02a6a5ffa8bddab6816f7ff3e0db9a442f#diff-30ee60b48548622c54dfa266e095021f403ad23ab4848c74b2deed5df329ae00).

This is a bandaid fix..