### PR TITLE
Clarify AUTHORS entry is optional

### DIFF
--- a/changelog/648.doc.rst
+++ b/changelog/648.doc.rst
@@ -1,0 +1,1 @@
+Clarify that adding yourself to ``AUTHORS`` is optional but encouraged.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -140,7 +140,7 @@ Submitting changes
 1. Fork `the GitHub repository`_.
 2. Make a branch off of ``main`` and commit your changes to it.
 3. Run the tests, check code style, and build the docs as described above.
-4. Optionally, add your name to the end of the :file:`AUTHORS`
+4. (Optional but encouraged) add your name to the end of the :file:`AUTHORS`
    file using the format ``Name <email@domain.com> (url)``, where the
    ``(url)`` portion is optional.
 5. Submit a pull request to the ``main`` branch on GitHub, referencing an


### PR DESCRIPTION
## Summary
- Clarify that adding yourself to AUTHORS is optional but encouraged.
- Add a small documentation changelog entry.

Closes #648

## Validation
- git diff --check
- sphinx-build -W --keep-going -b html -d .\.tox\docs\tmp\doctrees docs docs\_build\html
- sphinx-build -W --keep-going -b doctest -d .\.tox\docs\tmp\doctrees docs docs\_build\html