### PR TITLE
Support Core Metadata 2.5 upload fields

### DIFF
--- a/changelog/1327.bugfix.rst
+++ b/changelog/1327.bugfix.rst
@@ -1,0 +1,1 @@
+Support Core Metadata 2.5 upload fields.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -221,6 +221,8 @@ def test_metadata_dictionary_values(gpg_signature, attestation):
         dynamic=pretend.stub(),
         license_expression=pretend.stub(),
         license_files=pretend.stub(),
+        import_names=pretend.stub(),
+        import_namespaces=pretend.stub(),
     )
 
     package = package_file.PackageFile(
@@ -277,6 +279,10 @@ def test_metadata_dictionary_values(gpg_signature, attestation):
     # Metadata 2.4 - PEP 639
     assert result["license_expression"] == meta["license_expression"]
     assert result["license_file"] == meta["license_files"]
+
+    # Metadata 2.5 - PEP 794
+    assert result["import_name"] == meta["import_names"]
+    assert result["import_namespace"] == meta["import_namespaces"]
 
     # Additional metadata
     assert result["comment"] == package.comment
@@ -458,3 +464,23 @@ def test_setuptools_license_file_valid(monkeypatch):
     package = package_file.PackageFile.from_filename(filename, comment=None)
     meta = package.metadata_dictionary()
     assert "license_file" in meta
+
+
+def test_core_metadata_25_fields(monkeypatch):
+    """Keep Core Metadata 2.5 import declarations."""
+    read_data = (
+        "Metadata-Version: 2.5\n"
+        "Name: test-package\n"
+        "Version: 1.0.0\n"
+        "Import-Name: test_package\n"
+        "Import-Namespace: test_namespace\n"
+    )
+    monkeypatch.setattr(package_file.wheel.Wheel, "read", lambda _: read_data)
+    filename = "tests/fixtures/twine-4.0.2-py3-none-any.whl"
+
+    package = package_file.PackageFile.from_filename(filename, comment=None)
+    meta = package.metadata_dictionary()
+
+    assert meta["metadata_version"] == "2.5"
+    assert meta["import_name"] == ["test_package"]
+    assert meta["import_namespace"] == ["test_namespace"]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,14 +61,30 @@ def test_iterables_are_flattened():
     assert tuples == [("platform", "UNKNOWN"), ("platform", "ANOTHERPLATFORM")]
 
 
+def test_core_metadata_25_fields_are_flattened():
+    """Flatten Core Metadata 2.5 import declaration fields."""
+    data = {
+        "metadata_version": "2.5",
+        "name": "example",
+        "version": "1.0",
+        "import_name": ["example"],
+        "import_namespace": ["example_namespace"],
+    }
+
+    tuples = repository.Repository._convert_metadata_to_list_of_tuples(data)
+
+    assert ("import_name", "example") in tuples
+    assert ("import_namespace", "example_namespace") in tuples
+
+
 def test_all_metadata_fields_are_flattened(monkeypatch):
     """Verify that package metadata fields are correctly flattened."""
     if version.Version(packaging.__version__) < version.Version("24.1"):
         # All metadata fields up to metadata version 2.3
-        metadata = open("tests/fixtures/everything.metadata23")
+        metadata = open("tests/fixtures/everything.metadata23", encoding="utf-8")
     else:
         # All metadata fields up to metadata version 2.4
-        metadata = open("tests/fixtures/everything.metadata24")
+        metadata = open("tests/fixtures/everything.metadata24", encoding="utf-8")
     monkeypatch.setattr(package.wheel.Wheel, "read", metadata.read)
     filename = "tests/fixtures/twine-4.0.2-py3-none-any.whl"
     data = package.PackageFile.from_filename(

--- a/twine/package.py
+++ b/twine/package.py
@@ -93,6 +93,9 @@ _RAW_TO_PACKAGE_METADATA = {
     # Metadata 2.4 - PEP 639
     "license_expression": "license_expression",
     "license_files": "license_file",  # Renamed
+    # Metadata 2.5 - PEP 794
+    "import_names": "import_name",  # Renamed
+    "import_namespaces": "import_namespace",  # Renamed
 }
 
 
@@ -138,6 +141,10 @@ class PackageMetadata(TypedDict, total=False):
     # Metadata 2.4 - PEP 639
     license_expression: str
     license_file: List[str]
+
+    # Metadata 2.5 - PEP 794
+    import_name: List[str]
+    import_namespace: List[str]
 
     # Additional metadata
     comment: str


### PR DESCRIPTION
## Summary
- Preserve Core Metadata 2.5 `Import-Name` and `Import-Namespace` fields in Twine's upload metadata.
- Add regression coverage for parsing and flattening Core Metadata 2.5 import declarations.
- Read metadata fixtures as UTF-8 so the repository test remains portable across local encodings.

Fixes #1327

## Tests
- `.\.venv\Scripts\python -m pytest tests/test_package.py tests/test_repository.py -q`
- `.\.venv\Scripts\python -m pytest tests/test_package.py::test_core_metadata_25_fields tests/test_package.py::test_metadata_dictionary_values tests/test_repository.py::test_core_metadata_25_fields_are_flattened tests/test_repository.py::test_all_metadata_fields_are_flattened -q`
- `.\.venv\Scripts\isort --check-only --diff twine/ tests/`
- `.\.venv\Scripts\black --check --diff twine/ tests/`
- `.\.venv\Scripts\flake8 twine/ tests/`
- `.\.venv\Scripts\mypy --txt-report mypy twine`