### PR TITLE
fix(tests): update expected RST warning for docutils 0.23

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -119,7 +119,7 @@ def test_fails_rst_syntax_error(tmp_path, capsys, caplog):
             logging.ERROR,
             "`long_description` has syntax errors in markup "
             "and would not be rendered on PyPI.\n"
-            "line 2: Warning: Document or section may not begin with a transition.",
+            "line 2: Warning: Transition at the end of the document.",
         ),
     ]
 


### PR DESCRIPTION
## Changes

One line in `tests/test_check.py`: the expected warning message string in `test_fails_rst_syntax_error`.

```
- "line 2: Warning: Document or section may not begin with a transition."
+ "line 2: Warning: Transition at the end of the document."
```

## Why?

`docutils` 0.23 ([recently released](https://pypi.org/project/docutils/0.23/)) changed the warning text it emits for a bare transition (`====`) at the start or end of an RST document (<https://sourceforge.net/p/docutils/code/10300/>).

The production logic in `twine/commands/check.py` is unaffected: `docutils` still refuses to render the malformed RST, `readme_renderer.rst.render()` still returns `None`, and `_check_file` still sets `is_ok = False`. The check correctly fails in practice -- only the human-readable message text changed.

## Supporting both versions in the test?

Twine has no direct `docutils` dependency and no upper version bound. `docutils` enters transitively via `readme-renderer >= 35.0`. `tox` creates fresh virtual environments and resolves to current PyPI packages, so anyone running `tox -e py` will get `docutils` 0.23+. Supporting the old message string alongside the new one would weaken/complicate the test without practical benefits.
