### PR TITLE
changelog: backfill entries from PRs

### DIFF
--- a/changelog/1268.bugfix.rst
+++ b/changelog/1268.bugfix.rst
@@ -1,0 +1,1 @@
+Specify UTF-8 encoding when reading ``.pypirc`` files.

--- a/changelog/1275.bugfix.rst
+++ b/changelog/1275.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing subdependencies to ``--version`` output.

--- a/changelog/1298.misc.rst
+++ b/changelog/1298.misc.rst
@@ -1,0 +1,1 @@
+Python 3.10 is now the minimum supported version.

--- a/changelog/1308.bugfix.rst
+++ b/changelog/1308.bugfix.rst
@@ -1,0 +1,1 @@
+The dependency on ``rich`` has been bumped to avoid a hang in some environments.

--- a/changelog/1309.bugfix.rst
+++ b/changelog/1309.bugfix.rst
@@ -1,0 +1,1 @@
+Indices that respond with non-standard HTTP codes are now handled more gracefully.

--- a/changelog/1317.removal.rst
+++ b/changelog/1317.removal.rst
@@ -1,0 +1,1 @@
+Remove monkeypatch allowing Metadata 2.0.

--- a/changelog/1317.removal.rst
+++ b/changelog/1317.removal.rst
@@ -1,1 +1,1 @@
-Remove monkeypatch allowing Metadata 2.0.
+Fix uploading packages with metadata version 2.5. The fix no longer allows metadata version 2.0, which was never officially standardised.

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -141,16 +141,14 @@ def test_fails_rst_no_content(tmp_path, capsys, caplog):
     assert check.check([sdist])
 
     assert capsys.readouterr().out == f"Checking {sdist}: FAILED\n"
+    assert len(caplog.record_tuples) == 1
 
-    assert caplog.record_tuples == [
-        (
-            "twine.commands.check",
-            logging.ERROR,
-            "`long_description` has syntax errors in markup "
-            "and would not be rendered on PyPI.\n"
-            "No content rendered from RST source.",
-        ),
-    ]
+    # Note: we intentionally don't check the full error message below,
+    # since readme_renderer/docutils doesn't guarantee it.
+    error = caplog.record_tuples[0]
+    assert error[0] == "twine.commands.check"
+    assert error[1] == logging.ERROR
+    assert "syntax errors" in error[2]
 
 
 def test_passes_rst_description(tmp_path, capsys, caplog):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -119,7 +119,7 @@ def test_fails_rst_syntax_error(tmp_path, capsys, caplog):
             logging.ERROR,
             "`long_description` has syntax errors in markup "
             "and would not be rendered on PyPI.\n"
-            "line 2: Warning: Document or section may not begin with a transition.",
+            "line 2: Warning: Transition at the end of the document.",
         ),
     ]
 


### PR DESCRIPTION
In prep for doing a release (#1327), I noticed these PRs didn't have changelog entries.