### PR TITLE
Remove unused input_func shim and unimplemented verify_package_integrity stub

### DIFF
--- a/twine/repository.py
+++ b/twine/repository.py
@@ -239,8 +239,3 @@ class Repository:
             f"{url}project/{package.safe_name}/{package.version}/"
             for package in packages
         }
-
-    def verify_package_integrity(self, package: package_file.PackageFile) -> None:
-        # TODO(sigmavirus24): Add a way for users to download the package and
-        # check its hash against what it has locally.
-        pass

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -32,9 +32,6 @@ from requests_toolbelt.utils import user_agent
 import twine
 from twine import exceptions
 
-# Shim for input to allow testing.
-input_func = input
-
 DEFAULT_REPOSITORY = "https://upload.pypi.org/legacy/"
 TEST_REPOSITORY = "https://test.pypi.org/legacy/"
 


### PR DESCRIPTION
Hihi! Cleanup crew here. i am NOT a bot/ai (just setting things straight here lmao)..  

Was scanning twine and found 2 pieces of dead code identified via static analysis                                         
  
([Skylos](https://github.com/duriantaco/skylos)):                                              
                                                                                                 
  - `input_func = input` in `utils.py` ->  a shim intended for testing that is never imported?                             
  - `verify_package_integrity()` in `repository.py` -> an unimplemented stub (`pass` body) with zero call sites 