### PR TITLE
Group uploads by distribution

### DIFF
--- a/changelog/1254.feature.rst
+++ b/changelog/1254.feature.rst
@@ -1,0 +1,1 @@
+Upload each project's wheel and source archive together.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -50,6 +51,29 @@ def test_find_dists_handles_real_files():
     ]
     files = commands._find_dists(expected)
     assert expected == files
+
+
+def test_find_dists_groups_artifacts_by_distribution(tmp_path):
+    for filename in [
+        "bar-0.0.2-py3-none-any.whl",
+        "buzz-0.0.3-py3-none-any.whl",
+        "foo-0.0.1-py3-none-any.whl",
+        "bar-0.0.2.tar.gz",
+        "buzz-0.0.3.tar.gz",
+        "foo-0.0.1.tar.gz",
+    ]:
+        (tmp_path / filename).write_text("artifact")
+
+    files = commands._find_dists([str(tmp_path / "*")])
+
+    assert [Path(filename).name for filename in files] == [
+        "bar-0.0.2-py3-none-any.whl",
+        "bar-0.0.2.tar.gz",
+        "buzz-0.0.3-py3-none-any.whl",
+        "buzz-0.0.3.tar.gz",
+        "foo-0.0.1-py3-none-any.whl",
+        "foo-0.0.1.tar.gz",
+    ]
 
 
 def test_split_inputs():

--- a/twine/commands/__init__.py
+++ b/twine/commands/__init__.py
@@ -22,6 +22,12 @@ import glob
 import os.path
 from typing import Dict, List, NamedTuple
 
+from packaging.utils import InvalidSdistFilename
+from packaging.utils import InvalidWheelFilename
+from packaging.utils import canonicalize_name
+from packaging.utils import parse_sdist_filename
+from packaging.utils import parse_wheel_filename
+
 from twine import exceptions
 
 __all__: List[str] = []
@@ -32,9 +38,23 @@ def _group_wheel_files_first(files: List[str]) -> List[str]:
         # Return early if there's no wheel files
         return files
 
-    files.sort(key=lambda x: -1 if x.endswith(".whl") else 0)
+    def sort_key(indexed_file: tuple[int, str]) -> tuple[object, ...]:
+        index, filename = indexed_file
+        basename = os.path.basename(filename)
 
-    return files
+        try:
+            if basename.endswith(".whl"):
+                name, version, _, _ = parse_wheel_filename(basename)
+                return (0, canonicalize_name(name), version, 0, basename, index)
+            if basename.endswith((".tar.gz", ".zip")):
+                name, version = parse_sdist_filename(basename)
+                return (0, canonicalize_name(name), version, 1, basename, index)
+        except (InvalidSdistFilename, InvalidWheelFilename):
+            pass
+
+        return (1, 0 if basename.endswith(".whl") else 1, index)
+
+    return [filename for _, filename in sorted(enumerate(files), key=sort_key)]
 
 
 def _find_dists(dists: List[str]) -> List[str]:


### PR DESCRIPTION
## Problem
Fixes #1254.

When `twine upload` receives multiple wheels and source archives, `_find_dists()` currently pulls every wheel to the front of the list. If one later upload fails, earlier projects can be left half-published with only their wheel uploaded.

A local repro with `bar`, `buzz`, and `foo` artifacts currently produces:

```text
buzz-0.0.3-py3-none-any.whl
foo-0.0.1-py3-none-any.whl
bar-0.0.2-py3-none-any.whl
buzz-0.0.3.tar.gz
foo-0.0.1.tar.gz
bar-0.0.2.tar.gz
```

## Solution
Sort upload candidates by parsed distribution identity instead of using a global wheel-first shuffle.

This keeps wheel-before-sdist ordering within each project release, while grouping each project's artifacts together before moving to the next one. Invalid or non-distribution filenames keep the old wheel-first fallback behavior.

## Verification
- `.venv/bin/python - <<'PY' ...` repro now orders `bar` wheel+sdist, then `buzz`, then `foo`
- `.venv/bin/pytest tests/test_commands.py -q`
- `.venv/bin/isort --check-only --diff twine/ tests/`
- `.venv/bin/black --check --diff twine/ tests/`
- `.venv/bin/flake8 twine/ tests/`
- `git diff --check`

## Limitations
This only changes Twine's local upload ordering. It does not make multi-file uploads transactional on the repository side.
