### PR TITLE
Add tox environment for no-coverage test runs

### DIFF
--- a/changelog/1122.misc.rst
+++ b/changelog/1122.misc.rst
@@ -1,0 +1,1 @@
+Add a ``tox -e nocov`` environment for focused pytest runs.

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,18 @@ commands =
     python -m coverage html
     python -m coverage report --skip-covered --show-missing --fail-under 97
 
+[testenv:nocov]
+deps =
+    pretend
+    pytest
+    pytest-socket
+passenv =
+    PYTEST_ADDOPTS
+setenv =
+    HOME=/tmp/nonexistent
+commands =
+    python -m pytest {posargs}
+
 [testenv:integration]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
## Summary

- add a `tox -e nocov` environment for focused local pytest runs
- keep the same core test dependencies and `HOME=/tmp/nonexistent` behavior as the default test environment
- add a towncrier fragment for the new local test workflow

This addresses the workflow described in #1122: selecting one test through tox currently passes pytest and then fails only because the global coverage threshold is still enforced.

## Tests

```bash
.venv/bin/tox -e nocov -- -k 'Metadata-Version'
```

Result: `1 passed, 231 deselected`.

I also reproduced the current default behavior:

```bash
.venv/bin/tox -e py -- -k 'Metadata-Version'
```

Result: pytest passed, then coverage failed because total coverage was below `--fail-under 97`.
