### PR TITLE
Explain GitHub Actions OIDC permission failures

### DIFF
--- a/changelog/+github-oidc-permission-errors.feature.rst
+++ b/changelog/+github-oidc-permission-errors.feature.rst
@@ -1,0 +1,6 @@
+Improve the error message shown when GitHub Actions refuses to issue an OIDC
+token for trusted publishing.
+
+The message now recommends the ``id-token: write`` permission explicitly, and
+notes that pull requests from forks are never granted OIDC permissions even
+when that permission is configured.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -455,3 +455,32 @@ def test_inability_to_make_token_raises_error():
     )
     with pytest.raises(exceptions.TrustedPublishingFailure):
         authenticator(None)
+
+
+def test_github_permission_error_recommends_id_token_write(monkeypatch, config):
+    monkeypatch.setenv("GITHUB_ACTIONS", "1")
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+
+    def make_session():
+        return MockSession(
+            get_response_list=[
+                MockResponse(status_code=200, json={"audience": "fake-aud"})
+            ],
+            post_response_list=[],
+        )
+
+    config.update({"repository": utils.TEST_REPOSITORY})
+    monkeypatch.setattr(auth.utils, "make_requests_session", make_session)
+    res = auth.Resolver(config, auth.CredentialInput(username="__token__"))
+
+    with pytest.raises(exceptions.TrustedPublishingFailure) as exc_info:
+        res.make_trusted_publishing_token()
+
+    message = str(exc_info.value)
+    assert "for trusted publishing.\n\nGitHub: missing" in message
+    assert "id-token: write" in message
+    assert (
+        "https://docs.pypi.org/trusted-publishers/using-a-publisher/#github-actions"
+        in message
+    )

--- a/twine/auth.py
+++ b/twine/auth.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import requests.auth
 from id import AmbientCredentialError
+from id import GitHubOidcPermissionCredentialError
 from id import detect_credential
 
 # keyring has an indirect dependency on PyCA cryptography, which has no
@@ -172,8 +173,12 @@ class Resolver:
 
         try:
             oidc_token = detect_credential(audience)
+        except GitHubOidcPermissionCredentialError as e:
+            raise exceptions.TrustedPublishingFailure.from_github_permission_error(
+                e
+            ) from e
         except AmbientCredentialError as e:
-            # If we get here, we're on a supported CI platform for trusted
+            # If we get here, we're on a non-GHA supported CI platform for trusted
             # publishing, and we have not been given any token, so we can error.
             raise exceptions.TrustedPublishingFailure(
                 "Unable to retrieve an OIDC token from the CI platform for "

--- a/twine/exceptions.py
+++ b/twine/exceptions.py
@@ -151,10 +151,43 @@ class NonInteractive(TwineException):
     pass
 
 
+_GITHUB_TOKEN_RETRIEVAL_FAILED = (
+    "Unable to retrieve an OIDC token from GitHub Actions for trusted "
+    "publishing.\n"
+    "\n"
+    "{identity_error}\n"
+    "\n"
+    "This generally indicates a workflow configuration error, such as "
+    "insufficient permissions. Make sure that your workflow has "
+    "`id-token: write` configured at the job level, e.g.:\n"
+    "\n"
+    "    permissions:\n"
+    "      id-token: write\n"
+    "\n"
+    "If this workflow was triggered by a pull request from a fork, note that "
+    "GitHub does not grant OIDC permissions to those workflows, even when "
+    "`id-token: write` is configured. Change the workflow to use an event "
+    "that forks cannot trigger, such as a tag or release, or a manual "
+    "workflow dispatch.\n"
+    "\n"
+    "Learn more at https://docs.pypi.org/trusted-publishers"
+    "/using-a-publisher/#github-actions"
+)
+
+
 class TrustedPublishingFailure(TwineException):
     """Raised if we expected to use trusted publishing but couldn't."""
 
-    pass
+    @classmethod
+    def from_github_permission_error(
+        cls, identity_error: Exception
+    ) -> "TrustedPublishingFailure":
+        """Return a failure for a GitHub Actions OIDC permission error."""
+        return cls(
+            _GITHUB_TOKEN_RETRIEVAL_FAILED.format(
+                identity_error=identity_error,
+            )
+        )
 
 
 class InvalidPyPIUploadURL(TwineException):


### PR DESCRIPTION
Part of https://github.com/pypa/twine/issues/1355. Add more information to the error message when getting the OIDC token from a GHA workflow fails.

cc @woodruffw @webknjaz 