### PR TITLE
Fix MockResponse.ok method

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -339,8 +339,9 @@ class MockResponse:
         if 400 <= self.status_code:
             raise requests.exceptions.HTTPError()
 
+    @property
     def ok(self) -> bool:
-        return self.status_code == 200
+        return self.status_code < 400
 
 
 class MockSession:


### PR DESCRIPTION
It wasn't a property before, so the tests passed because `response.ok` was truthy (as a method).

Also change it to match the actual `requests` [behavior](https://requests.readthedocs.io/en/latest/api/#requests.Response.ok) (OK if status < 400)

cc @woodruffw 