### PR TITLE
Fix confusing error on missing trailing slash in repository URL (#1248)

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -342,10 +342,10 @@ def test_deprecated_repo(make_settings):
     "repository_url, redirect_url, message_match",
     [
         (
-            "https://test.pypi.org/legacy",
-            "https://test.pypi.org/legacy/",
+            "https://custom.repo.com/legacy",
+            "https://custom.repo.com/legacy/",
             (
-                r"https://test.pypi.org/legacy.+https://test.pypi.org/legacy/"
+                r"https://custom.repo.com/legacy.+https://custom.repo.com/legacy/"
                 r".+\nYour repository URL is missing a trailing slash"
             ),
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -366,3 +366,25 @@ def test_get_file_size(size_in_bytes, formatted_size, monkeypatch):
     file_size = utils.get_file_size(size_in_bytes)
 
     assert file_size == formatted_size
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # Known hosts: trailing slash added
+        ("https://test.pypi.org/legacy", "https://test.pypi.org/legacy/"),
+        ("https://upload.pypi.org/legacy", "https://upload.pypi.org/legacy/"),
+        # Known hosts: already has trailing slash
+        ("https://test.pypi.org/legacy/", "https://test.pypi.org/legacy/"),
+        ("https://upload.pypi.org/legacy/", "https://upload.pypi.org/legacy/"),
+        # Known hosts: root path (no trailing slash needed)
+        ("https://test.pypi.org", "https://test.pypi.org"),
+        # Known hosts: HTTP upgraded to HTTPS + trailing slash
+        ("http://test.pypi.org/legacy", "https://test.pypi.org/legacy/"),
+        # Non-known hosts: not modified
+        ("https://custom.repo.com/simple/", "https://custom.repo.com/simple/"),
+        ("https://custom.repo.com/simple", "https://custom.repo.com/simple"),
+    ],
+)
+def test_normalize_repository_url_trailing_slash(url, expected):
+    assert utils.normalize_repository_url(url) == expected

--- a/twine/utils.py
+++ b/twine/utils.py
@@ -234,7 +234,10 @@ def _config_from_repository_url(url: str) -> RepositoryConfig:
 def normalize_repository_url(url: str) -> str:
     parsed = urlparse(url)
     if parsed.netloc in _HOSTNAMES:
-        return urlunparse(("https",) + parsed[1:])
+        path = parsed.path
+        if path and not path.endswith("/"):
+            path += "/"
+        return urlunparse(("https",) + (parsed.netloc, path) + parsed[3:])
     return urlunparse(parsed)
 
 


### PR DESCRIPTION
Fixes #1248.

When a known PyPI host URL was missing a trailing slash (e.g. `https://test.pypi.org/legacy`), the server redirect caused a confusing "body may not contain duplicate keys" error.

Modified `normalize_repository_url()` to ensure known PyPI host URLs always include a trailing slash when the path is non-empty.