### PR TITLE
Clarify keyring warning when SecretService can't create/unlock a collection

### DIFF
--- a/changelog/1343.bugfix.rst
+++ b/changelog/1343.bugfix.rst
@@ -1,0 +1,3 @@
+Log a short informational message, instead of a warning with a traceback,
+when the keyring's SecretService backend can't create or unlock its
+collection (e.g. no keyring is configured on the system).

--- a/changelog/1343.bugfix.rst
+++ b/changelog/1343.bugfix.rst
@@ -1,3 +1,3 @@
-Log a short informational message, instead of a warning with a traceback,
-when the keyring's SecretService backend can't create or unlock its
-collection (e.g. no keyring is configured on the system).
+Show a short message, instead of a warning with a traceback, when the
+keyring's SecretService backend can't create or unlock its collection
+(e.g. no keyring is configured on the system).

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -190,80 +190,64 @@ def test_get_password_keyring_runtime_error_logged(
     )
 
 
-def test_get_username_keyring_init_error_logged(
-    entered_username, monkeypatch, config, caplog
+def test_get_username_keyring_init_error_notifies(
+    entered_username, monkeypatch, config, capsys
 ):
-    """Simulate a SecretService backend that can't create/unlock a collection."""
-    caplog.set_level(logging.INFO, "twine")
-
     class FailKeyring:
         @staticmethod
         def get_credential(system, username):
             raise auth.InitError("Failed to create the collection: Prompt dismissed.")
 
     monkeypatch.setattr(auth, "keyring", FailKeyring)
-
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
+    captured = capsys.readouterr()
+    assert "No keyring backend accessible" in captured.out
+    assert "Traceback" not in captured.out
 
-    assert "No keyring backend accessible" in caplog.text
-    assert "Traceback" not in caplog.text
 
-
-def test_get_password_keyring_init_error_logged(
-    entered_username, entered_password, monkeypatch, config, caplog
+def test_get_password_keyring_init_error_notifies(
+    entered_username, entered_password, monkeypatch, config, capsys
 ):
-    """Simulate a SecretService backend that can't create/unlock a collection."""
-    caplog.set_level(logging.INFO, "twine")
-
     class FailKeyring:
         @staticmethod
         def get_password(system, username):
             raise auth.InitError("Failed to create the collection: Prompt dismissed.")
 
     monkeypatch.setattr(auth, "keyring", FailKeyring)
-
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
+    captured = capsys.readouterr()
+    assert "No keyring backend accessible" in captured.out
+    assert "Traceback" not in captured.out
 
-    assert "No keyring backend accessible" in caplog.text
-    assert "Traceback" not in caplog.text
 
-
-def test_get_username_keyring_locked_logged(
-    entered_username, monkeypatch, config, caplog
+def test_get_username_keyring_locked_notifies(
+    entered_username, monkeypatch, config, capsys
 ):
-    """Simulate a SecretService backend where the user dismissed the unlock prompt."""
-    caplog.set_level(logging.INFO, "twine")
-
     class FailKeyring:
         @staticmethod
         def get_credential(system, username):
             raise auth.KeyringLocked("Failed to unlock the collection!")
 
     monkeypatch.setattr(auth, "keyring", FailKeyring)
-
     assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
+    captured = capsys.readouterr()
+    assert "No keyring backend accessible" in captured.out
+    assert "Traceback" not in captured.out
 
-    assert "No keyring backend accessible" in caplog.text
-    assert "Traceback" not in caplog.text
 
-
-def test_get_password_keyring_locked_logged(
-    entered_username, entered_password, monkeypatch, config, caplog
+def test_get_password_keyring_locked_notifies(
+    entered_username, entered_password, monkeypatch, config, capsys
 ):
-    """Simulate a SecretService backend where the user dismissed the unlock prompt."""
-    caplog.set_level(logging.INFO, "twine")
-
     class FailKeyring:
         @staticmethod
         def get_password(system, username):
             raise auth.KeyringLocked("Failed to unlock the collection!")
 
     monkeypatch.setattr(auth, "keyring", FailKeyring)
-
     assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
-
-    assert "No keyring backend accessible" in caplog.text
-    assert "Traceback" not in caplog.text
+    captured = capsys.readouterr()
+    assert "No keyring backend accessible" in captured.out
+    assert "Traceback" not in captured.out
 
 
 def _raise_home_key_error():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -190,6 +190,82 @@ def test_get_password_keyring_runtime_error_logged(
     )
 
 
+def test_get_username_keyring_init_error_logged(
+    entered_username, monkeypatch, config, caplog
+):
+    """Simulate a SecretService backend that can't create/unlock a collection."""
+    caplog.set_level(logging.INFO, "twine")
+
+    class FailKeyring:
+        @staticmethod
+        def get_credential(system, username):
+            raise auth.InitError("Failed to create the collection: Prompt dismissed.")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
+
+    assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
+
+    assert "No keyring backend accessible" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+def test_get_password_keyring_init_error_logged(
+    entered_username, entered_password, monkeypatch, config, caplog
+):
+    """Simulate a SecretService backend that can't create/unlock a collection."""
+    caplog.set_level(logging.INFO, "twine")
+
+    class FailKeyring:
+        @staticmethod
+        def get_password(system, username):
+            raise auth.InitError("Failed to create the collection: Prompt dismissed.")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
+
+    assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
+
+    assert "No keyring backend accessible" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+def test_get_username_keyring_locked_logged(
+    entered_username, monkeypatch, config, caplog
+):
+    """Simulate a SecretService backend where the user dismissed the unlock prompt."""
+    caplog.set_level(logging.INFO, "twine")
+
+    class FailKeyring:
+        @staticmethod
+        def get_credential(system, username):
+            raise auth.KeyringLocked("Failed to unlock the collection!")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
+
+    assert auth.Resolver(config, auth.CredentialInput()).username == "entered user"
+
+    assert "No keyring backend accessible" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+def test_get_password_keyring_locked_logged(
+    entered_username, entered_password, monkeypatch, config, caplog
+):
+    """Simulate a SecretService backend where the user dismissed the unlock prompt."""
+    caplog.set_level(logging.INFO, "twine")
+
+    class FailKeyring:
+        @staticmethod
+        def get_password(system, username):
+            raise auth.KeyringLocked("Failed to unlock the collection!")
+
+    monkeypatch.setattr(auth, "keyring", FailKeyring)
+
+    assert auth.Resolver(config, auth.CredentialInput()).password == "entered pw"
+
+    assert "No keyring backend accessible" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
 def _raise_home_key_error():
     """Simulate environment from https://github.com/pypa/twine/issues/889."""
     try:

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -16,13 +16,19 @@ from id import detect_credential
 # pre-built wheels for ppc64le and s390x, see #1158.
 if t.TYPE_CHECKING:
     import keyring
+    from keyring.errors import InitError
+    from keyring.errors import KeyringLocked
     from keyring.errors import NoKeyringError
 else:
     try:
         import keyring
+        from keyring.errors import InitError
+        from keyring.errors import KeyringLocked
         from keyring.errors import NoKeyringError
     except ModuleNotFoundError:  # pragma: no cover
         keyring = None
+        InitError = None
+        KeyringLocked = None
         NoKeyringError = None
 
 from twine import exceptions
@@ -244,6 +250,8 @@ class Resolver:
         except AttributeError:
             # To support keyring prior to 15.2
             pass
+        except (InitError, KeyringLocked):
+            logger.info("No keyring backend accessible")
         except Exception as exc:
             logger.warning("Error getting username from keyring", exc_info=exc)
         return None
@@ -259,6 +267,8 @@ class Resolver:
             return cast(str, keyring.get_password(system, username))
         except NoKeyringError:
             logger.info("No keyring backend found")
+        except (InitError, KeyringLocked):
+            logger.info("No keyring backend accessible")
         except Exception as exc:
             logger.warning("Error getting password from keyring", exc_info=exc)
         return None

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -9,6 +9,7 @@ from typing import cast
 from urllib.parse import urlparse
 
 import requests.auth
+import rich
 from id import AmbientCredentialError
 from id import detect_credential
 
@@ -97,6 +98,7 @@ class TrustedPublishingAuthenticator(requests.auth.AuthBase):
 class Resolver:
     _tp_token: t.Optional[TrustedPublishingToken] = None
     _expires: t.Optional[int] = None
+    _notified_no_keyring: bool = False
 
     def __init__(
         self,
@@ -237,6 +239,17 @@ class Resolver:
     def system(self) -> t.Optional[str]:
         return self.config["repository"]
 
+    def _notify_no_keyring_backend(self) -> None:
+        # keyring is installed but its backend can't be used — e.g. no
+        # SecretService/D-Bus session is available, or the user dismissed the
+        # unlock prompt (keyring raises InitError / KeyringLocked). Twine falls
+        # back to prompting for credentials, so surface a short, non-alarming
+        # notice. Print it (rather than logger.info) so it is visible even at
+        # twine's default WARNING log level — see #556.
+        if not self._notified_no_keyring:
+            rich.print("No keyring backend accessible")
+            self._notified_no_keyring = True
+
     def get_username_from_keyring(self) -> t.Optional[str]:
         if keyring is None:
             logger.info("keyring module is not available")
@@ -251,7 +264,7 @@ class Resolver:
             # To support keyring prior to 15.2
             pass
         except (InitError, KeyringLocked):
-            logger.info("No keyring backend accessible")
+            self._notify_no_keyring_backend()
         except Exception as exc:
             logger.warning("Error getting username from keyring", exc_info=exc)
         return None
@@ -268,7 +281,7 @@ class Resolver:
         except NoKeyringError:
             logger.info("No keyring backend found")
         except (InitError, KeyringLocked):
-            logger.info("No keyring backend accessible")
+            self._notify_no_keyring_backend()
         except Exception as exc:
             logger.warning("Error getting password from keyring", exc_info=exc)
         return None


### PR DESCRIPTION
When the SecretService backend can't create or unlock its collection (e.g. no keyring is configured and the user dismisses the prompt), keyring raises `InitError` or `KeyringLocked`. This previously fell through to the generic exception handler, which logs a full traceback under a message like "Failed to create the collection: Prompt dismissed." That reads as an upload failure, even though twine falls back to a password prompt and the upload succeeds.

This handles those two cases the same way the existing `NoKeyringError` case is handled: a short, informational log message instead of a warning with a traceback.

Fixes #556